### PR TITLE
Add pub-sub-admin-params for Pulsar admin URL plumbing

### DIFF
--- a/trustgraph_configurator/templates/2.4/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.4/core/control.jsonnet
@@ -103,7 +103,7 @@ local cassandra = import "backends/cassandra.jsonnet";
                                 class: "trustgraph.flow.service.Processor",
                                 params:  {
                                     id: "flow-svc",
-                                } + $["pub-sub-params"],
+                                } + $["pub-sub-params"] + $["pub-sub-admin-params"],
                             },
                             {
                                 class: "trustgraph.cores.service.Processor",

--- a/trustgraph_configurator/templates/2.4/pubsub/kafka.jsonnet
+++ b/trustgraph_configurator/templates/2.4/pubsub/kafka.jsonnet
@@ -11,6 +11,8 @@ local images = import "values/images.jsonnet";
         kafka_bootstrap_servers: "kafka:9092",
     },
 
+    "pub-sub-admin-params":: {},
+
     "pub-sub-args":: [
         "--pubsub-backend",
         "kafka",

--- a/trustgraph_configurator/templates/2.4/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.4/pubsub/pulsar.jsonnet
@@ -14,6 +14,10 @@ local url = import "values/url.jsonnet";
         pulsar_host: url.pulsar,
     },
 
+    "pub-sub-admin-params":: {
+        pulsar_admin_url: url.pulsar_admin,
+    },
+
     "pub-sub-args":: [
         "--pubsub-backend",
         "pulsar",

--- a/trustgraph_configurator/templates/2.4/pubsub/rabbitmq.jsonnet
+++ b/trustgraph_configurator/templates/2.4/pubsub/rabbitmq.jsonnet
@@ -11,6 +11,8 @@ local url = import "values/url.jsonnet";
         rabbitmq_host: "rabbitmq",
     },
 
+    "pub-sub-admin-params":: {},
+
     "pub-sub-args":: [
         "--pubsub-backend",
         "rabbitmq",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -33,7 +33,7 @@
         {
             "name": "2.4",
             "description": "IAM & data separation through workspaces",
-            "version": "2.4.24",
+            "version": "2.4.29",
             "status": "beta"
         }
     ],


### PR DESCRIPTION
Verified e2e with Pulsar:
- Add pub-sub-admin-params for Pulsar admin URL plumbing
- Bump 2.4 -> 2.4.29
