### PR TITLE
Fix ZK volume mount path for compatibility with newer macOS Docker

### DIFF
--- a/trustgraph_configurator/templates/2.4/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.4/pubsub/pulsar.jsonnet
@@ -101,7 +101,7 @@ local url = import "values/url.jsonnet";
                     .with_reservations("0.05", zkMemReserv)
                     .with_user(0)
                     .with_group(1000)
-                    .with_volume_mount(zkVolume, "/pulsar/data/zookeeper")
+                    .with_volume_mount(zkVolume, "/pulsar/data")
                     .with_environment({
                         "metadataStoreUrl": "zk:zookeeper:2181",
                         "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [

--- a/trustgraph_configurator/templates/2.5/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.5/pubsub/pulsar.jsonnet
@@ -101,7 +101,7 @@ local url = import "values/url.jsonnet";
                     .with_reservations("0.05", zkMemReserv)
                     .with_user(0)
                     .with_group(1000)
-                    .with_volume_mount(zkVolume, "/pulsar/data/zookeeper")
+                    .with_volume_mount(zkVolume, "/pulsar/data")
                     .with_environment({
                         "metadataStoreUrl": "zk:zookeeper:2181",
                         "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [


### PR DESCRIPTION
Mount the ZooKeeper volume at /pulsar/data instead of /pulsar/data/zookeeper, which resolves a failure on newer macOS versions where Docker cannot create subdirectories under the container's existing /pulsar/data path.