### PR TITLE
Make Cassandra swappable: self-hosted component + external path

### DIFF
--- a/trustgraph_configurator/templates/2.5/backends/cassandra-external.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra-external.jsonnet
@@ -1,0 +1,24 @@
+// External Cassandra (managed / secured cluster). Deploys nothing - it only
+// populates control's cassandra-secrets hook so every Cassandra consumer
+// (control, triples, rows) reads its connection settings from env-var secrets
+// supplied at deploy time, and omits the cassandra_host param so those env
+// vars take effect:
+//
+//   CASSANDRA_HOST     CASSANDRA_USERNAME
+//   CASSANDRA_PASSWORD CASSANDRA_REPLICATION_FACTOR
+//
+// Wire these via a K8s Secret named "cassandra" (keys host / username /
+// password / replication-factor), compose env, or the equivalent ACA secret
+// refs. replication-factor isn't secret but rides the same env bundle for
+// consistency.
+//
+// Mutually exclusive with cassandra-cluster - import one Cassandra backend.
+
+{
+    "cassandra-secrets" +:: {
+        CASSANDRA_HOST: "host",
+        CASSANDRA_USERNAME: "username",
+        CASSANDRA_PASSWORD: "password",
+        CASSANDRA_REPLICATION_FACTOR: "replication-factor",
+    },
+}

--- a/trustgraph_configurator/templates/2.5/backends/cassandra-store.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra-store.jsonnet
@@ -1,0 +1,64 @@
+local images = import "values/images.jsonnet";
+local cassandra = import "cassandra.jsonnet";
+
+// Self-hosted single-node Cassandra. List as the "cassandra" component to
+// deploy it; consumers then talk to host "cassandra" with no auth. Mutually
+// exclusive with cassandra-external (managed/secured cluster) - import one.
+// cassandra-cluster overrides this single node with a multi-node ring.
+
+cassandra + {
+
+    "cassandra" +: {
+
+        // Memory settings (can be overridden by memory-profile)
+        "memory-limit":: "1400M",
+        "memory-reservation":: "1400M",
+        "heap":: "700M",
+
+        create:: function(engine)
+
+            // External Cassandra also selected (creds via env secrets): deploy
+            // nothing, external wins. Consumers read CASSANDRA_HOST etc.
+            if std.length($["cassandra-secrets"]) > 0 then
+                engine.resources([])
+            else
+
+            // Capture memory settings into locals
+            local memLimit = self["memory-limit"];
+            local memReserv = self["memory-reservation"];
+            local heap = self["heap"];
+
+            local vol = engine.volume("cassandra").with_size("20G");
+
+            local container =
+                engine.container("cassandra")
+                    .with_image(images.cassandra)
+                    .with_user(999)
+                    .with_group(999)
+                    .with_environment({
+                        JVM_OPTS: "-Xms%s -Xmx%s -Dcassandra.skip_wait_for_gossip_to_settle=0" % [
+                            heap, heap,
+                        ],
+                    })
+                    .with_limits("1.0", memLimit)
+                    .with_reservations("0.5", memReserv)
+                    .with_port(9042, 9042, "cassandra")
+                    .with_volume_mount(vol, "/var/lib/cassandra");
+
+            local containerSet = engine.containers(
+                "cassandra", [ container ]
+            );
+
+            local service =
+                engine.internalService("cassandra", containerSet)
+                .with_port(9042, 9042, "api");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
@@ -1,52 +1,31 @@
-local images = import "values/images.jsonnet";
+// Cassandra connection hooks shared by every consumer (control, triples,
+// rows). This file deploys nothing - it only declares the wiring that
+// consumers read. The self-hosted deployment lives in the separately-listed
+// "cassandra" component (backends/cassandra-store.jsonnet); the managed path
+// in "cassandra-external". One of those must be in the config to back
+// Cassandra (config generation is owned upstream, so this isn't validated
+// here).
 
 {
 
-    "cassandra" +: {
+    // ENV_VAR -> secret-key map. Empty by default, which means the self-hosted
+    // store is in use: consumers talk to host "cassandra" with no auth. The
+    // cassandra-external backend populates this map; +:: so component order in
+    // the config list never clobbers it.
+    "cassandra-secrets" +:: {},
 
-        // Memory settings (can be overridden by memory-profile)
-        "memory-limit":: "1400M",
-        "memory-reservation":: "1400M",
-        "heap":: "700M",
-
-        create:: function(engine)
-
-            // Capture memory settings into locals
-            local memLimit = self["memory-limit"];
-            local memReserv = self["memory-reservation"];
-            local heap = self["heap"];
-
-            local vol = engine.volume("cassandra").with_size("20G");
-
-            local container =
-                engine.container("cassandra")
-                    .with_image(images.cassandra)
-                    .with_user(999)
-                    .with_group(999)
-                    .with_environment({
-                        JVM_OPTS: "-Xms%s -Xmx%s -Dcassandra.skip_wait_for_gossip_to_settle=0" % [
-                            heap, heap,
-                        ],
-                    })
-                    .with_limits("1.0", memLimit)
-                    .with_reservations("0.5", memReserv)
-                    .with_port(9042, 9042, "cassandra")
-                    .with_volume_mount(vol, "/var/lib/cassandra");
-
-            local containerSet = engine.containers(
-                "cassandra", [ container ]
-            );
-
-            local service =
-                engine.internalService("cassandra", containerSet)
-                .with_port(9042, 9042, "api");
-
-            engine.resources([
-                vol,
-                containerSet,
-                service,
-            ])
-
-    },
+    // Fixed helper (backends populate the map above, not this). Builds the
+    // engine env secrets from the map, or null when empty. Consumers
+    // (control / triples / rows) call this to attach the secrets to their
+    // container and to decide whether to omit the cassandra_host param.
+    "cassandra-env-secrets":: function(engine)
+        local m = $["cassandra-secrets"];
+        if std.length(m) > 0 then
+            std.foldl(
+                function(s, v) s.with_env_var(v, m[v]),
+                std.objectFields(m),
+                engine.envSecrets("cassandra")
+            )
+        else null,
 
 }

--- a/trustgraph_configurator/templates/2.5/components.jsonnet
+++ b/trustgraph_configurator/templates/2.5/components.jsonnet
@@ -60,8 +60,16 @@
    // Row stores
    "row-store-cassandra": import "row-store/cassandra.jsonnet",
 
+   // Self-hosted Cassandra (single node). List this to deploy it; consumers
+   // talk to host "cassandra". Mutually exclusive with cassandra-external.
+   "cassandra": import "backends/cassandra-store.jsonnet",
+
    // Distributed Cassandra override (include AFTER the cassandra store)
    "cassandra-cluster": import "backends/cassandra-cluster.jsonnet",
+
+   // External (managed/secured) Cassandra: deploys nothing, supplies
+   // connection via env secrets. Mutually exclusive with cassandra-cluster.
+   "cassandra-external": import "backends/cassandra-external.jsonnet",
 
    // Observability support
    "grafana": import "monitoring/grafana.jsonnet",

--- a/trustgraph_configurator/templates/2.5/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/control.jsonnet
@@ -65,6 +65,11 @@ local cassandra = import "backends/cassandra.jsonnet";
                     )
                 else null;
 
+            // External Cassandra (cassandra-external backend) supplies the
+            // librarian/iam/config/knowledge keyspaces' connection via env
+            // secrets; null when self-hosted (host "cassandra", no auth).
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+
             local librarianParams = {
                  id: "librarian",
             } + $["object-store-params"] + $["pub-sub-params"];
@@ -212,11 +217,17 @@ local cassandra = import "backends/cassandra.jsonnet";
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
 
-            // Attach object-store env secrets only if a backend populated them.
-            local container =
+            // Attach object-store and Cassandra env secrets only if a backend
+            // populated them.
+            local containerWithObjectStore =
                 if objectStoreSecrets != null then
                     baseContainer.with_env_var_secrets(objectStoreSecrets)
                 else baseContainer;
+
+            local container =
+                if cassandraSecrets != null then
+                    containerWithObjectStore.with_env_var_secrets(cassandraSecrets)
+                else containerWithObjectStore;
 
             local containerSet = engine.containers(
                 "control", [ container ]
@@ -235,6 +246,8 @@ local cassandra = import "backends/cassandra.jsonnet";
                     service,
                 ]
                 + (if objectStoreSecrets != null then [ objectStoreSecrets ]
+                   else [])
+                + (if cassandraSecrets != null then [ cassandraSecrets ]
                    else [])
             )
 

--- a/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
@@ -1,6 +1,5 @@
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
-local cassandra_hosts = "cassandra";
 local cassandra = import "backends/cassandra.jsonnet";
 
 cassandra + {
@@ -27,6 +26,13 @@ cassandra + {
 
         create:: function(engine)
 
+            // External Cassandra supplies host/creds via env secrets; in that
+            // case omit cassandra_host so the processor reads CASSANDRA_HOST.
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else { cassandra_host: "cassandra" };
+
             local cfgVol = engine.configVolume(
                 "rows-launch-cfg", "launch/rows",
 		{
@@ -36,22 +42,20 @@ cassandra + {
                                 class: "trustgraph.query.rows.cassandra.Processor",
                                 params: {
                                     id: "rows-query",
-                                    cassandra_host: cassandra_hosts,
-                                } + $["pub-sub-params"],
+                                } + cassandraParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.storage.rows.cassandra.Processor",
                                 params: {
                                     id: "rows-write",
-                                    cassandra_host: cassandra_hosts,
-                                } + $["pub-sub-params"],
+                                } + cassandraParams + $["pub-sub-params"],
                             },
                         ]
                     })
 		}
             );
 
-            local container =
+            local baseContainer =
                 engine.container("rows")
                     .with_image(images.trustgraph_flow)
                     .with_command([
@@ -65,6 +69,11 @@ cassandra + {
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
 
+            local container =
+                if cassandraSecrets != null then
+                    baseContainer.with_env_var_secrets(cassandraSecrets)
+                else baseContainer;
+
             local containerSet = engine.containers(
                 "rows", [ container ]
             ).with_replicas(replicas);
@@ -77,7 +86,7 @@ cassandra + {
                 cfgVol,
                 containerSet,
                 service,
-            ])
+            ] + (if cassandraSecrets != null then [ cassandraSecrets ] else []))
 
     },
 

--- a/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
@@ -1,6 +1,5 @@
 local images = import "values/images.jsonnet";
 local url = import "values/url.jsonnet";
-local cassandra_hosts = "cassandra";
 local cassandra = import "backends/cassandra.jsonnet";
 
 cassandra + {
@@ -27,6 +26,13 @@ cassandra + {
 
         create:: function(engine)
 
+            // External Cassandra supplies host/creds via env secrets; in that
+            // case omit cassandra_host so the processor reads CASSANDRA_HOST.
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else { cassandra_host: "cassandra" };
+
             local cfgVol = engine.configVolume(
                 "triples-launch-cfg", "launch/triples",
 		{
@@ -36,22 +42,20 @@ cassandra + {
                                 class: "trustgraph.query.triples.cassandra.Processor",
                                 params: {
                                     id: "triples-query",
-                                    cassandra_host: cassandra_hosts,
-                                } + $["pub-sub-params"],
+                                } + cassandraParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.storage.triples.cassandra.Processor",
                                 params: {
                                     id: "triples-write",
-                                    cassandra_host: cassandra_hosts,
-                                } + $["pub-sub-params"],
+                                } + cassandraParams + $["pub-sub-params"],
                             },
                         ]
                     })
 		}
             );
 
-            local container =
+            local baseContainer =
                 engine.container("triples")
                     .with_image(images.trustgraph_flow)
                     .with_command([
@@ -65,6 +69,11 @@ cassandra + {
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
 
+            local container =
+                if cassandraSecrets != null then
+                    baseContainer.with_env_var_secrets(cassandraSecrets)
+                else baseContainer;
+
             local containerSet = engine.containers(
                 "triples", [ container ]
             ).with_replicas(replicas);
@@ -77,7 +86,7 @@ cassandra + {
                 cfgVol,
                 containerSet,
                 service,
-            ])
+            ] + (if cassandraSecrets != null then [ cassandraSecrets ] else []))
 
     },
 


### PR DESCRIPTION
Split backends/cassandra.jsonnet into hooks-only (cassandra-secrets + cassandra-env-secrets, imported by control/triples/rows) and a standalone, explicitly-listed "cassandra" component (backends/cassandra-store.jsonnet) for the self-hosted single node. Add cassandra-external, which deploys nothing and wires every consumer to read CASSANDRA_HOST/USERNAME/PASSWORD/ REPLICATION_FACTOR from env secrets, omitting the cassandra_host param so those env vars take effect. Configs now select Cassandra by including either "cassandra" or "cassandra-external".