### PR TITLE
Fix minikube-k8s template rendering, bump versions, retire old templates

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import pytest
 # =============================================================================
 # Version Configuration - Update these when adding new template versions
 # =============================================================================
-TESTED_VERSIONS = ["2.3", "2.4"]
-PRIMARY_VERSION = "2.4"  # Used when only one version is tested
+TESTED_VERSIONS = ["2.4", "2.5"]
+PRIMARY_VERSION = "2.5"  # Used when only one version is tested
 import sys
 import json
 import tempfile

--- a/trustgraph_configurator/templates/2.4/core/chunker-recursive.jsonnet
+++ b/trustgraph_configurator/templates/2.4/core/chunker-recursive.jsonnet
@@ -1,0 +1,8 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+
+{
+
+}
+

--- a/trustgraph_configurator/templates/2.4/engine/minikube-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.4/engine/minikube-k8s.jsonnet
@@ -85,6 +85,7 @@ k8s + {
                         { src: src, dest: dest, name: name  }
                     ]
                 },
+        with_external:: function() self,
         add:: function() [
             {
                 apiVersion: "v1",

--- a/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
@@ -5,9 +5,9 @@ local images = import "values/images.jsonnet";
     "cassandra" +: {
 
         // Memory settings (can be overridden by memory-profile)
-        "memory-limit":: "1000M",
-        "memory-reservation":: "1000M",
-        "heap":: "300M",
+        "memory-limit":: "1400M",
+        "memory-reservation":: "1400M",
+        "heap":: "700M",
 
         create:: function(engine)
 

--- a/trustgraph_configurator/templates/2.5/engine/minikube-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/minikube-k8s.jsonnet
@@ -85,6 +85,7 @@ k8s + {
                         { src: src, dest: dest, name: name  }
                     ]
                 },
+        with_external:: function() self,
         add:: function() [
             {
                 apiVersion: "v1",

--- a/trustgraph_configurator/templates/2.5/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.5/values/images.jsonnet
@@ -31,7 +31,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.1.1",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.2.0",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.0",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -1,23 +1,5 @@
 {
     "templates": [
-	{
-            "name": "1.8",
-            "description": "Pluggable messaging fabric, switched to Garage for object store",
-            "version": "1.8.21",
-            "status": "stable"
-        },
-	{
-            "name": "1.9",
-            "description": "Ontology extraction update, JSONL output from prompts",
-            "version": "1.9.4",
-            "status": "stable"
-        },
-        {
-            "name": "2.1",
-            "description": "End-to-end provenance tracking and explainability across the knowledge pipeline — from document ingestion through extraction to query-time retrieval - every answer traceable to its source evidence",
-            "version": "2.1.26",
-            "status": "stable"
-        },
         {
             "name": "2.2",
             "description": "Multi-pattern agent orchestration with explainability, extended document processing for cover many document types",
@@ -33,13 +15,13 @@
         {
             "name": "2.4",
             "description": "IAM & data separation through workspaces",
-            "version": "2.4.31",
+            "version": "2.4.33",
             "status": "stable"
         },
         {
             "name": "2.5",
             "description": "Further updates to SPARQL retrieval",
-            "version": "2.5.3",
+            "version": "2.5.7",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
Add missing with_external method to minikube-k8s service override in 2.4 and 2.5, and add missing chunker-recursive.jsonnet for 2.4 — both caused jsonnet rendering failures for minikube deployments.

Increase Cassandra memory/heap in 2.5 (1000M/300M -> 1400M/700M). Bump TG to 2.4.33 and 2.5.7, TG-UI to 0.2.0.
Remove retired template versions (1.8, 1.9, 2.1) from index. Update test matrix from 2.3/2.4 to 2.4/2.5.