### PR TITLE
Remove erroneous log-level invocation

### DIFF
--- a/trustgraph_configurator/templates/1.2/components/configuration.jsonnet
+++ b/trustgraph_configurator/templates/1.2/components/configuration.jsonnet
@@ -29,8 +29,6 @@ local url = import "values/url.jsonnet";
                             url.pulsar_admin,
                             "--config-file",
                             "/trustgraph/config.json",
-                            "--log-level",
-                            $["log-level"],
                         ]
                     )
                     .with_limits("0.5", "128M")


### PR DESCRIPTION
Seeing errors regarding invalid --log-level arg in the tg-init-trustgraph container