### PR TITLE
Fix init collection name not matching workspace update

### DIFF
--- a/trustgraph_configurator/templates/2.4/runtime-config/trustgraph-config.jsonnet
+++ b/trustgraph_configurator/templates/2.4/runtime-config/trustgraph-config.jsonnet
@@ -37,7 +37,7 @@ local configuration = {
     "embeddings-models" +:: {},
 
     collections +:: {
-      "trustgraph:default": {
+      "default": {
         "user": "default-user",
         "collection": "default",
         "name": "Default Collection",


### PR DESCRIPTION
Default collection was set to `trustgraph:default` from previous regime, now `default`.

Rationale: This is a workspace template, not applied directly to initial config