### PR TITLE
Update to remove api-gateway and mcp-server secrets from templates

### DIFF
--- a/trustgraph_configurator/templates/2.4/components.jsonnet
+++ b/trustgraph_configurator/templates/2.4/components.jsonnet
@@ -61,6 +61,9 @@
    // Extra MCP services
    "ddg-mcp-server": import "mcp/ddg-mcp-server.jsonnet",
 
+   // Optional MCP server
+   "mcp-server": import "core/mcp-server.jsonnet",
+
    // Does nothing.  But, can be a hack to overwrite parameters
    "null": {},
 

--- a/trustgraph_configurator/templates/2.4/core/api-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.4/core/api-gateway.jsonnet
@@ -27,9 +27,6 @@ local images = import "values/images.jsonnet";
 
         create:: function(engine)
 
-            local envSecrets = engine.envSecrets("gateway-secret")
-                .with_env_var("GATEWAY_SECRET", "gateway-secret");
-
             local container =
                 engine.container("api-gateway")
                     .with_image(images.trustgraph_flow)
@@ -43,7 +40,6 @@ local images = import "values/images.jsonnet";
                         "--log-level",
                         logLevel,
                     ])
-                    .with_env_var_secrets(envSecrets)
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation)
                     .with_port(port, port, "api");
@@ -58,7 +54,6 @@ local images = import "values/images.jsonnet";
                 .with_port(port, port, "api");
 
             engine.resources([
-                envSecrets,
                 containerSet,
                 service,
             ])

--- a/trustgraph_configurator/templates/2.4/core/mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.4/core/mcp-server.jsonnet
@@ -26,10 +26,6 @@ local url = import "values/url.jsonnet";
 
         create:: function(engine)
 
-            local envSecrets = engine.envSecrets("mcp-server-secret")
-                .with_env_var("MCP_SERVER_SECRET", "mcp-server-secret")
-                .with_env_var("GATEWAY_SECRET", "gateway-secret");
-
             local container =
                 engine.container("mcp-server")
                     .with_image(images.trustgraph_mcp)
@@ -38,7 +34,6 @@ local url = import "values/url.jsonnet";
                         "--port",
                         std.toString(port),
                     ])
-                    .with_env_var_secrets(envSecrets)
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation)
                     .with_port(port, port, "mcp");
@@ -52,7 +47,6 @@ local url = import "values/url.jsonnet";
                 .with_port(port, port, "mcp");
 
             engine.resources([
-                envSecrets,
                 containerSet,
                 service,
             ])

--- a/trustgraph_configurator/templates/2.4/core/trustgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.4/core/trustgraph.jsonnet
@@ -11,7 +11,6 @@ local control = import "control.jsonnet";
 local ingest = import "ingest.jsonnet";
 local rag = import "rag.jsonnet";
 local api_gateway = import "api-gateway.jsonnet";
-local mcp_server = import "mcp-server.jsonnet";
 local document_decoder = import "document-decoder.jsonnet";
 local workbench = import "../ui/workbench-ui.jsonnet";
 local ddg = import "mcp/ddg-mcp-server.jsonnet";
@@ -27,6 +26,6 @@ local ddg = import "mcp/ddg-mcp-server.jsonnet";
         "log-level":: "INFO",
     },
 
-} + control + ingest + rag + api_gateway + mcp_server + document_decoder
+} + control + ingest + rag + api_gateway + document_decoder
   + workbench + config + ddg
 


### PR DESCRIPTION
- Made mcp-server optional, need to add a 'mcp-server' parameter
- Removed gateway secret and MCP server secret
- Leaves mcp-server exposed, except that current implementation is now not able to authenticate with gateway so can't do anything.  Need mcp-server auth to be addressed in the trustgraph package