### PR TITLE
Fix Bedrock text-completion image

### DIFF
--- a/trustgraph_configurator/templates/2.3/llm/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.3/llm/bedrock.jsonnet
@@ -75,7 +75,7 @@ local models = import "parameters/bedrock.jsonnet";
 
             local container =
                 engine.container("text-completion")
-                    .with_image(images.trustgraph_flow)
+                    .with_image(images.trustgraph_bedrock)
                     .with_command([
                         "processor-group",
                         "--log-level",

--- a/trustgraph_configurator/templates/2.4/llm/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.4/llm/bedrock.jsonnet
@@ -75,7 +75,7 @@ local models = import "parameters/bedrock.jsonnet";
 
             local container =
                 engine.container("text-completion")
-                    .with_image(images.trustgraph_flow)
+                    .with_image(images.trustgraph_bedrock)
                     .with_command([
                         "processor-group",
                         "--log-level",

--- a/trustgraph_configurator/templates/2.5/llm/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/bedrock.jsonnet
@@ -75,7 +75,7 @@ local models = import "parameters/bedrock.jsonnet";
 
             local container =
                 engine.container("text-completion")
-                    .with_image(images.trustgraph_flow)
+                    .with_image(images.trustgraph_bedrock)
                     .with_command([
                         "processor-group",
                         "--log-level",


### PR DESCRIPTION
Bedrock text-completion installed the wrong image (flow instead of bedrock) for Bedroc text-completion.  This is fixed.