### PR TITLE
Minor code tidy and additional code comments

### DIFF
--- a/docs/tech-specs/tests.md
+++ b/docs/tech-specs/tests.md
@@ -135,12 +135,12 @@ For each (version, platform, config) combination:
 Most tests call the Python entry point function directly rather than invoking the subprocess:
 
 ```python
-from trustgraph_configurator import run
+from trustgraph_configurator import generate_deployment
 import sys
 import json
 
 def test_basic_compilation(monkeypatch, capsys):
-    """Test compilation by calling run() directly"""
+    """Test compilation by calling generate_deployment() directly"""
     # Mock sys.argv with CLI arguments
     monkeypatch.setattr(sys, 'argv', [
         'tg-build-deployment',
@@ -151,7 +151,7 @@ def test_basic_compilation(monkeypatch, capsys):
     ])
 
     # Call the entry point directly
-    run.run()
+    generate_deployment()
 
     # Capture and validate output
     captured = capsys.readouterr()
@@ -233,13 +233,13 @@ def run_configurator(monkeypatch, capsys):
         Run configurator with args list.
         Returns (stdout, stderr, exit_code)
         """
-        from trustgraph_configurator import run
+        from trustgraph_configurator import generate_deployment
 
         monkeypatch.setattr(sys, 'argv', ['tg-build-deployment'] + args)
 
         exit_code = 0
         try:
-            run.run()
+            generate_deployment()
         except SystemExit as e:
             exit_code = e.code or 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dev = [
 Homepage = "https://github.com/trustgraph-ai/trustgraph-configurator"
 
 [project.scripts]
-tg-build-deployment = "trustgraph_configurator:run"
+tg-build-deployment = "trustgraph_configurator:generate_deployment"
 tg-config-svc = "trustgraph_configurator:run_service"
-tg-show-config-params = "trustgraph_configurator:list"
+tg-show-config-params = "trustgraph_configurator:list_templates"
 
 [tool.setuptools.packages.find]
 include = ["trustgraph_configurator*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,14 +52,14 @@ def run_configurator(monkeypatch, capsys):
         tuple: (stdout, stderr, exit_code)
     """
     def _run(args):
-        from trustgraph_configurator import run
+        from trustgraph_configurator import generate_deployment
 
         # Set sys.argv with the command and arguments
         monkeypatch.setattr(sys, 'argv', ['tg-build-deployment'] + args)
 
         exit_code = 0
         try:
-            run()  # run is already the function, not a module
+            generate_deployment()
         except SystemExit as e:
             exit_code = e.code if e.code is not None else 0
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -45,7 +45,7 @@ class TestRun:
 
     def test_exit_code_propagates(self, monkeypatch):
         """Test that exit codes are properly set."""
-        from trustgraph_configurator import run
+        from trustgraph_configurator import generate_deployment
 
         # Test successful exit (no exception)
         # This would require a valid config, so we'll just test the error path
@@ -57,6 +57,6 @@ class TestRun:
         ])
 
         with pytest.raises(SystemExit) as exc_info:
-            run()  # run is already the function
+            generate_deployment()
 
         assert exc_info.value.code == 1

--- a/trustgraph_configurator/__init__.py
+++ b/trustgraph_configurator/__init__.py
@@ -4,7 +4,7 @@ __version__ = "0.0.0"
 from . generator import Generator
 from . packager import Packager
 from . index import Index
-from . run import run
-from . list import list
+from . run import generate_deployment
+from . list import list_templates
 from . service import run_service
 

--- a/trustgraph_configurator/__main__.py
+++ b/trustgraph_configurator/__main__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-from . import run
+from . import generate_deployment
 
 if __name__ == '__main__':
-    run()
+    generate_deployment()
 

--- a/trustgraph_configurator/generator.py
+++ b/trustgraph_configurator/generator.py
@@ -1,3 +1,13 @@
+"""
+Jsonnet snippet evaluator.
+
+Wraps the gojsonnet native bindings to evaluate a Jsonnet template
+(either a string snippet or a file) and return the rendered JSON as
+a Python object. Import resolution is delegated to a fetch callback
+supplied by the caller (typically Packager), which lets templates
+reference bundled resources and dynamically-injected files such as
+config.json and version.jsonnet.
+"""
 
 import _gojsonnet as j
 import json

--- a/trustgraph_configurator/list.py
+++ b/trustgraph_configurator/list.py
@@ -1,3 +1,11 @@
+"""
+CLI entry point for `tg-show-config-params`.
+
+Prints the platforms and template versions bundled with this package
+as two tables, plus the current `latest` and `latest stable`
+pointers resolved from templates/index.json. Used to discover valid
+-t/-p values for `tg-build-deployment`.
+"""
 
 import json
 import logging
@@ -8,7 +16,7 @@ from . import Index
 
 from . import Generator, Packager
 
-def list():
+def list_templates():
 
     parser = argparse.ArgumentParser(
         prog="tg-show-config-params",

--- a/trustgraph_configurator/packager.py
+++ b/trustgraph_configurator/packager.py
@@ -1,3 +1,17 @@
+"""
+Deployment package builder.
+
+Given a template name, version and target platform, locates the
+bundled Jsonnet templates, feeds a user-supplied config.json through
+the platform-specific renderer (config-to-docker-compose.jsonnet,
+config-to-<k8s-flavour>.jsonnet, etc.) and emits a zip containing
+the deployment artefacts: docker-compose.yaml or resources.yaml,
+plus any trustgraph/config.json and additional files declared by
+the template's config-to-additionals.jsonnet renderer.
+
+Also exposes write_tg_config / write_resources for writing a single
+artefact to stdout instead of producing a zip.
+"""
 
 import pathlib
 import yaml

--- a/trustgraph_configurator/run.py
+++ b/trustgraph_configurator/run.py
@@ -1,3 +1,12 @@
+"""
+CLI entry point for `tg-build-deployment`.
+
+Parses command-line arguments, loads an input config.json and drives
+Packager to emit a deployment zip (default) or, with -O / -R, a
+single artefact (TrustGraph config JSON or the compose/k8s resources
+YAML) to stdout. Logging is suppressed when writing to stdout so the
+output remains machine-parseable.
+"""
 
 import json
 import logging
@@ -6,7 +15,7 @@ import sys
 
 from . import Generator, Packager
 
-def run():
+def generate_deployment():
 
     parser = argparse.ArgumentParser(
         prog="tg-build-deployment",

--- a/trustgraph_configurator/service.py
+++ b/trustgraph_configurator/service.py
@@ -1,3 +1,11 @@
+"""
+CLI entry point for `tg-config-svc`.
+
+Starts the aiohttp-based HTTP service (see api.py) that exposes the
+configurator as a REST API: POST /api/generate/{platform}/{template}
+to build a deployment zip from a supplied config, plus GET endpoints
+for version discovery and the bundled dialog-flow / docs resources.
+"""
 
 import logging
 

--- a/trustgraph_configurator/templates/2.3/core/agent-manager-react.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/agent-manager-react.jsonnet
@@ -1,3 +1,5 @@
+// ReAct-style agent manager processor definition.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/agent-orchestrator.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/agent-orchestrator.jsonnet
@@ -1,3 +1,5 @@
+// Plan-then-execute / supervisor agent orchestrator processor.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/api-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/api-gateway.jsonnet
@@ -1,3 +1,5 @@
+// External HTTP/WebSocket API gateway processor definition.
+
 local images = import "values/images.jsonnet";
 
 {

--- a/trustgraph_configurator/templates/2.3/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/control.jsonnet
@@ -1,3 +1,5 @@
+// Control-plane processors: flow orchestration and librarian service.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 local garage = import "backends/garage.jsonnet";

--- a/trustgraph_configurator/templates/2.3/core/document-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/document-decoder.jsonnet
@@ -1,3 +1,6 @@
+// Document decoder processor — turns uploaded files (PDF, etc.)
+// into the text representation consumed by the ingest pipeline.
+
 local images = import "values/images.jsonnet";
 
 {

--- a/trustgraph_configurator/templates/2.3/core/document-rag.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/document-rag.jsonnet
@@ -1,3 +1,6 @@
+// Document-RAG processor — retrieves text chunks by vector
+// similarity and synthesises answers from the retrieved context.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 local prompts = import "prompts/mixtral.jsonnet";

--- a/trustgraph_configurator/templates/2.3/core/graph-rag.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/graph-rag.jsonnet
@@ -1,3 +1,6 @@
+// Graph-RAG processor — retrieves sub-graphs from the knowledge
+// graph and synthesises answers grounded in the traversed nodes.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/ingest.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/ingest.jsonnet
@@ -1,3 +1,6 @@
+// Document ingest pipeline: loaders and pre-processing that feed
+// the extraction and embedding stages.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/mcp-server.jsonnet
@@ -1,3 +1,6 @@
+// MCP (Model Context Protocol) server processor — exposes
+// TrustGraph tools to MCP-capable clients.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/prompt-overrides.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/prompt-overrides.jsonnet
@@ -1,3 +1,6 @@
+// Helpers for overriding individual prompt templates from the
+// default set without copying the full default-prompts.jsonnet.
+
 local default_prompts = import "prompts/default-prompts.jsonnet";
 
 {

--- a/trustgraph_configurator/templates/2.3/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/rag.jsonnet
@@ -1,3 +1,6 @@
+// RAG query path: graph- and document-RAG processors plus their
+// supporting prompt / LLM interfaces.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/rev-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/rev-gateway.jsonnet
@@ -1,3 +1,6 @@
+// Reverse gateway processor — ingress front-end that terminates
+// external connections and forwards to internal services.
+
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
 

--- a/trustgraph_configurator/templates/2.3/core/trustgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.3/core/trustgraph.jsonnet
@@ -1,3 +1,9 @@
+// Core TrustGraph assembly.
+// Composes the always-on processor set (control plane, ingest, RAG,
+// API gateway, MCP server, workbench UI, runtime config) into a
+// single object that the platform renderers consume. Individual
+// processor definitions live in sibling files in this directory.
+
 local images = import "values/images.jsonnet";
 
 local config_initialiser = import "configuration.jsonnet";

--- a/trustgraph_configurator/templates/2.3/runtime-config/agent-patterns.jsonnet
+++ b/trustgraph_configurator/templates/2.3/runtime-config/agent-patterns.jsonnet
@@ -1,3 +1,6 @@
+// Agent reasoning patterns available to the agent manager.
+// Each entry describes one strategy (ReAct, plan-then-execute,
+// supervisor) and the iteration / tool-use contract it follows.
 
 {
     "react": {

--- a/trustgraph_configurator/templates/2.3/runtime-config/agent-task-types.jsonnet
+++ b/trustgraph_configurator/templates/2.3/runtime-config/agent-task-types.jsonnet
@@ -1,3 +1,6 @@
+// Agent task-type definitions — domain framings plus the set of
+// reasoning patterns (see agent-patterns.jsonnet) that are valid
+// for each task type.
 
 {
     "general": {

--- a/trustgraph_configurator/templates/2.3/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.3/values/images.jsonnet
@@ -1,3 +1,8 @@
+// Container image references used across the templates.
+// TrustGraph images are tagged with the version from
+// version.jsonnet (injected by the packager); third-party
+// images are pinned explicitly here.
+
 local version = import "version.jsonnet";
 {
     cassandra: "docker.io/cassandra:5.0.6",

--- a/trustgraph_configurator/templates/2.3/values/token-costs.jsonnet
+++ b/trustgraph_configurator/templates/2.3/values/token-costs.jsonnet
@@ -1,3 +1,7 @@
+// Per-model input/output token prices (USD per token), keyed by
+// provider-qualified model id. Consumed by the runtime config so
+// downstream accounting can attribute cost per LLM call.
+
 {
   "mistral.mistral-large-2407-v1:0": {
     "model_name": "mistral.mistral-large-2407-v1:0",

--- a/trustgraph_configurator/templates/2.3/values/url.jsonnet
+++ b/trustgraph_configurator/templates/2.3/values/url.jsonnet
@@ -1,3 +1,7 @@
+// Internal service URLs used by processors to reach infrastructure
+// components (pulsar, object store, vector stores). Hostnames assume
+// the deployment-internal DNS names produced by the renderers.
+
 {
     pulsar: "pulsar://pulsar:6650",
     pulsar_admin: "http://pulsar:8080",


### PR DESCRIPTION
Python (trustgraph_configurator/):

- Added module docstrings to generator.py, packager.py, list.py, run.py, service.py

- Renamed run() → generate_deployment() and list() → list_templates(); updated __init__.py, __main__.py, pyproject.toml, tests/conftest.py, tests/unit/test_run.py, docs/tech-specs/tests.md

2.3 templates:

- Added assembly-point header to core/trustgraph.jsonnet and 1–2 line headers to each core service file (control, ingest, rag, api-gateway, mcp-server, document-decoder, rev-gateway, agent-manager-react, agent-orchestrator, document-rag, graph-rag, prompt-overrides)

- Added headers to runtime-config/agent-patterns.jsonnet and agent-task-types.jsonnet (other runtime-config files already had them)

- Added headers to all three files in values/ (images, url, token-costs)

- Prompt files already carried short headers — left alone

Verified: imports resolve, --help renders the new docstring, and a full 2.3 docker-compose build still renders.