### PR TITLE
Fix problem setting RABBITMQ_PORT on K8s

### DIFF
--- a/trustgraph_configurator/templates/2.2/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.2/engine/k8s.jsonnet
@@ -108,6 +108,7 @@
                                 }
                             },
                             spec: {
+                                enableServiceLinks: false,
                                 containers: [
                                     {
                                         name: container.name,

--- a/trustgraph_configurator/templates/2.3/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.3/engine/k8s.jsonnet
@@ -108,6 +108,7 @@
                                 }
                             },
                             spec: {
+                                enableServiceLinks: false,
                                 containers: [
                                     {
                                         name: container.name,


### PR DESCRIPTION
Set "enableServiceLinks: false"

Which turns off the mapping of service information into environment variables.  This works around a clash where TG services interpret RABBITMQ_PORT as a port number whereas K8s sets this to a URL as part of its service mapping.