### PR TITLE
Add forced database + object-store dialog steps for >= 2.5

### DIFF
--- a/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
@@ -182,6 +182,45 @@ steps:
           icon: "cassandra"
           description: "NoSQL database with fast read/write performance at scale. Used for row storage in TrustGraph."
     transitions:
+      # Backing database + object store became explicit components in 2.5;
+      # older versions bundle them, so only offer these steps for >= 2.5.
+      - when: "version >= '2.5'"
+        next: database
+      - next: model-deployment
+
+  # ─────────────────────────────────────────────────────────────
+  # Database Deployment (>= 2.5 only)
+  # ─────────────────────────────────────────────────────────────
+  database:
+    title: "Which database to deploy?"
+    description: "Backing database for the librarian, config and knowledge stores. Required regardless of the chosen graph store."
+    state_key: database
+    input:
+      type: select
+      options:
+        - label: "Apache Cassandra"
+          value: "cassandra"
+          icon: "cassandra"
+          description: "NoSQL database deployed for the librarian, config and knowledge stores."
+          recommended: true
+    transitions:
+      - next: object-store
+
+  # ─────────────────────────────────────────────────────────────
+  # Object Store Deployment (>= 2.5 only)
+  # ─────────────────────────────────────────────────────────────
+  object-store:
+    title: "Which object store?"
+    description: "S3-compatible object storage used by the librarian"
+    state_key: object_store
+    input:
+      type: select
+      options:
+        - label: "Garage"
+          value: "garage"
+          description: "Lightweight, self-hosted S3-compatible object store. Low resource usage."
+          recommended: true
+    transitions:
       - next: model-deployment
 
   # ─────────────────────────────────────────────────────────────

--- a/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
+++ b/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
@@ -50,6 +50,20 @@
     $component("grafana")
   ];
 
+  /* ─────────────────────────────────────────────────────────────
+   * Backing services deployed for the librarian / config / knowledge
+   * stores: a database (Cassandra) and an object store (Garage). These
+   * are required regardless of the chosen graph/row store, so they are
+   * their own forced choices in the dialog. The flow only offers these
+   * steps for version >= 2.5 (older versions bundle them implicitly),
+   * so we just map whatever the dialog set - the version gating lives
+   * in the flow, not here.
+   * ───────────────────────────────────────────────────────────── */
+  $backend_components := $append(
+    database ? [ $component(database) ] : [],
+    object_store ? [ $component(object_store) ] : []
+  );
+
 
   /* ─────────────────────────────────────────────────────────────
    * Model Deployment Components
@@ -132,8 +146,11 @@
     $append(
       $append(
         $append(
-          $base_components,
-          $infrastructure
+          $append(
+            $base_components,
+            $infrastructure
+          ),
+          $backend_components
         ),
         $model_components
       ),


### PR DESCRIPTION
In 2.5 the librarian's backing Cassandra and Garage object store stopped riding in implicitly and became components that must be listed explicitly. These backends are required by the librarian/config/knowledge services regardless of the chosen graph/row store, so model them as their own forced single-option dialog steps rather than deriving them from the store selection.

The steps are reached only for version >= 2.5 (older versions still bundle the backends), gating purely via flow transitions. The output transform just maps the resulting state keys to components, matching the existing state-driven pattern - no version logic in the transform.