### PR TITLE
Service scaling and internal/external service refactor (2.5)

### DIFF
--- a/trustgraph_configurator/resources/2.5/loki/local-config.yaml
+++ b/trustgraph_configurator/resources/2.5/loki/local-config.yaml
@@ -2,31 +2,22 @@ auth_enabled: false
 
 server:
   http_listen_port: 3100
-  grpc_listen_port: 9096
-  log_level: debug
-  grpc_server_max_concurrent_streams: 1000
 
 common:
   instance_addr: 127.0.0.1
-  path_prefix: /tmp/loki
+  path_prefix: /loki
   storage:
     filesystem:
-      chunks_directory: /tmp/loki/chunks
-      rules_directory: /tmp/loki/rules
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
   replication_factor: 1
   ring:
     kvstore:
       store: inmemory
 
-query_range:
-  results_cache:
-    cache:
-      embedded_cache:
-        enabled: true
-        max_size_mb: 100
-
-limits_config:
-  metric_aggregation_enabled: true
+ingester:
+  lifecycler:
+    join_after: 2s
 
 schema_config:
   configs:
@@ -38,16 +29,8 @@ schema_config:
         prefix: index_
         period: 24h
 
-pattern_ingester:
-  enabled: true
-  metric_aggregation:
-    loki_address: localhost:3100
-
 ruler:
   alertmanager_url: http://localhost:9093
-
-frontend:
-  encoding: protobuf
 
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
@@ -55,9 +38,10 @@ frontend:
 # Statistics help us better understand how Loki is used, and they show us performance
 # levels for most users. This helps us prioritize features and documentation.
 # For more information on what's sent, look at
-# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
 # Refer to the buildReport method to see what goes into a report.
 #
 # If you would like to disable reporting, uncomment the following lines:
 analytics:
   reporting_enabled: false
+

--- a/trustgraph_configurator/resources/2.5/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.5/prometheus/prometheus-pulsar.yml
@@ -68,7 +68,7 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets:
-        - 'api-gateway:8000'
+        - 'api-gateway-metrics:8000'
 
   - job_name: 'mcp-server'
     scrape_interval: 5s

--- a/trustgraph_configurator/resources/2.5/prometheus/prometheus-rabbitmq.yml
+++ b/trustgraph_configurator/resources/2.5/prometheus/prometheus-rabbitmq.yml
@@ -68,7 +68,7 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets:
-        - 'api-gateway:8000'
+        - 'api-gateway-metrics:8000'
 
   - job_name: 'mcp-server'
     scrape_interval: 5s

--- a/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
@@ -38,7 +38,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("cassandra", containerSet)
                 .with_port(9042, 9042, "api");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/backends/ceph.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/ceph.jsonnet
@@ -395,22 +395,22 @@ local images = import "values/images.jsonnet";
 
             // Services - expose daemon ports for inter-daemon communication
             local mon_service =
-                engine.service(mon_containerSet)
+                engine.internalService("ceph-mon", mon_containerSet)
                     .with_port(6789, 6789, "mon")
                     .with_port(3300, 3300, "mon-msgr2");
 
             local mgr_service =
-                engine.service(mgr_containerSet)
+                engine.internalService("ceph-mgr", mgr_containerSet)
                     .with_port(7000, 7000, "mgr")
                     .with_port(8443, 8443, "dashboard")
                     .with_port(9283, 9283, "prometheus");
 
             local osd_service =
-                engine.service(osd_containerSet)
+                engine.internalService("ceph-osd", osd_containerSet)
                     .with_port(6800, 6800, "osd");
 
             local rgw_service =
-                engine.service(rgw_containerSet)
+                engine.internalService("ceph-rgw", rgw_containerSet)
                     .with_port(7480, 7480, "s3");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/backends/falkordb.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/falkordb.jsonnet
@@ -24,7 +24,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("falkordb", containerSet)
                 .with_port(6379, 6379, "api")
                 .with_port(3010, 3010, "ui");
 

--- a/trustgraph_configurator/templates/2.5/backends/garage.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/garage.jsonnet
@@ -230,7 +230,7 @@ local images = import "values/images.jsonnet";
 
             // Service - expose Garage ports
             local garage_service =
-                engine.service(garage_containerSet)
+                engine.internalService("garage", garage_containerSet)
                     .with_port(3900, 3900, "s3-api")
                     .with_port(3901, 3901, "rpc")
                     .with_port(3902, 3902, "web")

--- a/trustgraph_configurator/templates/2.5/backends/memgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/memgraph.jsonnet
@@ -25,7 +25,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("memgraph", containerSet)
                 .with_port(7474, 7474, "api")
                 .with_port(7687, 7687, "api2");
 
@@ -57,7 +57,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("memgraph", containerSet)
                 .with_port(3010, 3010, "http");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/backends/milvus.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/milvus.jsonnet
@@ -38,7 +38,7 @@ minio {
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("etcd", containerSet)
                 .with_port(2379, 2379, "api");
 
             engine.resources([
@@ -78,7 +78,7 @@ minio {
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("etcd", containerSet)
                 .with_port(9091, 9091, "api")
                 .with_port(19530, 19530, "api2");
 

--- a/trustgraph_configurator/templates/2.5/backends/minio.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/minio.jsonnet
@@ -35,7 +35,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("minio", containerSet)
                 .with_port(9000, 9000, "api")
                 .with_port(9001, 9001, "console");
 

--- a/trustgraph_configurator/templates/2.5/backends/neo4j.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/neo4j.jsonnet
@@ -32,7 +32,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("neo4j", containerSet)
                 .with_port(7474, 7474, "api")
                 .with_port(7687, 7687, "api2");
 

--- a/trustgraph_configurator/templates/2.5/backends/pinecone.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/pinecone.jsonnet
@@ -31,7 +31,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("pinecone", containerSet)
                 .with_port(5080, 5080, "api");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/backends/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/qdrant.jsonnet
@@ -52,7 +52,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("qdrant", containerSet)
                 .with_port(6333, 6333, "api")
                 .with_port(6334, 6334, "api2");
 

--- a/trustgraph_configurator/templates/2.5/core/api-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/api-gateway.jsonnet
@@ -11,6 +11,8 @@ local images = import "values/images.jsonnet";
         "api-gateway-cpu-reservation": "0.1",
         "api-gateway-memory-limit": "512M",
         "api-gateway-memory-reservation": "512M",
+        "api-gateway-replicas": 1,
+        "api-gateway-external": true,
     },
 
     "api-gateway" +: {
@@ -24,6 +26,8 @@ local images = import "values/images.jsonnet";
         local cpuReservation = pars["api-gateway-cpu-reservation"],
         local memoryLimit = pars["api-gateway-memory-limit"],
         local memoryReservation = pars["api-gateway-memory-reservation"],
+        local replicas = pars["api-gateway-replicas"],
+        local external = pars["api-gateway-external"],
 
         create:: function(engine)
 
@@ -46,17 +50,26 @@ local images = import "values/images.jsonnet";
 
             local containerSet = engine.containers(
                 "api-gateway", [ container ]
-            );
+            ).with_replicas(replicas);
 
-            local service =
-                engine.internalService(containerSet)
+            local svc =
+                if external then
+                    engine.service("api-gateway", containerSet)
+                else
+                    engine.internalService("api-gateway", containerSet);
+
+            local service = svc
                 .with_port(port, port, "api")
-                .with_port(8000, 8000, "metrics")
-                .with_external();
+                ;
+
+            local metrics =
+                engine.internalService("api-gateway-metrics", containerSet)
+                .with_port(8000, 8000, "metrics");
 
             engine.resources([
                 containerSet,
                 service,
+                metrics,
             ])
 
     },

--- a/trustgraph_configurator/templates/2.5/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/control.jsonnet
@@ -12,6 +12,7 @@ local cassandra = import "backends/cassandra.jsonnet";
         "control-cpu-reservation": "0.1",
         "control-memory-limit": "256M",
         "control-memory-reservation": "256M",
+        "control-replicas": 1,
     },
 
     "control" +: {
@@ -23,6 +24,7 @@ local cassandra = import "backends/cassandra.jsonnet";
         local cpuReservation = pars["control-cpu-reservation"],
         local memoryLimit = pars["control-memory-limit"],
         local memoryReservation = pars["control-memory-reservation"],
+        local replicas = pars["control-replicas"],
 
         create:: function(engine)
 
@@ -182,10 +184,10 @@ local cassandra = import "backends/cassandra.jsonnet";
 
             local containerSet = engine.containers(
                 "control", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("control", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/core/document-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/document-decoder.jsonnet
@@ -10,6 +10,7 @@ local images = import "values/images.jsonnet";
         "document-decoder-cpu-reservation": "0.1",
         "document-decoder-memory-limit": "512M",
         "document-decoder-memory-reservation": "512M",
+        "document-decoder-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -22,6 +23,7 @@ local images = import "values/images.jsonnet";
         local cpuReservation = pars["document-decoder-cpu-reservation"],
         local memoryLimit = pars["document-decoder-memory-limit"],
         local memoryReservation = pars["document-decoder-memory-reservation"],
+        local replicas = pars["document-decoder-replicas"],
 
         create:: function(engine)
 
@@ -39,10 +41,10 @@ local images = import "values/images.jsonnet";
 
             local containerSet = engine.containers(
                 "document-decoder", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("document-decoder", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/core/ingest.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/ingest.jsonnet
@@ -16,6 +16,7 @@ local url = import "values/url.jsonnet";
         "ingest-cpu-reservation": "0.1",
         "ingest-memory-limit": "256M",
         "ingest-memory-reservation": "256M",
+        "ingest-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -41,6 +42,7 @@ local url = import "values/url.jsonnet";
         local cpuReservation = pars["ingest-cpu-reservation"],
         local memoryLimit = pars["ingest-memory-limit"],
         local memoryReservation = pars["ingest-memory-reservation"],
+        local replicas = pars["ingest-replicas"],
 
         create:: function(engine)
 
@@ -113,10 +115,10 @@ local url = import "values/url.jsonnet";
 
             local containerSet = engine.containers(
                 "ingest", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("ingest", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/core/mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/mcp-server.jsonnet
@@ -12,6 +12,7 @@ local url = import "values/url.jsonnet";
         "mcp-server-cpu-reservation": "0.1",
         "mcp-server-memory-limit": "256M",
         "mcp-server-memory-reservation": "256M",
+        "mcp-server-replicas": 1,
     },
 
     "mcp-server" +: {
@@ -23,6 +24,7 @@ local url = import "values/url.jsonnet";
         local cpuReservation = pars["mcp-server-cpu-reservation"],
         local memoryLimit = pars["mcp-server-memory-limit"],
         local memoryReservation = pars["mcp-server-memory-reservation"],
+        local replicas = pars["mcp-server-replicas"],
 
         create:: function(engine)
 
@@ -40,10 +42,10 @@ local url = import "values/url.jsonnet";
 
             local containerSet = engine.containers(
                 "mcp-server", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("mcp-server", containerSet)
                 .with_port(port, port, "mcp");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/rag.jsonnet
@@ -20,6 +20,7 @@ local url = import "values/url.jsonnet";
         "rag-cpu-reservation": "0.1",
         "rag-memory-limit": "256M",
         "rag-memory-reservation": "256M",
+        "rag-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -41,6 +42,7 @@ local url = import "values/url.jsonnet";
         local cpuReservation = pars["rag-cpu-reservation"],
         local memoryLimit = pars["rag-memory-limit"],
         local memoryReservation = pars["rag-memory-reservation"],
+        local replicas = pars["rag-replicas"],
 
         local retrieval = "trustgraph.retrieval",
         local agentOrchestrator = "trustgraph.agent.orchestrator.Processor",
@@ -144,10 +146,10 @@ local url = import "values/url.jsonnet";
 
             local containerSet = engine.containers(
                 "rag", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("rag", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/core/rev-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/rev-gateway.jsonnet
@@ -54,7 +54,7 @@ local url = import "values/url.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("rev-gateway", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/embeddings/embeddings-fastembed.jsonnet
+++ b/trustgraph_configurator/templates/2.5/embeddings/embeddings-fastembed.jsonnet
@@ -89,7 +89,7 @@ local models = import "parameters/embeddings-fastembed.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/embeddings/embeddings-hf.jsonnet
+++ b/trustgraph_configurator/templates/2.5/embeddings/embeddings-hf.jsonnet
@@ -34,7 +34,7 @@ local models = import "parameters/embeddings-huggingface.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/embeddings/embeddings-ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.5/embeddings/embeddings-ollama.jsonnet
@@ -41,7 +41,7 @@ local models = import "parameters/embeddings-ollama.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
@@ -234,20 +234,18 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
     },
 
-    internalService:: self.service,
-
-    // service emits a sentinel marker rather than a free-standing ARM
-    // resource; ACA ingress is a property of the containerApp, not a
-    // separate resource. `package()` recognises the marker and folds
-    // it into the matching containerApp before output.
-    service:: function(containers)
+    // service/internalService emit sentinel markers rather than
+    // free-standing ARM resources; ACA ingress is a property of the
+    // containerApp, not a separate resource. `package()` recognises
+    // the marker and folds it into the matching containerApp before
+    // output.
+    internalService:: function(name, containers)
     {
 
         local service = self,
 
-        name: containers.name,
+        name: name,
         ports: [],
-        external: false,
 
         with_port::
             function(src, dest, name) self + {
@@ -256,7 +254,31 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
                 ],
             },
 
-        with_external:: function() self + { external: true },
+        add:: function()
+            if std.length(service.ports) == 0 then []
+            else [{
+                _aca_kind: "ingress",
+                targetApp: service.name,
+                ports: service.ports,
+                external: false,
+            }],
+
+    },
+
+    service:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        ports: [],
+
+        with_port::
+            function(src, dest, name) self + {
+                ports: super.ports + [
+                    { src: src, dest: dest, name: name }
+                ],
+            },
 
         add:: function()
             if std.length(service.ports) == 0 then []
@@ -264,7 +286,7 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
                 _aca_kind: "ingress",
                 targetApp: service.name,
                 ports: service.ports,
-                external: service.external,
+                external: true,
             }],
 
     },
@@ -359,6 +381,8 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
         name: name,
         containers: containers,
+
+        with_replicas:: function(n) self,
 
         add:: function() std.flattenArrays(
             [ c.add() for c in cont.containers ]

--- a/trustgraph_configurator/templates/2.5/engine/compose.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/compose.jsonnet
@@ -108,14 +108,7 @@
                 },
 
         with_port::
-            function(src, dest, name)
-                self + {
-                    ports:
-                        if std.objectHas(container, "ports") then
-                            container.ports + [ "%d:%d" % [src, dest] ]
-                        else
-                            [ "%d:%d" % [src, dest] ]
-                },
+            function(src, dest, name) self,
 
         with_env_var_secrets::
             function(vars)
@@ -129,45 +122,71 @@
 
         restart: "on-failure:100",
 
-        add:: function() {
+        add:: function(replicas=1) {
             services +: {
-                [container.name]: container,
+                [container.name]: container + (
+                    if replicas > 1 then
+                        { scale: replicas }
+                    else {}
+                ),
             }
         }
 
     },
 
-    internalService:: function(containers)
+    internalService:: function(name, containers)
     {
 
         local service = self,
 
-        name: containers.name,
+        name: name,
+        ports: [],
 
         with_port:: function(src, dest, name)
-            self + { port: [src, dest] },
+            self + {
+                ports: super.ports + [dest],
+            },
 
-        with_external:: function() self,
-
-        add:: function() {
-        }
+        add:: function()
+            if std.length(service.ports) == 0 then {}
+            else {
+                services +: {
+                    [containers.name] +: {
+                        expose: [
+                            "%d" % [port]
+                            for port in service.ports
+                        ],
+                    },
+                },
+            },
 
     },
 
-    service:: function(containers)
+    service:: function(name, containers)
     {
 
         local service = self,
 
-        name: containers.name,
+        name: name,
+        ports: [],
 
         with_port:: function(src, dest, name)
-            self + { port: [src, dest] },
+            self + {
+                ports: super.ports + [{ src: src, dest: dest }],
+            },
 
-        with_external:: function() self,
-
-        add:: function() {
-        }
+        add:: function()
+            if std.length(service.ports) == 0 then {}
+            else {
+                services +: {
+                    [containers.name] +: {
+                        ports: [
+                            "%d:%d" % [port.src, port.dest]
+                            for port in service.ports
+                        ],
+                    },
+                },
+            },
 
     },
 
@@ -250,9 +269,12 @@
 
         name: name,
         containers: containers,
+        replicas: 1,
+
+        with_replicas:: function(n) self + { replicas: n },
 
         add:: function() std.foldl(
-            function(state, c) state + c.add(),
+            function(state, c) state + c.add(cont.replicas),
             cont.containers,
             {}
         ),

--- a/trustgraph_configurator/templates/2.5/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/k8s.jsonnet
@@ -90,7 +90,7 @@
                     self
                 ),
 
-        add:: function() [
+        add:: function(replicas=1) [
 
                 {
                     apiVersion: "apps/v1",
@@ -103,7 +103,7 @@
                         }
                     },
                     spec: {
-                        replicas: 1,
+                        replicas: replicas,
                         selector: {
                             matchLabels: {
                                 app: container.name,
@@ -221,15 +221,13 @@
 
     },
 
-    // Just an alias
-    internalService:: self.service,
-
-    service:: function(containers)
+    internalService:: function(name, containers)
     {
 
         local service = self,
 
-        name: containers.name,
+        name: name,
+        appName: containers.name,
 
         ports: [],
 
@@ -240,8 +238,6 @@
                         { src: src, dest: dest, name: name  }
                     ]
                 },
-
-        with_external:: function() self,
 
         add:: function() [
 
@@ -255,7 +251,7 @@
                     },
                     spec: {
                         selector: {
-                            app: service.name,
+                            app: service.appName,
                         },
                         ports: [
                             {
@@ -270,6 +266,8 @@
             ],
 
     },
+
+    service:: self.internalService,
 
     volume:: function(name)
     {
@@ -390,9 +388,12 @@
 
         name: name,
         containers: containers,
+        replicas: 1,
+
+        with_replicas:: function(n) self + { replicas: n },
 
         add:: function() std.flattenArrays(
-            [ c.add() for c in cont.containers ]
+            [ c.add(cont.replicas) for c in cont.containers ]
         ),
 
     },

--- a/trustgraph_configurator/templates/2.5/engine/minikube-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/minikube-k8s.jsonnet
@@ -73,10 +73,11 @@ k8s + {
 
     },
 
-    service:: function(containers)
+    service:: function(name, containers)
     {
         local service = self,
-        name: containers.name,
+        name: name,
+        appName: containers.name,
         ports: [],
         with_port::
             function(src, dest, name)
@@ -85,7 +86,6 @@ k8s + {
                         { src: src, dest: dest, name: name  }
                     ]
                 },
-        with_external:: function() self,
         add:: function() [
             {
                 apiVersion: "v1",
@@ -96,7 +96,7 @@ k8s + {
                 },
                 spec: {
                     selector: {
-                        app: service.name,
+                        app: service.appName,
                     },
                     type: "LoadBalancer",
                     ports: [

--- a/trustgraph_configurator/templates/2.5/engine/noop.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/noop.jsonnet
@@ -40,15 +40,13 @@
         add:: function() {},
     },
 
-    internalService:: function(containers) {
+    internalService:: function(name, containers) {
         with_port:: function(src, dest, name) self + {},
-        with_external:: function() self + {},
         add:: function() {},
     },
 
-    service:: function(containers) {
+    service:: function(name, containers) {
         with_port:: function(src, dest, name) self + {},
-        with_external:: function() self + {},
         add:: function() {},
     },
 
@@ -71,6 +69,7 @@
     },
 
     containers:: function(name, containers) {
+        with_replicas:: function(n) self,
         add:: function() {},
     },
 

--- a/trustgraph_configurator/templates/2.5/llm/azure-openai.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/azure-openai.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/azure-openai.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/azure-openai.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -93,10 +95,10 @@ local models = import "parameters/azure-openai.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/azure.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/azure.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/azure.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/azure.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -92,10 +94,10 @@ local models = import "parameters/azure.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/bedrock.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/bedrock.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/bedrock.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -93,10 +95,10 @@ local models = import "parameters/bedrock.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/claude.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/claude.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/claude.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/claude.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -91,10 +93,10 @@ local models = import "parameters/claude.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/cohere.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/cohere.jsonnet
@@ -20,6 +20,7 @@ local models = import "parameters/cohere.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -33,6 +34,7 @@ local models = import "parameters/cohere.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -88,10 +90,10 @@ local models = import "parameters/cohere.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/googleaistudio.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/googleaistudio.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/googleaistudio.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/googleaistudio.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -91,10 +93,10 @@ local models = import "parameters/googleaistudio.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/llamafile.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/llamafile.jsonnet
@@ -19,6 +19,7 @@ local models = import "parameters/llamafile.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -32,6 +33,7 @@ local models = import "parameters/llamafile.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -85,10 +87,10 @@ local models = import "parameters/llamafile.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/lmstudio.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/lmstudio.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/lmstudio.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/lmstudio.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -91,10 +93,10 @@ local models = import "parameters/lmstudio.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/mistral.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/mistral.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/mistral.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/mistral.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -91,10 +93,10 @@ local models = import "parameters/mistral.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/ollama.jsonnet
@@ -19,6 +19,7 @@ local models = import "parameters/ollama.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -32,6 +33,7 @@ local models = import "parameters/ollama.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -85,10 +87,10 @@ local models = import "parameters/ollama.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/openai.jsonnet
@@ -21,6 +21,7 @@ local models = import "parameters/openai.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -34,6 +35,7 @@ local models = import "parameters/openai.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -92,10 +94,10 @@ local models = import "parameters/openai.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/tgi.jsonnet
@@ -17,6 +17,7 @@ local prompts = import "prompts/mixtral.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -30,6 +31,7 @@ local prompts = import "prompts/mixtral.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -87,10 +89,10 @@ local prompts = import "prompts/mixtral.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/vertexai.jsonnet
@@ -23,6 +23,7 @@ local models = import "parameters/vertexai.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "256M",
         "text-completion-memory-reservation": "256M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -36,6 +37,7 @@ local models = import "parameters/vertexai.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -102,10 +104,10 @@ local models = import "parameters/vertexai.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/llm/vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.5/llm/vllm.jsonnet
@@ -22,6 +22,7 @@ local models = import "parameters/vllm.jsonnet";
         "text-completion-cpu-reservation": "0.1",
         "text-completion-memory-limit": "128M",
         "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
         "text-completion-concurrency": 1,
         "text-completion-rag-concurrency": 1,
     },
@@ -35,6 +36,7 @@ local models = import "parameters/vllm.jsonnet";
         local cpuReservation = pars["text-completion-cpu-reservation"],
         local memoryLimit = pars["text-completion-memory-limit"],
         local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
         local textCompletionConc = pars["text-completion-concurrency"],
         local textCompletionRagConc = pars["text-completion-rag-concurrency"],
 
@@ -92,10 +94,10 @@ local models = import "parameters/vllm.jsonnet";
 
             local containerSet = engine.containers(
                 "text-completion", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("text-completion", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/mcp/ddg-mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.5/mcp/ddg-mcp-server.jsonnet
@@ -23,7 +23,7 @@ local url = import "values/url.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("ddg-mcp-server", containerSet)
                 .with_port(port, port, "mcp");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/cpu-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/cpu-tgi.jsonnet
@@ -53,7 +53,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("tgi-service", containerSet)
                 .with_port(7000, 7000, "tgi");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/intel-battlemage-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/intel-battlemage-vllm.jsonnet
@@ -84,7 +84,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("vllm-service", containerSet)
                 .with_port(7000, 7000, "vllm");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/intel-gaudi-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/intel-gaudi-tgi.jsonnet
@@ -81,7 +81,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("tgi-service", containerSet)
                 .with_port(7000, 7000, "tgi");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/intel-gaudi-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/intel-gaudi-vllm.jsonnet
@@ -62,7 +62,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("vllm-service", containerSet)
                 .with_port(7000, 7000, "vllm");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/intel-xpu-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/intel-xpu-tgi.jsonnet
@@ -60,7 +60,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("tgi-service", containerSet)
                 .with_port(7000, 7000, "tgi");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/intel-xpu-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/intel-xpu-vllm.jsonnet
@@ -83,7 +83,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("vllm-service", containerSet)
                 .with_port(7000, 7000, "vllm");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/model-hosting/nvidia-gpu-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.5/model-hosting/nvidia-gpu-vllm.jsonnet
@@ -58,7 +58,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("vllm-service", containerSet)
                 .with_port(7000, 7000, "vllm");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.5/monitoring/grafana.jsonnet
@@ -36,7 +36,7 @@ local loki = import "loki.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("prometheus", containerSet)
                 .with_port(9090, 9090, "http");
 
             engine.resources([
@@ -123,9 +123,9 @@ local loki = import "loki.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.service("grafana", containerSet)
                 .with_port(3000, 3000, "http")
-                .with_external();
+                ;
 
             engine.resources([
                 vol,

--- a/trustgraph_configurator/templates/2.5/monitoring/loki.jsonnet
+++ b/trustgraph_configurator/templates/2.5/monitoring/loki.jsonnet
@@ -20,8 +20,8 @@ local images = import "values/images.jsonnet";
                     .with_image(images.loki)
                     .with_user(10001)
                     .with_group(10001)
-                    .with_limits("0.5", "256M")
-                    .with_reservations("0.1", "256M")
+                    .with_limits("1.0", "350M")
+                    .with_reservations("0.5", "350M")
                     .with_port(3100, 3100, "http")
                     .with_volume_mount(cfgVol, "/etc/loki/")
                     .with_volume_mount(vol, "/loki");
@@ -31,7 +31,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("loki", containerSet)
                 .with_port(3100, 3100, "http");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/ocr/mistral-ocr.jsonnet
+++ b/trustgraph_configurator/templates/2.5/ocr/mistral-ocr.jsonnet
@@ -35,7 +35,7 @@ local url = import "values/url.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("mistral-ocr", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/ocr/ocr.jsonnet
+++ b/trustgraph_configurator/templates/2.5/ocr/ocr.jsonnet
@@ -22,7 +22,7 @@ local url = import "values/url.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("pdf-ocr", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/pubsub/kafka.jsonnet
+++ b/trustgraph_configurator/templates/2.5/pubsub/kafka.jsonnet
@@ -85,7 +85,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("kafka", containerSet)
                 .with_port(9092, 9092, "kafka");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/pubsub/pulsar-manager.jsonnet
+++ b/trustgraph_configurator/templates/2.5/pubsub/pulsar-manager.jsonnet
@@ -25,7 +25,7 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.service(containerSet)
+                engine.internalService("pulsar", containerSet)
                 .with_port(9527, 9527, "api")
                 .with_port(7750, 7750, "api2);
 

--- a/trustgraph_configurator/templates/2.5/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.5/pubsub/pulsar.jsonnet
@@ -218,19 +218,19 @@ local url = import "values/url.jsonnet";
 
             // Zookeeper service
             local zkService =
-                engine.service(zkContainerSet)
+                engine.internalService("zookeeper", zkContainerSet)
                 .with_port(2181, 2181, "zookeeper")
                 .with_port(2888, 2888, "zookeeper2")
                 .with_port(3888, 3888, "zookeeper3");
 
             // Bookkeeper service
             local bookieService =
-                engine.service(bookieContainerSet)
+                engine.internalService("bookie", bookieContainerSet)
                 .with_port(3181, 3181, "bookie");
 
             // Pulsar broker service
             local brokerService =
-                engine.service(brokerContainerSet)
+                engine.internalService("pulsar", brokerContainerSet)
                 .with_port(6650, 6650, "pulsar")
                 .with_port(8080, 8080, "admin");
 

--- a/trustgraph_configurator/templates/2.5/pubsub/rabbitmq.jsonnet
+++ b/trustgraph_configurator/templates/2.5/pubsub/rabbitmq.jsonnet
@@ -73,7 +73,7 @@ local url = import "values/url.jsonnet";
 
             // RabbitMQ service
             local service =
-                engine.service(containerSet)
+                engine.internalService("rabbitmq", containerSet)
                 .with_port(5672, 5672, "amqp")
                 .with_port(15672, 15672, "management");
 

--- a/trustgraph_configurator/templates/2.5/renderers/config-to-additionals.jsonnet
+++ b/trustgraph_configurator/templates/2.5/renderers/config-to-additionals.jsonnet
@@ -76,16 +76,16 @@ local engine = {
         with_env_var:: function(name, key) self,
     },
 
-    containers:: function(name, containers) self,
-
-    service:: function(containers) {
-        with_port:: function(src, dest, name) self,
-        with_external:: function() self,
+    containers:: function(name, containers) {
+        with_replicas:: function(n) self,
     },
 
-    internalService:: function(containers) {
+    internalService:: function(name, containers) {
         with_port:: function(src, dest, name) self,
-        with_external:: function() self,
+    },
+
+    service:: function(name, containers) {
+        with_port:: function(src, dest, name) self,
     },
 
     resources:: function(res)

--- a/trustgraph_configurator/templates/2.5/renderers/config-to-docker-compose.jsonnet
+++ b/trustgraph_configurator/templates/2.5/renderers/config-to-docker-compose.jsonnet
@@ -9,7 +9,7 @@
 // owning component has been merged elsewhere) and you want the build to
 // fail rather than silently produce an incomplete deployment.
 
-local engine = import "../engine/docker-compose.jsonnet";
+local engine = import "../engine/compose.jsonnet";
 local decode = import "decode-config.jsonnet";
 local components = import "../components.jsonnet";
 

--- a/trustgraph_configurator/templates/2.5/renderers/config-to-podman-compose.jsonnet
+++ b/trustgraph_configurator/templates/2.5/renderers/config-to-podman-compose.jsonnet
@@ -2,7 +2,7 @@
 // — podman-compose consumes the same spec shape, so we import the same
 // engine and run the same foldl over `patterns`.
 
-local engine = import "../engine/docker-compose.jsonnet";
+local engine = import "../engine/compose.jsonnet";
 local decode = import "decode-config.jsonnet";
 local components = import "../components.jsonnet";
 

--- a/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
@@ -10,6 +10,7 @@ cassandra + {
         "rows-cpu-reservation": "0.1",
         "rows-memory-limit": "512M",
         "rows-memory-reservation": "512M",
+        "rows-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -22,6 +23,7 @@ cassandra + {
         local cpuReservation = pars["rows-cpu-reservation"],
         local memoryLimit = pars["rows-memory-limit"],
         local memoryReservation = pars["rows-memory-reservation"],
+        local replicas = pars["rows-replicas"],
 
         create:: function(engine)
 
@@ -65,10 +67,10 @@ cassandra + {
 
             local containerSet = engine.containers(
                 "rows", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("rows", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
@@ -10,6 +10,7 @@ cassandra + {
         "triples-cpu-reservation": "0.1",
         "triples-memory-limit": "512M",
         "triples-memory-reservation": "512M",
+        "triples-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -22,6 +23,7 @@ cassandra + {
         local cpuReservation = pars["triples-cpu-reservation"],
         local memoryLimit = pars["triples-memory-limit"],
         local memoryReservation = pars["triples-memory-reservation"],
+        local replicas = pars["triples-replicas"],
 
         create:: function(engine)
 
@@ -65,10 +67,10 @@ cassandra + {
 
             local containerSet = engine.containers(
                 "triples", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/falkordb.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/falkordb.jsonnet
@@ -31,7 +31,7 @@ falkordb + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -64,7 +64,7 @@ falkordb + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/memgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/memgraph.jsonnet
@@ -34,7 +34,7 @@ memgraph + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -69,7 +69,7 @@ memgraph + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/neo4j.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/neo4j.jsonnet
@@ -31,7 +31,7 @@ neo4j + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -64,7 +64,7 @@ neo4j + {
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/ui/trustgraph-ui.jsonnet
+++ b/trustgraph_configurator/templates/2.5/ui/trustgraph-ui.jsonnet
@@ -18,9 +18,9 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.service("trustgraph-ui", containerSet)
                 .with_port(8888, 8888, "ui")
-                .with_external();
+                ;
 
             engine.resources([
                 containerSet,

--- a/trustgraph_configurator/templates/2.5/ui/workbench-ui.jsonnet
+++ b/trustgraph_configurator/templates/2.5/ui/workbench-ui.jsonnet
@@ -18,9 +18,9 @@ local images = import "values/images.jsonnet";
             );
 
             local service =
-                engine.internalService(containerSet)
+                engine.service("workbench-ui", containerSet)
                 .with_port(8888, 8888, "ui")
-                .with_external();
+                ;
 
             engine.resources([
                 containerSet,

--- a/trustgraph_configurator/templates/2.5/vector-store/milvus.jsonnet
+++ b/trustgraph_configurator/templates/2.5/vector-store/milvus.jsonnet
@@ -5,7 +5,15 @@ local milvus = import "backends/milvus.jsonnet";
 
 milvus + {
 
+    parameters +:: {
+        "store-graph-embeddings-replicas": 1,
+        "query-graph-embeddings-replicas": 1,
+        "store-doc-embeddings-replicas": 1,
+        "query-doc-embeddings-replicas": 1,
+    },
+
     local logLevel = $.parameters["log-level"],
+    local pars = $.parameters,
 
     "store-graph-embeddings" +: {
     
@@ -27,10 +35,10 @@ milvus + {
 
             local containerSet = engine.containers(
                 "store-graph-embeddings", [ container ]
-            );
+            ).with_replicas(pars["store-graph-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -60,10 +68,10 @@ milvus + {
 
             local containerSet = engine.containers(
                 "query-graph-embeddings", [ container ]
-            );
+            ).with_replicas(pars["query-graph-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -93,10 +101,10 @@ milvus + {
 
             local containerSet = engine.containers(
                 "store-doc-embeddings", [ container ]
-            );
+            ).with_replicas(pars["store-doc-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -126,10 +134,10 @@ milvus + {
 
             local containerSet = engine.containers(
                 "query-doc-embeddings", [ container ]
-            );
+            ).with_replicas(pars["query-doc-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/vector-store/pinecone.jsonnet
+++ b/trustgraph_configurator/templates/2.5/vector-store/pinecone.jsonnet
@@ -4,7 +4,15 @@ local cassandra_hosts = "cassandra";
 
 {
 
+    parameters +:: {
+        "store-graph-embeddings-replicas": 1,
+        "query-graph-embeddings-replicas": 1,
+        "store-doc-embeddings-replicas": 1,
+        "query-doc-embeddings-replicas": 1,
+    },
+
     local logLevel = $.parameters["log-level"],
+    local pars = $.parameters,
 
     "pinecone-cloud":: "aws",
     "pinecone-region":: "us-east-1",
@@ -31,10 +39,10 @@ local cassandra_hosts = "cassandra";
 
             local containerSet = engine.containers(
                 "store-graph-embeddings", [ container ]
-            );
+            ).with_replicas(pars["store-graph-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -67,10 +75,10 @@ local cassandra_hosts = "cassandra";
 
             local containerSet = engine.containers(
                 "query-graph-embeddings", [ container ]
-            );
+            ).with_replicas(pars["query-graph-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -103,10 +111,10 @@ local cassandra_hosts = "cassandra";
 
             local containerSet = engine.containers(
                 "store-doc-embeddings", [ container ]
-            );
+            ).with_replicas(pars["store-doc-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
@@ -139,10 +147,10 @@ local cassandra_hosts = "cassandra";
 
             local containerSet = engine.containers(
                 "query-doc-embeddings", [ container ]
-            );
+            ).with_replicas(pars["query-doc-embeddings-replicas"]);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("store-graph-embeddings", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/vector-store/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.5/vector-store/qdrant.jsonnet
@@ -9,6 +9,7 @@ qdrant + {
         "vector-store-cpu-reservation": "0.1",
         "vector-store-memory-limit": "256M",
         "vector-store-memory-reservation": "256M",
+        "vector-store-replicas": 1,
     },
 
     local logLevel = $.parameters["log-level"],
@@ -21,6 +22,7 @@ qdrant + {
         local cpuReservation = pars["vector-store-cpu-reservation"],
         local memoryLimit = pars["vector-store-memory-limit"],
         local memoryReservation = pars["vector-store-memory-reservation"],
+        local replicas = pars["vector-store-replicas"],
 
         create:: function(engine)
 
@@ -92,10 +94,10 @@ qdrant + {
 
             local containerSet = engine.containers(
                 "vector-store", [ container ]
-            );
+            ).with_replicas(replicas);
 
             local service =
-                engine.internalService(containerSet)
+                engine.internalService("vector-store", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([


### PR DESCRIPTION
Rework the 2.5 engine service abstraction and add replica/scaling support across components.

Service abstraction:
- service:: now takes an explicit (name, containers) instead of deriving the name; callers updated to pass explicit names.
- Reinstate the internal/external boundary: internalService:: for cluster-only reachability, service:: for host/external. Drop the with_external() flag entirely.
- Compose: internalService emits expose:, service emits ports:; container with_port is a no-op (ports live on the service layer).
- k8s: selectors use appName (container name) so they stay correct when the service name differs; service:: aliases internalService (Ingress can be added later). minikube overrides to LoadBalancer.
- ACA: internalService = external:false, service = external:true.
- Fix pre-existing bug: grafana's service was named "prometheus".
- Split api-gateway into external "api-gateway" and internal "api-gateway-metrics"; repoint prometheus scrape accordingly.

Scaling:
- containers:: stores a replicas field; with_replicas:: sets it.
- k8s uses replicas in the Deployment spec; compose emits scale:.
- Add <name>-replicas parameters to core, storage, LLM (text-completion) and api-gateway components.
- api-gateway-external parameter to flip the gateway internal for scale testing without host port conflicts.

Also: rename docker-compose.jsonnet to compose.jsonnet and fix renderer imports; bump Loki resources.