### PR TITLE
Use gemma3:12b as default for Ollama

### DIFF
--- a/trustgraph_configurator/templates/1.4/parameters/ollama.jsonnet
+++ b/trustgraph_configurator/templates/1.4/parameters/ollama.jsonnet
@@ -4,7 +4,7 @@
 {
     "type": "string",
     "description": "LLM model to use",
-    "default": "llama3.1:70b",
+    "default": "gemma3:12b",
     "enum": [
         // Gemma3 models
         {


### PR DESCRIPTION
Use smaller model as default for Ollama: llama3.1:70b is massive