### PR TITLE
Harden Grafana deployment: Secret-based admin password

### DIFF
--- a/trustgraph_configurator/templates/2.2/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.2/monitoring/grafana.jsonnet
@@ -89,7 +89,7 @@ local loki = import "loki.jsonnet";
                     })
                     .with_limits("1.0", "256M")
                     .with_reservations("0.5", "256M")
-                    .with_port(3000, 3000, "cassandra")
+                    .with_port(3000, 3000, "grafana")
                     .with_volume_mount(vol, "/var/lib/grafana")
                     .with_volume_mount(
                         provDashVol, "/etc/grafana/provisioning/dashboards/"

--- a/trustgraph_configurator/templates/2.3/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.3/monitoring/grafana.jsonnet
@@ -89,7 +89,7 @@ local loki = import "loki.jsonnet";
                     })
                     .with_limits("1.0", "256M")
                     .with_reservations("0.5", "256M")
-                    .with_port(3000, 3000, "cassandra")
+                    .with_port(3000, 3000, "grafana")
                     .with_volume_mount(vol, "/var/lib/grafana")
                     .with_volume_mount(
                         provDashVol, "/etc/grafana/provisioning/dashboards/"

--- a/trustgraph_configurator/templates/2.4/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.4/monitoring/grafana.jsonnet
@@ -3,6 +3,10 @@ local loki = import "loki.jsonnet";
 
 {
 
+    parameters +:: {
+        "grafana-admin-user":: "admin",
+    },
+
     "prometheus" +: {
     
         create:: function(engine)
@@ -45,10 +49,15 @@ local loki = import "loki.jsonnet";
     },
 
     "grafana" +: {
-    
+
+        local pars = $.parameters,
+
         create:: function(engine)
 
             local vol = engine.volume("grafana-storage").with_size("20G");
+
+            local envSecrets = engine.envSecrets("grafana-secret")
+                .with_env_var("GF_SECURITY_ADMIN_PASSWORD", "password");
 
             local provDashVol = engine.configVolume(
                 "prov-dash", "grafana/provisioning/",
@@ -84,16 +93,20 @@ local loki = import "loki.jsonnet";
                     .with_image(images.grafana)
                     .with_user(472)
                     .with_group(472)
+                    .with_env_var_secrets(envSecrets)
                     .with_environment({
-                        // GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin",
-                        // GF_AUTH_ANONYMOUS_ENABLED: "true",
-                        // GF_ORG_ROLE: "Admin",
                         GF_ORG_NAME: "trustgraph.ai",
-                        // GF_SERVER_ROOT_URL: "https://example.com",
+                        GF_SECURITY_ADMIN_USER: pars["grafana-admin-user"],
+                        GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: "/var/lib/grafana/dashboards/overview-dashboard.json",
+                        GF_ANALYTICS_REPORT_WHATS_NEW: "false",
+                        GF_PANELS_DISABLE_NEWS_FEED: "true",
+                        GF_NEWS_NEWS_FEED_ENABLED: "false",
+                        GF_PLUGINS_EXCLUDE_APPS: "grafana-assistant-app",
+                        GF_FEATURE_TOGGLES_ASSISTANT: "false",
                     })
                     .with_limits("1.0", "256M")
                     .with_reservations("0.5", "256M")
-                    .with_port(3000, 3000, "cassandra")
+                    .with_port(3000, 3000, "grafana")
                     .with_volume_mount(vol, "/var/lib/grafana")
                     .with_volume_mount(
                         provDashVol, "/etc/grafana/provisioning/dashboards/"

--- a/trustgraph_configurator/templates/2.5/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.5/monitoring/grafana.jsonnet
@@ -3,6 +3,10 @@ local loki = import "loki.jsonnet";
 
 {
 
+    parameters +:: {
+        "grafana-admin-user":: "admin",
+    },
+
     "prometheus" +: {
     
         create:: function(engine)
@@ -45,10 +49,15 @@ local loki = import "loki.jsonnet";
     },
 
     "grafana" +: {
+
+        local pars = $.parameters,
     
         create:: function(engine)
 
             local vol = engine.volume("grafana-storage").with_size("20G");
+
+            local envSecrets = engine.envSecrets("grafana-secret")
+                .with_env_var("GF_SECURITY_ADMIN_PASSWORD", "password");
 
             local provDashVol = engine.configVolume(
                 "prov-dash", "grafana/provisioning/",
@@ -84,16 +93,20 @@ local loki = import "loki.jsonnet";
                     .with_image(images.grafana)
                     .with_user(472)
                     .with_group(472)
+                    .with_env_var_secrets(envSecrets)
                     .with_environment({
-                        // GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin",
-                        // GF_AUTH_ANONYMOUS_ENABLED: "true",
-                        // GF_ORG_ROLE: "Admin",
                         GF_ORG_NAME: "trustgraph.ai",
-                        // GF_SERVER_ROOT_URL: "https://example.com",
+                        GF_SECURITY_ADMIN_USER: pars["grafana-admin-user"],
+                        GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: "/var/lib/grafana/dashboards/overview-dashboard.json",
+                        GF_ANALYTICS_REPORT_WHATS_NEW: "false",
+                        GF_PANELS_DISABLE_NEWS_FEED: "true",
+                        GF_NEWS_NEWS_FEED_ENABLED: "false",
+                        GF_PLUGINS_EXCLUDE_APPS: "grafana-assistant-app",
+                        GF_FEATURE_TOGGLES_ASSISTANT: "false",
                     })
                     .with_limits("1.0", "256M")
                     .with_reservations("0.5", "256M")
-                    .with_port(3000, 3000, "cassandra")
+                    .with_port(3000, 3000, "grafana")
                     .with_volume_mount(vol, "/var/lib/grafana")
                     .with_volume_mount(
                         provDashVol, "/etc/grafana/provisioning/dashboards/"


### PR DESCRIPTION
Adds envSecrets for admin password, parameterises admin username, sets a default home dashboard, disables analytics/news/assistant features, and fixes the misnamed "cassandra" port label across all template versions (2.2–2.5).