### PR TITLE
Fix librarian problems in 2.4 flow blueprints

### DIFF
--- a/trustgraph_configurator/templates/2.4/flows/agent.jsonnet
+++ b/trustgraph_configurator/templates/2.4/flows/agent.jsonnet
@@ -8,6 +8,8 @@ local flow = helpers.flow;
 local request = helpers.request;
 local response = helpers.response;
 local request_response_if = helpers.request_response_if;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
 
 // Import shared services (agent requires LLM for reasoning, MCP for tools)
 local llm_services = import "llm-services.jsonnet";
@@ -44,6 +46,8 @@ llm_services + mcp_service + {
                 "row-embeddings-query-request": request("row-embeddings:{workspace}:{id}"),
                 "row-embeddings-query-response": response("row-embeddings:{workspace}:{id}"),
                 explainability: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
             },
         },
     },

--- a/trustgraph_configurator/templates/2.4/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.4/flows/document-store.jsonnet
@@ -8,6 +8,8 @@ local flow_if = helpers.flow_if;
 local request = helpers.request;
 local response = helpers.response;
 local request_response_if = helpers.request_response_if;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
 
 // Import shared services
 local llm_services = import "llm-services.jsonnet";
@@ -50,6 +52,8 @@ llm_services + embeddings_service + {
                 "document-embeddings-request": request("document-embeddings:{workspace}:{id}"),
                 "document-embeddings-response": response("document-embeddings:{workspace}:{id}"),
                 explainability: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
             },
         },
         "doc-embeddings-query:{id}": {

--- a/trustgraph_configurator/templates/2.4/flows/helpers.jsonnet
+++ b/trustgraph_configurator/templates/2.4/flows/helpers.jsonnet
@@ -13,8 +13,8 @@ local request(x) = "request:tg:" + x;
 // Creates a non-persistent response URI for request-response patterns
 local response(x) = "response:tg:" + x;
 
-local librarian_request = request("librarian");
-local librarian_response = response("librarian");
+local librarian_request = request("librarian:{workspace}");
+local librarian_response = response("librarian:{workspace}");
 
 // Creates a request-response pair for bidirectional communication
 // Returns an object with both request and response URIs


### PR DESCRIPTION
Added missing librarian queue configuration to agent-manager
and document-rag processor in the flow blueprints