### PR TITLE
Minimum volume sizes for K8s and ACA

### DIFF
--- a/trustgraph_configurator/templates/2.3/engine/eks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.3/engine/eks-k8s.jsonnet
@@ -1,6 +1,25 @@
 
 local k8s = import "k8s.jsonnet";
 
+// gp3 with 6000 IOPS / 400 MiB/s requires minimum 16 GiB
+// (500 IOPS-per-GiB ratio needs 12 GiB; throughput floor needs 16 GiB).
+local minGib = 16;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -29,6 +48,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)

--- a/trustgraph_configurator/templates/2.3/engine/gcp-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.3/engine/gcp-k8s.jsonnet
@@ -1,6 +1,24 @@
 
 local k8s = import "k8s.jsonnet";
 
+// GCP persistent disks have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -27,6 +45,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)

--- a/trustgraph_configurator/templates/2.3/engine/ovh-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.3/engine/ovh-k8s.jsonnet
@@ -1,6 +1,24 @@
 
 local k8s = import "k8s.jsonnet";
 
+// OVHcloud high-speed volumes have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -28,6 +46,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)

--- a/trustgraph_configurator/templates/2.4/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.4/engine/aca.jsonnet
@@ -590,7 +590,7 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
         };
         local quotaGib = function(s)
             local g = parseMemGib(s);
-            if g < 1 then 1 else std.ceil(g);
+            if g < 100 then 100 else std.ceil(g);
         local storageAccount =
             if std.length(azureFileMarkers) > 0 then [{
                 type: "Microsoft.Storage/storageAccounts",

--- a/trustgraph_configurator/templates/2.4/engine/eks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.4/engine/eks-k8s.jsonnet
@@ -1,6 +1,25 @@
 
 local k8s = import "k8s.jsonnet";
 
+// gp3 with 6000 IOPS / 400 MiB/s requires minimum 16 GiB
+// (500 IOPS-per-GiB ratio needs 12 GiB; throughput floor needs 16 GiB).
+local minGib = 16;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -29,6 +48,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)

--- a/trustgraph_configurator/templates/2.4/engine/gcp-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.4/engine/gcp-k8s.jsonnet
@@ -1,6 +1,24 @@
 
 local k8s = import "k8s.jsonnet";
 
+// GCP persistent disks have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -27,6 +45,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)

--- a/trustgraph_configurator/templates/2.4/engine/ovh-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.4/engine/ovh-k8s.jsonnet
@@ -1,6 +1,24 @@
 
 local k8s = import "k8s.jsonnet";
 
+// OVHcloud high-speed volumes have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
 local ns = {
     apiVersion: "v1",
     kind: "Namespace",
@@ -28,6 +46,15 @@ local sc = {
 };
 
 k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
 
     // Extract resources usnig the engine
     package:: function(patterns)


### PR DESCRIPTION
Updated for 2.4 templates:
  - ACA: Floor Azure Premium File Share quotas at 100 GiB (provider minimum)                                                        
  - EKS: Floor PVC sizes at 16 GiB (required by gp3 with 6000 IOPS / 400 MiB/s)                                                     
  - GCP: Floor PVC sizes at 10 GiB (pd-balanced minimum)                                                                            
  - OVH: Floor PVC sizes at 10 GiB (high-speed Cinder volume minimum)
                                                                                                                                    
Backported K8s floors to 2.3 templates.
