### PR TITLE
Flow classes are now configured to support separate model selection for standard text completion vs RAG operations

### DIFF
--- a/trustgraph_configurator/templates/1.4/flows/documentrag.jsonnet
+++ b/trustgraph_configurator/templates/1.4/flows/documentrag.jsonnet
@@ -25,7 +25,8 @@ local request_response = helpers.request_response;
     },
     // Parameters that can be configured for this flow
     "parameters": {
-        "model": "llm-model",  // LLM model selection for RAG responses
+        "llm-model": "llm-model",  // LLM model selection for RAG responses
+        "llm-rag-model": "llm-model",  // LLM model for RAG operations
     },
     // Flow-level processors for document embedding and storage
     "flow": {
@@ -80,12 +81,12 @@ local request_response = helpers.request_response;
         "text-completion:{class}": {
             request: request("text-completion:{class}"),
             response: response("text-completion:{class}"),
-            model: "{model}",
+            model: "{llm-model}",
         },
         "text-completion-rag:{class}": {
             request: request("text-completion-rag:{class}"),
             response: response("text-completion-rag:{class}"),
-            model: "{model}",
+            model: "{llm-rag-model}",
         },
         "metering:{class}": {
             input: response("text-completion:{class}"),

--- a/trustgraph_configurator/templates/1.4/flows/graphrag.jsonnet
+++ b/trustgraph_configurator/templates/1.4/flows/graphrag.jsonnet
@@ -28,7 +28,8 @@ local request_response = helpers.request_response;
     },
     // Parameters that can be configured for this flow
     "parameters": {
-        "model": "llm-model",  // LLM model selection parameter
+        "llm-model": "llm-model",  // LLM model selection parameter
+        "llm-rag-model": "llm-model",  // LLM model for RAG operations
     },
     // Flow-level processors - handle data streams for a specific flow instance
     "flow": {
@@ -86,12 +87,12 @@ local request_response = helpers.request_response;
         "text-completion:{class}": {
             request: request("text-completion:{class}"),
             response: response("text-completion:{class}"),
-            model: "{model}",
+            model: "{llm-model}",
         },
         "text-completion-rag:{class}": {
             request: request("text-completion-rag:{class}"),
             response: response("text-completion-rag:{class}"),
-            model: "{model}",
+            model: "{llm-rag-model}",
         },
         "metering:{class}": {
             input: response("text-completion:{class}"),

--- a/trustgraph_configurator/templates/1.4/flows/structured.jsonnet
+++ b/trustgraph_configurator/templates/1.4/flows/structured.jsonnet
@@ -28,7 +28,8 @@ local request_response = helpers.request_response;
     },
     // Parameters that can be configured for this flow
     "parameters": {
-        "model": "llm-model",  // LLM model selection for query processing
+        "llm-model": "llm-model",  // LLM model selection for query processing
+        "llm-rag-model": "llm-model",  // LLM model for RAG operations
     },
     // Flow-level processors for structured data extraction
     "flow": {
@@ -88,12 +89,12 @@ local request_response = helpers.request_response;
         "text-completion:{class}": {
             request: request("text-completion:{class}"),
             response: response("text-completion:{class}"),
-            model: "{model}",
+            model: "{llm-model}",
         },
         "text-completion-rag:{class}": {
             request: request("text-completion-rag:{class}"),
             response: response("text-completion-rag:{class}"),
-            model: "{model}",
+            model: "{llm-rag-model}",
         },
         "metering:{class}": {
             input: response("text-completion:{class}"),


### PR DESCRIPTION
Changes Applied:
  1. ✅ Renamed "model" parameter to "llm-model"
  2. ✅ Added new "llm-rag-model" parameter of type "llm-model"
  3. ✅ Updated text-completion processors to use {llm-model} instead of {model}
  4. ✅ Updated text-completion-rag processors to use {llm-rag-model}

