### PR TITLE
Decouple the librarian's object store from Garage

### DIFF
--- a/trustgraph_configurator/templates/2.5/backends/garage-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/garage-cluster.jsonnet
@@ -1,4 +1,5 @@
 local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
 
 // Distributed (multi-node) Garage: a primary node plus N peers forming an
 // S3-compatible cluster with real data replication.
@@ -23,6 +24,18 @@ local images = import "values/images.jsonnet";
 // (3 nodes, factor 3) is balanced; adjust both together.
 
 {
+
+    // Point the librarian's object store at this cluster (control's
+    // object-store-params hook). Reads $.garage so it tracks cred overrides.
+    // Set here too - not just in garage.jsonnet - so importing garage-cluster
+    // on its own is a complete object-store path. Idempotent when both are
+    // imported: the value is identical.
+    "object-store-params" +:: {
+        object_store_endpoint: url.object_store,
+        object_store_access_key: $.garage["access-key"],
+        object_store_secret_key: $.garage["secret-key"],
+        object_store_region: $.garage.region,
+    },
 
     garage +: {
 

--- a/trustgraph_configurator/templates/2.5/backends/garage.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/garage.jsonnet
@@ -1,6 +1,17 @@
 local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
 
 {
+
+    // Point the librarian's object store at this Garage deployment by writing
+    // creds into its launch.yaml (control's object-store-params hook). Reads
+    // from $.garage so it tracks credential overrides (incl. garage-cluster).
+    "object-store-params" +:: {
+        object_store_endpoint: url.object_store,
+        object_store_access_key: $.garage["access-key"],
+        object_store_secret_key: $.garage["secret-key"],
+        object_store_region: $.garage.region,
+    },
 
     garage +: {
 

--- a/trustgraph_configurator/templates/2.5/backends/object-store-s3.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/object-store-s3.jsonnet
@@ -1,0 +1,30 @@
+// External S3-compatible object store (AWS S3, Cloudflare R2, managed MinIO,
+// etc.). Deploys nothing - it only populates control's object-store-secrets
+// hook so the librarian reads every setting from env-var secrets supplied at
+// deploy time. It sets no object-store-params, so launch.yaml stays free of
+// object_store_* and the librarian falls through to its env-var path.
+//
+//   OBJECT_STORE_ENDPOINT    OBJECT_STORE_ACCESS_KEY
+//   OBJECT_STORE_SECRET_KEY  OBJECT_STORE_REGION    OBJECT_STORE_USE_SSL
+//
+// Fail-secure: nothing is baked into the rendered config. If the secret /
+// environment is not supplied at deploy, the librarian has no credentials and
+// denies access. Wire these via a K8s Secret named "object-store" (keys
+// endpoint / access-key / secret-key / region / use-ssl), compose env, or the
+// equivalent ACA secret refs.
+//
+// Mutually exclusive with garage / garage-cluster - import exactly one object
+// store backend.
+
+// The map is ENV_VAR -> secret-key; control builds the env-var secrets from
+// it (Secret named "object-store" with these keys).
+
+{
+    "object-store-secrets" +:: {
+        OBJECT_STORE_ENDPOINT: "endpoint",
+        OBJECT_STORE_ACCESS_KEY: "access-key",
+        OBJECT_STORE_SECRET_KEY: "secret-key",
+        OBJECT_STORE_REGION: "region",
+        OBJECT_STORE_USE_SSL: "use-ssl",
+    },
+}

--- a/trustgraph_configurator/templates/2.5/components.jsonnet
+++ b/trustgraph_configurator/templates/2.5/components.jsonnet
@@ -37,6 +37,17 @@
    "vector-store-qdrant": import "vector-store/qdrant.jsonnet",
    "vector-store-pinecone": import "vector-store/pinecone.jsonnet",
 
+   // Object store (S3-compatible) for the librarian. Import exactly one of
+   // these to select how the librarian gets its object store.
+   "garage": import "backends/garage.jsonnet",
+
+   // Distributed Garage override (include AFTER garage)
+   "garage-cluster": import "backends/garage-cluster.jsonnet",
+
+   // External S3-compatible store (AWS S3, R2, managed MinIO, ...). Deploys
+   // nothing; wires the librarian to read creds from env-var secrets.
+   "object-store-s3": import "backends/object-store-s3.jsonnet",
+
    // Distributed Qdrant override (include AFTER vector-store-qdrant)
    "qdrant-cluster": import "backends/qdrant-cluster.jsonnet",
 
@@ -51,9 +62,6 @@
 
    // Distributed Cassandra override (include AFTER the cassandra store)
    "cassandra-cluster": import "backends/cassandra-cluster.jsonnet",
-
-   // Distributed Garage override (include AFTER the garage store)
-   "garage-cluster": import "backends/garage-cluster.jsonnet",
 
    // Observability support
    "grafana": import "monitoring/grafana.jsonnet",

--- a/trustgraph_configurator/templates/2.5/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/control.jsonnet
@@ -2,7 +2,6 @@
 
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
-local garage = import "backends/garage.jsonnet";
 local cassandra = import "backends/cassandra.jsonnet";
 
 {
@@ -14,6 +13,25 @@ local cassandra = import "backends/cassandra.jsonnet";
         "control-memory-reservation": "256M",
         "control-replicas": 1,
     },
+
+    // S3-compatible object store the librarian talks to. Fail-secure hooks,
+    // empty by default: no params and no secrets means the librarian gets no
+    // credentials and denies (fail-closed). An object-store backend component
+    // populates one. control does NOT know which backends exist or how they
+    // work - it just merges whatever was populated.
+    //
+    // Both use +:: (merge, not replace) so these empty defaults never clobber
+    // a backend's value regardless of component order in the config list.
+    //
+    //   object-store-params  - map merged into the librarian's launch.yaml
+    //                          params (an embedded store, e.g. garage, owns
+    //                          its creds).
+    //   object-store-secrets - map of ENV_VAR -> secret-key. control builds
+    //                          the deploy-time env-var secrets from it (an
+    //                          external store, e.g. object-store-s3). Empty
+    //                          means no env secrets.
+    "object-store-params" +:: {},
+    "object-store-secrets" +:: {},
 
     "control" +: {
 
@@ -31,13 +49,25 @@ local cassandra = import "backends/cassandra.jsonnet";
             local envSecrets = engine.envSecrets("iam-bootstrap-token")
                 .with_env_var("IAM_BOOTSTRAP_TOKEN", "token");
 
+            // Object-store wiring comes entirely from the hooks above. A
+            // backend populates one; if neither is set the librarian gets no
+            // credentials and denies (fail-closed). control stays agnostic.
+            // Build env secrets from the ENV_VAR -> key map; empty map (the
+            // default, or an embedded backend) means no env secrets.
+            local objectStoreEnv = $["object-store-secrets"];
+            local objectStoreSecrets =
+                if std.length(objectStoreEnv) > 0 then
+                    std.foldl(
+                        function(s, envVar)
+                            s.with_env_var(envVar, objectStoreEnv[envVar]),
+                        std.objectFields(objectStoreEnv),
+                        engine.envSecrets("object-store")
+                    )
+                else null;
+
             local librarianParams = {
                  id: "librarian",
-                 object_store_endpoint: url.object_store,
-                 object_store_access_key: $.garage["access-key"],
-                 object_store_secret_key: $.garage["secret-key"],
-                 object_store_region: $.garage.region,
-            } + $["pub-sub-params"];
+            } + $["object-store-params"] + $["pub-sub-params"];
 
             local init = "trustgraph.bootstrap.initialisers";
 
@@ -162,7 +192,7 @@ local cassandra = import "backends/cassandra.jsonnet";
 		}
             );
 
-            local container =
+            local baseContainer =
                 engine.container("control")
                     .with_image(images.trustgraph_flow)
                     .with_command([
@@ -182,6 +212,12 @@ local cassandra = import "backends/cassandra.jsonnet";
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
 
+            // Attach object-store env secrets only if a backend populated them.
+            local container =
+                if objectStoreSecrets != null then
+                    baseContainer.with_env_var_secrets(objectStoreSecrets)
+                else baseContainer;
+
             local containerSet = engine.containers(
                 "control", [ container ]
             ).with_replicas(replicas);
@@ -190,16 +226,20 @@ local cassandra = import "backends/cassandra.jsonnet";
                 engine.internalService("control", containerSet)
                 .with_port(8000, 8000, "metrics");
 
-            engine.resources([
-                envSecrets,
-                cfgVol,
-                templateVol,
-                containerSet,
-                service,
-            ])
+            engine.resources(
+                [
+                    envSecrets,
+                    cfgVol,
+                    templateVol,
+                    containerSet,
+                    service,
+                ]
+                + (if objectStoreSecrets != null then [ objectStoreSecrets ]
+                   else [])
+            )
 
     }
 
-// Garage and Cassandra are used by the Librarian
-} + garage + cassandra
+// Cassandra is used by the Librarian.
+} + cassandra
 


### PR DESCRIPTION
Make the librarian's S3-compatible object store swappable instead of hard-wired to an always-deployed Garage. control.jsonnet no longer references Garage; it exposes two empty, fail-secure hooks and merges whatever a backend component populated:

  object-store-params  - creds written into the librarian's launch.yaml
  object-store-secrets  - ENV_VAR -> key map; control builds deploy-time
                          env-var secrets from it

Backends select a path by populating one hook:
  garage / garage-cluster (embedded) - deploy Garage and write their own
    creds into launch.yaml
  object-store-s3 (external)          - deploy nothing; wire the librarian
    to read all settings from operator-supplied env-var secrets

Both hooks use +:: (merge) so the empty defaults never clobber a backend regardless of component order. With neither imported the librarian gets no credentials and denies access (fail-closed).