### PR TITLE
Maint/flow lifecycle update

### DIFF
--- a/trustgraph_configurator/templates/2.3/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/control.jsonnet
@@ -40,6 +40,12 @@ local cassandra = import "backends/cassandra.jsonnet";
                                 } + $["pub-sub-params"],
                             },
                             {
+                                class: "trustgraph.flow.service.Processor",
+                                params:  {
+                                    id: "flow-svc",
+                                } + $["pub-sub-params"],
+                            },
+                            {
                                 class: "trustgraph.cores.service.Processor",
                                 params: {
                                     id: "knowledge",

--- a/trustgraph_configurator/templates/2.3/core/document-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/document-decoder.jsonnet
@@ -1,0 +1,52 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "document-decoder-cpu-limit": "0.5",
+        "document-decoder-cpu-reservation": "0.1",
+        "document-decoder-memory-limit": "512M",
+        "document-decoder-memory-reservation": "512M",
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "document-decoder" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["document-decoder-cpu-limit"],
+        local cpuReservation = pars["document-decoder-cpu-reservation"],
+        local memoryLimit = pars["document-decoder-memory-limit"],
+        local memoryReservation = pars["document-decoder-memory-reservation"],
+
+        create:: function(engine)
+
+            local container =
+                engine.container("document-decoder")
+                    .with_image(images.trustgraph_unstructured)
+                    .with_command([
+                        "universal-decoder",
+                    ] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "document-decoder", [ container ]
+            );
+
+            local service =
+                engine.internalService(containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.3/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/rag.jsonnet
@@ -39,6 +39,17 @@ local url = import "values/url.jsonnet";
         local memoryLimit = pars["rag-memory-limit"],
         local memoryReservation = pars["rag-memory-reservation"],
 
+        local retrieval = "trustgraph.retrieval",
+        local agentOrchestrator = "trustgraph.agent.orchestrator.Processor",
+        local graphRag = "%s.graph_rag.Processor" % retrieval,
+        local documentRag = "%s.document_rag.Processor" % retrieval,
+        local nlpQuery = "%s.nlp_query.Processor" % retrieval,
+        local structuredQuery = "%s.structured_query.Processor" % retrieval,
+        local structuredDiag = "%s.structured_diag.Processor" % retrieval,
+        local sparql = "trustgraph.query.sparql.Processor",
+        local promptProc = "trustgraph.prompt.template.Processor",
+        local mcpTool = "trustgraph.agent.mcp_tool.Service",
+
         create:: function(engine)
 
             local cfgVol = engine.configVolume(
@@ -47,13 +58,13 @@ local url = import "values/url.jsonnet";
 		    "launch.yaml": std.manifestYamlDoc({
                         processors: [
                             {
-                                class: "trustgraph.agent.orchestrator.Processor",
+                                class: agentOrchestrator,
                                 params: {
                                     id: "agent-manager",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.retrieval.graph_rag.Processor",
+                                class: graphRag,
                                 params: {
                                     id: "graph-rag",
                                     concurrency: graphRagConc,
@@ -66,45 +77,45 @@ local url = import "values/url.jsonnet";
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.retrieval.document_rag.Processor",
+                                class: documentRag,
                                 params: {
                                     id: "document-rag",
                                     doc_limit: docLimit,
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.retrieval.nlp_query.Processor",
+                                class: nlpQuery,
                                 params: {
                                     id: "nlp-query",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.retrieval.structured_query.Processor",
+                                class: structuredQuery,
                                 params: {
                                     id: "structured-query",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.retrieval.structured_diag.Processor",
+                                class: structuredDiag,
                                 params: {
                                     id: "structured-diag",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.query.sparql.Processor",
+                                class: sparql,
                                 params: {
                                     id: "sparql-query",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.prompt.template.Processor",
+                                class: promptProc,
                                 params: {
                                     id: "prompt-rag",
                                     concurrency: promptRagConc,
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.agent.mcp_tool.Service",
+                                class: mcpTool,
                                 params: {
                                     id: "mcp-tool",
                                 } + $["pub-sub-params"],

--- a/trustgraph_configurator/templates/2.3/core/trustgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/trustgraph.jsonnet
@@ -7,6 +7,7 @@ local ingest = import "ingest.jsonnet";
 local rag = import "rag.jsonnet";
 local api_gateway = import "api-gateway.jsonnet";
 local mcp_server = import "mcp-server.jsonnet";
+local document_decoder = import "document-decoder.jsonnet";
 local workbench = import "../ui/workbench-ui.jsonnet";
 local ddg = import "mcp/ddg-mcp-server.jsonnet";
 
@@ -15,50 +16,6 @@ local ddg = import "mcp/ddg-mcp-server.jsonnet";
         "log-level":: "INFO",
     },
 
-    local logLevel = $.parameters["log-level"],
-
-    "document-decoder" +: {
-
-        "cpu-limit":: "0.5",
-        "cpu-reservation":: "0.1",
-        "memory-limit":: "512M",
-        "memory-reservation":: "512M",
-
-        create:: function(engine)
-
-            local memoryLimit = self["memory-limit"];
-            local memoryReservation = self["memory-reservation"];
-
-            local container =
-                engine.container("document-decoder")
-                    .with_image(images.trustgraph_unstructured)
-                    .with_command([
-                        "universal-decoder",
-                    ] + $["pub-sub-args"] + [
-                        "--log-level",
-                        logLevel,
-                    ])
-                    .with_limits(self["cpu-limit"], memoryLimit)
-                    .with_reservations(
-                        self["cpu-reservation"],
-                        memoryReservation
-                    );
-
-            local containerSet = engine.containers(
-                "document-decoder", [ container ]
-            );
-
-            local service =
-                engine.internalService(containerSet)
-                .with_port(8000, 8000, "metrics");
-
-            engine.resources([
-                containerSet,
-                service,
-            ])
-
-    },
-
-} + control + ingest + rag + api_gateway + mcp_server + workbench
-  + config_initialiser + config + ddg
+} + control + ingest + rag + api_gateway + mcp_server + document_decoder
+  + workbench + config_initialiser + config + ddg
 

--- a/trustgraph_configurator/templates/2.3/embeddings/embeddings-fastembed.jsonnet
+++ b/trustgraph_configurator/templates/2.3/embeddings/embeddings-fastembed.jsonnet
@@ -27,6 +27,12 @@ local models = import "parameters/embeddings-fastembed.jsonnet";
         local memoryLimit = pars["embeddings-memory-limit"],
         local memoryReservation = pars["embeddings-memory-reservation"],
 
+        local embeds = "trustgraph.embeddings",
+        local fastEmbedProc = "%s.fastembed.Processor" % embeds,
+        local docEmbedProc = "%s.document_embeddings.Processor" % embeds,
+        local graphEmbedProc = "%s.graph_embeddings.Processor" % embeds,
+        local rowEmbedProc = "%s.row_embeddings.Processor" % embeds,
+
         create:: function(engine)
 
             local cfgVol = engine.configVolume(
@@ -35,26 +41,26 @@ local models = import "parameters/embeddings-fastembed.jsonnet";
 		    "launch.yaml": std.manifestYamlDoc({
                         processors: [
                             {
-                                class: "trustgraph.embeddings.fastembed.Processor",
+                                class: fastEmbedProc,
                                 params: {
                                     id: "embeddings",
                                     concurrency: embeddingsConc,
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.embeddings.document_embeddings.Processor",
+                                class: docEmbedProc,
                                 params: {
                                     id: "document-embeddings",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.embeddings.graph_embeddings.Processor",
+                                class: graphEmbedProc,
                                 params: {
                                     id: "graph-embeddings",
                                 } + $["pub-sub-params"],
                             },
                             {
-                                class: "trustgraph.embeddings.row_embeddings.Processor",
+                                class: rowEmbedProc,
                                 params: {
                                     id: "row-embeddings",
                                 } + $["pub-sub-params"],

--- a/trustgraph_configurator/templates/2.3/flows/agent.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/agent.jsonnet
@@ -7,7 +7,7 @@ local helpers = import "helpers.jsonnet";
 local flow = helpers.flow;
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 
 // Import shared services (agent requires LLM for reasoning, MCP for tools)
 local llm_services = import "llm-services.jsonnet";
@@ -18,39 +18,33 @@ llm_services + mcp_service + {
 
     // External interfaces for agent operations
     "interfaces" +: {
-        "agent": request_response("agent:{id}"),
+        "agent": request_response_if("agent:{id}"),
     },
 
     // Flow-level processors for agent management
     "flow" +: {
         // Agent manager orchestrates agent conversations and tool usage
         "agent-manager:{id}": {
-
-            // Agent communication channels
-            request: request("agent:{id}"),
-            next: request("agent:{id}"),
-            response: response("agent:{id}"),
-
-            // LLM and prompt services
-            "text-completion-request": request("text-completion:{id}"),
-            "text-completion-response": response("text-completion:{id}"),
-            "prompt-request": request("prompt-rag:{id}"),
-            "prompt-response": response("prompt-rag:{id}"),
-
-            // Tool integrations
-            "mcp-tool-request": request("mcp-tool:{id}"),
-            "mcp-tool-response": response("mcp-tool:{id}"),
-            "graph-rag-request": request("graph-rag:{id}"),
-            "graph-rag-response": response("graph-rag:{id}"),
-            "structured-query-request": request("structured-query:{id}"),
-            "structured-query-response": response("structured-query:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
-            "row-embeddings-query-request": request("row-embeddings:{id}"),
-            "row-embeddings-query-response": response("row-embeddings:{id}"),
-
-            // Explainability
-            explainability: flow("triples-store:{id}"),
+            topics: {
+                request: request("agent:{id}"),
+                next: request("agent:{id}"),
+                response: response("agent:{id}"),
+                "text-completion-request": request("text-completion:{id}"),
+                "text-completion-response": response("text-completion:{id}"),
+                "prompt-request": request("prompt-rag:{id}"),
+                "prompt-response": response("prompt-rag:{id}"),
+                "mcp-tool-request": request("mcp-tool:{id}"),
+                "mcp-tool-response": response("mcp-tool:{id}"),
+                "graph-rag-request": request("graph-rag:{id}"),
+                "graph-rag-response": response("graph-rag:{id}"),
+                "structured-query-request": request("structured-query:{id}"),
+                "structured-query-response": response("structured-query:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+                "row-embeddings-query-request": request("row-embeddings:{id}"),
+                "row-embeddings-query-response": response("row-embeddings:{id}"),
+                explainability: flow("triples-store:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/document-store.jsonnet
@@ -4,9 +4,10 @@
 
 local helpers = import "helpers.jsonnet";
 local flow = helpers.flow;
+local flow_if = helpers.flow_if;
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 
 // Import shared services
 local llm_services = import "llm-services.jsonnet";
@@ -18,36 +19,44 @@ llm_services + embeddings_service + {
     // External interfaces for document store
     "interfaces" +: {
         // Document embedding storage and retrieval
-        "document-embeddings-store": flow("document-embeddings-store:{id}"),
-        "document-rag": request_response("document-rag:{id}"),
-        "document-embeddings": request_response("document-embeddings:{id}"),
+        "document-embeddings-store": flow_if("document-embeddings-store:{id}"),
+        "document-rag": request_response_if("document-rag:{id}"),
+        "document-embeddings": request_response_if("document-embeddings:{id}"),
     },
 
     // Flow-level processors for document embedding and storage
     "flow" +: {
         "document-embeddings:{id}": {
-            input: flow("chunk-load:{id}"),
-            output: flow("document-embeddings-store:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
+            topics: {
+                input: flow("chunk-load:{id}"),
+                output: flow("document-embeddings-store:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+            },
         },
         "doc-embeddings-write:{id}": {
-            input: flow("document-embeddings-store:{id}"),
+            topics: {
+                input: flow("document-embeddings-store:{id}"),
+            },
         },
         "document-rag:{id}": {
-            request: request("document-rag:{id}"),
-            response: response("document-rag:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
-            "prompt-request": request("prompt-rag:{id}"),
-            "prompt-response": response("prompt-rag:{id}"),
-            "document-embeddings-request": request("document-embeddings:{id}"),
-            "document-embeddings-response": response("document-embeddings:{id}"),
-            explainability: flow("triples-store:{id}"),
+            topics: {
+                request: request("document-rag:{id}"),
+                response: response("document-rag:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+                "prompt-request": request("prompt-rag:{id}"),
+                "prompt-response": response("prompt-rag:{id}"),
+                "document-embeddings-request": request("document-embeddings:{id}"),
+                "document-embeddings-response": response("document-embeddings:{id}"),
+                explainability: flow("triples-store:{id}"),
+            },
         },
         "doc-embeddings-query:{id}": {
-            request: request("document-embeddings:{id}"),
-            response: response("document-embeddings:{id}"),
+            topics: {
+                request: request("document-embeddings:{id}"),
+                response: response("document-embeddings:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/embeddings-service.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/embeddings-service.jsonnet
@@ -5,12 +5,12 @@
 local helpers = import "helpers.jsonnet";
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 
 {
     // Interfaces exposed by embeddings service
     "interfaces" +: {
-        "embeddings": request_response("embeddings:{id}"),
+        "embeddings": request_response_if("embeddings:{id}"),
     },
 
     "parameters" +: {
@@ -19,9 +19,13 @@ local request_response = helpers.request_response;
     // Flow-level processor for embeddings
     "flow" +: {
         "embeddings:{id}": {
-            request: request("embeddings:{id}"),
-            response: response("embeddings:{id}"),
-            model: "{embeddings-model}",
+            topics: {
+                request: request("embeddings:{id}"),
+                response: response("embeddings:{id}"),
+            },
+            parameters: {
+                model: "{embeddings-model}",
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/graph-store.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/graph-store.jsonnet
@@ -4,9 +4,10 @@
 
 local helpers = import "helpers.jsonnet";
 local flow = helpers.flow;
+local flow_if = helpers.flow_if;
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 local librarian_request = helpers.librarian_request;
 local librarian_response = helpers.librarian_response;
 
@@ -20,59 +21,73 @@ llm_services + embeddings_service + {
     // External interfaces exposed by the graph store
     "interfaces" +: {
         // Data ingestion interfaces for graph construction
-        "entity-contexts-load": flow("entity-contexts-load:{id}"),
-        "triples-store": flow("triples-store:{id}"),
-        "graph-embeddings-store": flow("graph-embeddings-store:{id}"),
+        "entity-contexts-load": flow_if("entity-contexts-load:{id}"),
+        "triples-store": flow_if("triples-store:{id}"),
+        "graph-embeddings-store": flow_if("graph-embeddings-store:{id}"),
 
         // Query interfaces for graph-based operations
-        "graph-rag": request_response("graph-rag:{id}"),
-        "triples": request_response("triples:{id}"),
-        "graph-embeddings": request_response("graph-embeddings:{id}"),
-        "sparql": request_response("sparql:{id}"),
+        "graph-rag": request_response_if("graph-rag:{id}"),
+        "triples": request_response_if("triples:{id}"),
+        "graph-embeddings": request_response_if("graph-embeddings:{id}"),
+        "sparql": request_response_if("sparql:{id}"),
     },
 
     // Flow-level processors - handle data streams for a specific flow instance
     "flow" +: {
         "graph-embeddings:{id}": {
-            input: flow("entity-contexts-load:{id}"),
-            output: flow("graph-embeddings-store:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
+            topics: {
+                input: flow("entity-contexts-load:{id}"),
+                output: flow("graph-embeddings-store:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+            },
         },
         "triples-write:{id}": {
-            input: flow("triples-store:{id}"),
+            topics: {
+                input: flow("triples-store:{id}"),
+            },
         },
         "graph-embeddings-write:{id}": {
-            input: flow("graph-embeddings-store:{id}"),
+            topics: {
+                input: flow("graph-embeddings-store:{id}"),
+            },
         },
         "graph-rag:{id}": {
-            request: request("graph-rag:{id}"),
-            response: response("graph-rag:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
-            "prompt-request": request("prompt-rag:{id}"),
-            "prompt-response": response("prompt-rag:{id}"),
-            "graph-embeddings-request": request("graph-embeddings:{id}"),
-            "graph-embeddings-response": response("graph-embeddings:{id}"),
-            "triples-request": request("triples:{id}"),
-            "triples-response": response("triples:{id}"),
-            explainability: flow("triples-store:{id}"),
-            "librarian-request": librarian_request,
-            "librarian-response": librarian_response,
+            topics: {
+                request: request("graph-rag:{id}"),
+                response: response("graph-rag:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+                "prompt-request": request("prompt-rag:{id}"),
+                "prompt-response": response("prompt-rag:{id}"),
+                "graph-embeddings-request": request("graph-embeddings:{id}"),
+                "graph-embeddings-response": response("graph-embeddings:{id}"),
+                "triples-request": request("triples:{id}"),
+                "triples-response": response("triples:{id}"),
+                explainability: flow("triples-store:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
         },
         "sparql-query:{id}": {
-            request: request("sparql:{id}"),
-            response: response("sparql:{id}"),
-            "triples-request": request("triples:{id}"),
-            "triples-response": response("triples:{id}"),
+            topics: {
+                request: request("sparql:{id}"),
+                response: response("sparql:{id}"),
+                "triples-request": request("triples:{id}"),
+                "triples-response": response("triples:{id}"),
+            },
         },
         "triples-query:{id}": {
-            request: request("triples:{id}"),
-            response: response("triples:{id}"),
+            topics: {
+                request: request("triples:{id}"),
+                response: response("triples:{id}"),
+            },
         },
         "graph-embeddings-query:{id}": {
-            request: request("graph-embeddings:{id}"),
-            response: response("graph-embeddings:{id}"),
+            topics: {
+                request: request("graph-embeddings:{id}"),
+                response: response("graph-embeddings:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/graphrag-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/graphrag-extract.jsonnet
@@ -19,22 +19,24 @@ local response = helpers.response;
     // Flow-level processors for knowledge extraction
     "flow" +: {
         // Extracts entity definitions from text chunks
-        // Identifies and defines key entities mentioned in the text
         "kg-extract-definitions:{id}": {
-            input: flow("chunk-load:{id}"),                       // Input text chunks
-            triples: flow("triples-store:{id}"),                  // Output definition triples
-            "entity-contexts": flow("entity-contexts-load:{id}"), // Entity context information
-            "prompt-request": request("prompt:{id}"),          // Definition extraction prompts
-            "prompt-response": response("prompt:{id}"),
+            topics: {
+                input: flow("chunk-load:{id}"),
+                triples: flow("triples-store:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{id}"),
+                "prompt-request": request("prompt:{id}"),
+                "prompt-response": response("prompt:{id}"),
+            },
         },
 
         // Extracts relationships between entities
-        // Identifies how entities are connected and interact
         "kg-extract-relationships:{id}": {
-            input: flow("chunk-load:{id}"),                // Input text chunks
-            triples: flow("triples-store:{id}"),           // Output relationship triples
-            "prompt-request": request("prompt:{id}"),   // Relationship extraction prompts
-            "prompt-response": response("prompt:{id}"),
+            topics: {
+                input: flow("chunk-load:{id}"),
+                triples: flow("triples-store:{id}"),
+                "prompt-request": request("prompt:{id}"),
+                "prompt-response": response("prompt:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/helpers.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/helpers.jsonnet
@@ -13,27 +13,32 @@ local request(x) = "request:tg:" + x;
 // Creates a non-persistent response URI for request-response patterns
 local response(x) = "response:tg:" + x;
 
-// State broadcast queue — persistent, last-value semantics
-local state(x) = "state:tg:" + x;
-
 local librarian_request = request("librarian");
 local librarian_response = request("librarian");
 
 // Creates a request-response pair for bidirectional communication
 // Returns an object with both request and response URIs
-local request_response(x) = {
+local flow_if(x) = {
+  flow: flow(x),
+};
+
+local request_response_if(x) = {
   request: request(x),
   response: response(x),
 };
 
 // Export all helper functions for use in other modules
 {
+
     flow: flow,
     request: request,
     response: response,
-    request_response: request_response,
-    state: state,
+
+    flow_if: flow_if,
+    request_response_if: request_response_if,
+
     librarian_request: librarian_request,
     librarian_response: librarian_response,
+
 }
 

--- a/trustgraph_configurator/templates/2.3/flows/kgcore.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/kgcore.jsonnet
@@ -17,11 +17,11 @@ local flow = helpers.flow;
 
     // Flow-level processors for knowledge graph storage
     "flow" +: {
-        // Knowledge graph store consolidates extracted knowledge
-        // Takes processed triples and embeddings and stores them permanently
         "kg-store:{id}": {
-            "triples-input": flow("triples-store:{id}"),           // Input RDF triples stream
-            "graph-embeddings-input": flow("graph-embeddings-store:{id}"), // Input graph embeddings
+            topics: {
+                "triples-input": flow("triples-store:{id}"),
+                "graph-embeddings-input": flow("graph-embeddings-store:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/llm-services.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/llm-services.jsonnet
@@ -5,14 +5,14 @@
 local helpers = import "helpers.jsonnet";
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 local llm_parameters = import "llm-parameters.jsonnet";
 
 {
     // Interfaces exposed by LLM services
     "interfaces" +: {
-        "prompt": request_response("prompt:{id}"),
-        "text-completion": request_response("text-completion:{id}"),
+        "prompt": request_response_if("prompt:{id}"),
+        "text-completion": request_response_if("text-completion:{id}"),
     },
 
     // LLM configuration parameters
@@ -22,42 +22,58 @@ local llm_parameters = import "llm-parameters.jsonnet";
     "flow" +: {
         // Primary text completion service
         "text-completion:{id}": {
-            request: request("text-completion:{id}"),
-            response: response("text-completion:{id}"),
-            model: "{llm-model}",
+            topics: {
+                request: request("text-completion:{id}"),
+                response: response("text-completion:{id}"),
+            },
+            parameters: {
+                model: "{llm-model}",
+            },
         },
 
         // RAG-specific text completion (may use different model)
         "text-completion-rag:{id}": {
-            request: request("text-completion-rag:{id}"),
-            response: response("text-completion-rag:{id}"),
-            model: "{llm-rag-model}",
+            topics: {
+                request: request("text-completion-rag:{id}"),
+                response: response("text-completion-rag:{id}"),
+            },
+            parameters: {
+                model: "{llm-rag-model}",
+            },
         },
 
         // Prompt processing service
         "prompt:{id}": {
-            request: request("prompt:{id}"),
-            response: response("prompt:{id}"),
-            "text-completion-request": request("text-completion:{id}"),
-            "text-completion-response": response("text-completion:{id}"),
+            topics: {
+                request: request("prompt:{id}"),
+                response: response("prompt:{id}"),
+                "text-completion-request": request("text-completion:{id}"),
+                "text-completion-response": response("text-completion:{id}"),
+            },
         },
 
         // RAG-specific prompt processing
         "prompt-rag:{id}": {
-            request: request("prompt-rag:{id}"),
-            response: response("prompt-rag:{id}"),
-            "text-completion-request": request("text-completion-rag:{id}"),
-            "text-completion-response": response("text-completion-rag:{id}"),
+            topics: {
+                request: request("prompt-rag:{id}"),
+                response: response("prompt-rag:{id}"),
+                "text-completion-request": request("text-completion-rag:{id}"),
+                "text-completion-response": response("text-completion-rag:{id}"),
+            },
         },
 
         // Usage metering for primary completion
         "metering:{id}": {
-            input: response("text-completion:{id}"),
+            topics: {
+                input: response("text-completion:{id}"),
+            },
         },
 
         // Usage metering for RAG completion
         "metering-rag:{id}": {
-            input: response("text-completion-rag:{id}"),
+            topics: {
+                input: response("text-completion-rag:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/load.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/load.jsonnet
@@ -4,9 +4,9 @@
 
 local helpers = import "helpers.jsonnet";
 local flow = helpers.flow;
+local flow_if = helpers.flow_if;
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
 local librarian_request = helpers.librarian_request;
 local librarian_response = helpers.librarian_response;
 
@@ -18,8 +18,8 @@ embeddings_service + {
 
     // External interfaces for document loading
     "interfaces" +: {
-        "document-load": flow("document-load:{id}"),
-        "text-load": flow("text-document-load:{id}"),
+        "document-load": flow_if("document-load:{id}"),
+        "text-load": flow_if("text-document-load:{id}"),
     },
 
     // Flow-level processors for document preprocessing
@@ -27,23 +27,29 @@ embeddings_service + {
         // PDF decoder converts PDF documents to text
         // Also emits page provenance triples and saves pages via librarian
         "document-decoder:{id}": {
-            input: flow("document-load:{id}"),
-            output: flow("text-document-load:{id}"),
-            triples: flow("triples-store:{id}"),
-            "librarian-request": librarian_request,
-            "librarian-response": librarian_response,
+            topics: {
+                input: flow("document-load:{id}"),
+                output: flow("text-document-load:{id}"),
+                triples: flow("triples-store:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
         },
 
         // Chunker splits documents into smaller, processable pieces
         // Also emits chunk provenance triples and saves chunks via librarian
         "chunker:{id}": {
-            input: flow("text-document-load:{id}"),
-            output: flow("chunk-load:{id}"),
-            triples: flow("triples-store:{id}"),
-            "librarian-request": librarian_request,
-            "librarian-response": librarian_response,
-            "chunk-size": "{chunk-size}",
-            "chunk-overlap": "{chunk-overlap}",
+            topics: {
+                input: flow("text-document-load:{id}"),
+                output: flow("chunk-load:{id}"),
+                triples: flow("triples-store:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+            parameters: {
+                "chunk-size": "{chunk-size}",
+                "chunk-overlap": "{chunk-overlap}",
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/mcp-service.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/mcp-service.jsonnet
@@ -5,12 +5,12 @@
 local helpers = import "helpers.jsonnet";
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 
 {
     // Interfaces exposed by MCP service
     "interfaces" +: {
-        "mcp-tool": request_response("mcp-tool:{id}"),
+        "mcp-tool": request_response_if("mcp-tool:{id}"),
     },
 
     "parameters" +: {
@@ -19,10 +19,12 @@ local request_response = helpers.request_response;
     // Flow-level processor for MCP tool execution
     "flow" +: {
         "mcp-tool:{id}": {
-            request: request("mcp-tool:{id}"),
-            response: response("mcp-tool:{id}"),
-            "text-completion-request": request("text-completion:{id}"),
-            "text-completion-response": response("text-completion:{id}"),
+            topics: {
+                request: request("mcp-tool:{id}"),
+                response: response("mcp-tool:{id}"),
+                "text-completion-request": request("text-completion:{id}"),
+                "text-completion-response": response("text-completion:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/ontorag-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/ontorag-extract.jsonnet
@@ -8,7 +8,8 @@ local request = helpers.request;
 local response = helpers.response;
 
 {
-    // No external interfaces - this module provides internal extraction services
+    // No external interfaces - this module provides internal extraction
+    // services
     "interfaces" +: {
     },
 
@@ -18,18 +19,17 @@ local response = helpers.response;
 
     // Flow-level processors for knowledge extraction
     "flow" +: {
-        // Extracts using ontology definitions
         "kg-extract-ontology:{id}": {
-            input: flow("chunk-load:{id}"),           // Input text chunks
-            triples: flow("triples-store:{id}"),      // Output triples
-            "entity-contexts": flow("entity-contexts-load:{id}"), // Entity context information
-            "prompt-request": request("prompt:{id}"),   // Definition
-                                                        // extraction prompts
-            "prompt-response": response("prompt:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
+            topics: {
+                input: flow("chunk-load:{id}"),
+                triples: flow("triples-store:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{id}"),
+                "prompt-request": request("prompt:{id}"),
+                "prompt-response": response("prompt:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+            },
         },
-
     },
 
     // No blueprint-level processors needed

--- a/trustgraph_configurator/templates/2.3/flows/structured-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/structured-extract.jsonnet
@@ -17,11 +17,13 @@ local response = helpers.response;
     // Flow-level processor for structured row extraction
     "flow" +: {
         "kg-extract-rows:{id}": {
-            input: flow("chunk-load:{id}"),
-            output: flow("rows-store:{id}"),
-            "entity-contexts": flow("entity-contexts-load:{id}"),
-            "prompt-request": request("prompt:{id}"),
-            "prompt-response": response("prompt:{id}"),
+            topics: {
+                input: flow("chunk-load:{id}"),
+                output: flow("rows-store:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{id}"),
+                "prompt-request": request("prompt:{id}"),
+                "prompt-response": response("prompt:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/flows/structured-store.jsonnet
+++ b/trustgraph_configurator/templates/2.3/flows/structured-store.jsonnet
@@ -4,9 +4,10 @@
 
 local helpers = import "helpers.jsonnet";
 local flow = helpers.flow;
+local flow_if = helpers.flow_if;
 local request = helpers.request;
 local response = helpers.response;
-local request_response = helpers.request_response;
+local request_response_if = helpers.request_response_if;
 
 // Import shared services
 local llm_services = import "llm-services.jsonnet";
@@ -18,58 +19,74 @@ llm_services + embeddings_service + {
     // External interfaces for structured store
     "interfaces" +: {
         // Row storage and querying
-        "rows-store": flow("rows-store:{id}"),
-        "row-embeddings-store": flow("row-embeddings-store:{id}"),
-        "rows": request_response("rows:{id}"),
-        "row-embeddings": request_response("row-embeddings:{id}"),
+        "rows-store": flow_if("rows-store:{id}"),
+        "row-embeddings-store": flow_if("row-embeddings-store:{id}"),
+        "rows": request_response_if("rows:{id}"),
+        "row-embeddings": request_response_if("row-embeddings:{id}"),
 
         // Query interfaces
-        "nlp-query": request_response("nlp-query:{id}"),
-        "structured-query": request_response("structured-query:{id}"),
-        "structured-diag": request_response("structured-diag:{id}"),
+        "nlp-query": request_response_if("nlp-query:{id}"),
+        "structured-query": request_response_if("structured-query:{id}"),
+        "structured-diag": request_response_if("structured-diag:{id}"),
     },
 
     // Flow-level processors for structured storage and query
     "flow" +: {
         "row-embeddings:{id}": {
-            input: flow("rows-store:{id}"),
-            output: flow("row-embeddings-store:{id}"),
-            "embeddings-request": request("embeddings:{id}"),
-            "embeddings-response": response("embeddings:{id}"),
+            topics: {
+                input: flow("rows-store:{id}"),
+                output: flow("row-embeddings-store:{id}"),
+                "embeddings-request": request("embeddings:{id}"),
+                "embeddings-response": response("embeddings:{id}"),
+            },
         },
         "rows-write:{id}": {
-            input: flow("rows-store:{id}"),
+            topics: {
+                input: flow("rows-store:{id}"),
+            },
         },
         "row-embeddings-write:{id}": {
-            input: flow("row-embeddings-store:{id}"),
+            topics: {
+                input: flow("row-embeddings-store:{id}"),
+            },
         },
         "rows-query:{id}": {
-            request: request("rows:{id}"),
-            response: response("rows:{id}"),
+            topics: {
+                request: request("rows:{id}"),
+                response: response("rows:{id}"),
+            },
         },
         "row-embeddings-query:{id}": {
-            request: request("row-embeddings:{id}"),
-            response: response("row-embeddings:{id}"),
+            topics: {
+                request: request("row-embeddings:{id}"),
+                response: response("row-embeddings:{id}"),
+            },
         },
         "nlp-query:{id}": {
-            request: request("nlp-query:{id}"),
-            response: response("nlp-query:{id}"),
-            "prompt-request": request("prompt-rag:{id}"),
-            "prompt-response": response("prompt-rag:{id}"),
+            topics: {
+                request: request("nlp-query:{id}"),
+                response: response("nlp-query:{id}"),
+                "prompt-request": request("prompt-rag:{id}"),
+                "prompt-response": response("prompt-rag:{id}"),
+            },
         },
         "structured-query:{id}": {
-            request: request("structured-query:{id}"),
-            response: response("structured-query:{id}"),
-            "nlp-query-request": request("nlp-query:{id}"),
-            "nlp-query-response": response("nlp-query:{id}"),
-            "rows-query-request": request("rows:{id}"),
-            "rows-query-response": response("rows:{id}"),
+            topics: {
+                request: request("structured-query:{id}"),
+                response: response("structured-query:{id}"),
+                "nlp-query-request": request("nlp-query:{id}"),
+                "nlp-query-response": response("nlp-query:{id}"),
+                "rows-query-request": request("rows:{id}"),
+                "rows-query-response": response("rows:{id}"),
+            },
         },
         "structured-diag:{id}": {
-            request: request("structured-diag:{id}"),
-            response: response("structured-diag:{id}"),
-            "prompt-request": request("prompt:{id}"),
-            "prompt-response": response("prompt:{id}"),
+            topics: {
+                request: request("structured-diag:{id}"),
+                response: response("structured-diag:{id}"),
+                "prompt-request": request("prompt:{id}"),
+                "prompt-response": response("prompt:{id}"),
+            },
         },
     },
 

--- a/trustgraph_configurator/templates/2.3/runtime-config/config-composer.jsonnet
+++ b/trustgraph_configurator/templates/2.3/runtime-config/config-composer.jsonnet
@@ -86,8 +86,10 @@ local interface_builder = import "interface-builder.jsonnet";
                     },
                 },
 
-                // Active flow processors
-                "active-flow": active_flows,
+                // Active flow processors — each processor is its own
+                // config type keyed as "processor:<name>", with flow
+                // variants (e.g. "default", "flow2") as sub-keys.
+                } + active_flows + {
 
                 // Token costs and parameter types
                 "token-cost": config_spec.token_costs,

--- a/trustgraph_configurator/templates/2.3/runtime-config/flow-builder.jsonnet
+++ b/trustgraph_configurator/templates/2.3/runtime-config/flow-builder.jsonnet
@@ -5,21 +5,34 @@
 local param_processor = import "parameter-processor.jsonnet";
 
 {
+    // Recursively apply {blueprint}, {id}, and parameter substitutions
+    // to a value. Strings are replaced directly; objects recurse into
+    // their fields so that the topics/parameters sub-objects are handled
+    // transparently.
+    _replace_value: function(v, blueprint_name, flow_id, parameters)
+        if std.isString(v) then
+            local br = std.strReplace(v, "{blueprint}", blueprint_name);
+            local ir = if flow_id != null then std.strReplace(br, "{id}", flow_id) else br;
+            param_processor.substitute_parameters(ir, parameters)
+        else if std.isObject(v) then
+            {
+                [k]: $._replace_value(v[k], blueprint_name, flow_id, parameters)
+                for k in std.objectFieldsAll(v)
+            }
+        else
+            v,
+
     // Builds blueprint-level processors with parameter substitution
     // Processes the 'blueprint' section of flow blueprints
     build_blueprint_processors: function(flow_blueprints, blueprint_name, parameters)
         [
             [
-                // Replace {blueprint} in the processor key
                 local key = std.strReplace(processor.key, "{blueprint}", blueprint_name);
                 local parts = std.splitLimit(key, ":", 2);
                 parts,
                 {
-                    // Process each field in the processor configuration
                     [field.key]:
-                        // First replace {blueprint}, then substitute parameters
-                        local blueprint_replaced = std.strReplace(field.value, "{blueprint}", blueprint_name);
-                        param_processor.substitute_parameters(blueprint_replaced, parameters)
+                        $._replace_value(field.value, blueprint_name, null, parameters)
                     for field in std.objectKeysValuesAll(processor.value)
                 }
             ]
@@ -31,7 +44,6 @@ local param_processor = import "parameter-processor.jsonnet";
     build_flow_processors: function(flow_blueprints, blueprint_name, flow_id, parameters)
         [
             [
-                // Replace both {blueprint} and {id} in the processor key
                 local key = std.strReplace(
                     std.strReplace(processor.key, "{blueprint}", blueprint_name),
                     "{id}", flow_id
@@ -39,23 +51,21 @@ local param_processor = import "parameter-processor.jsonnet";
                 local parts = std.splitLimit(key, ":", 2);
                 parts,
                 {
-                    // Process each field in the processor configuration
                     [field.key]:
-                        // Replace {blueprint} and {id}, then substitute parameters
-                        local blueprint_replaced = std.strReplace(field.value, "{blueprint}", blueprint_name);
-                        local id_replaced = std.strReplace(blueprint_replaced, "{id}", flow_id);
-                        param_processor.substitute_parameters(id_replaced, parameters)
+                        $._replace_value(field.value, blueprint_name, flow_id, parameters)
                     for field in std.objectKeysValuesAll(processor.value)
                 }
             ]
             for processor in std.objectKeysValuesAll(flow_blueprints[blueprint_name].flow)
         ],
 
-    // Combines blueprint and flow processors into flow objects
+    // Combines blueprint and flow processors into flow objects.
+    // Each processor becomes its own config type keyed as
+    // "processor:<name>", with flow variants as sub-keys.
     build_flow_objects: function(processor_array)
         std.map(
             function(item) {
-                [item[0][0]] +: {
+                ["processor:" + item[0][0]] +: {
                     [item[0][1]]: item[1]
                 }
             },

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.3",
             "description": "Agent explainability analytics",
-            "version": "2.3.11",
+            "version": "2.3.13",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
Tracking change in TG 2.3.13

Split flow blueprint processor entries into explicit `topics` and `parameters` sub-objects, replacing the previous flat structure where topic URIs and config values were mixed at the same level.

- Flow processor entries change from flat dicts to `{"topics": {...}, "parameters": {...}}`
- Flow interfaces use dict wrappers (`flow_if`, `request_response_if`) instead of bare strings, removing string-vs-dict ambiguity
- Active-flow config keys change from `active-flow` with nested processor names to `processor:<name>` with flow variant as the key
- flow-builder uses recursive `_replace_value` to handle the new nested structure during parameter substitution
- Extract document-decoder into its own module (core/document-decoder.jsonnet)
- Deduplicate repetitive class name strings into local variables (rag.jsonnet, embeddings-fastembed.jsonnet)
- Add flow-svc processor to control.jsonnet
- Bump version to 2.3.13