### PR TITLE
Wire replica overrides through the ACA engine

### DIFF
--- a/tests/features/test_aca_scaling.py
+++ b/tests/features/test_aca_scaling.py
@@ -1,0 +1,83 @@
+"""
+Regression tests for replica-count wiring in the ACA (Azure Container Apps)
+engine.
+
+The *-replicas override params are honoured by the compose/k8s engines, but
+the ACA engine used to ignore them: containerSet.with_replicas was a no-op
+and every containerApp hardcoded scale.minReplicas / maxReplicas to 1. These
+tests render the ARM template and assert the override now reaches each app's
+scale block (min and max pinned to the count, matching k8s fixed-replica
+semantics).
+
+Rendered at template 2.5 / platform "aca" directly - the shared helper's
+run_packager is pinned to 2.3 / docker-compose.
+"""
+
+import json
+
+import pytest
+
+from helpers import minimal_config
+from trustgraph_configurator.packager import Packager
+
+
+pytestmark = pytest.mark.features
+
+
+TEMPLATE = "2.5"
+VERSION = "2.5.10"
+
+
+def render_aca(config):
+    """Render a config list to the ACA ARM template (a dict)."""
+    pkg = Packager(
+        version=VERSION,
+        template=TEMPLATE,
+        platform="aca",
+        latest=False,
+        latest_stable=False,
+    )
+    config_str = json.dumps(config)
+    pkg.config = config_str
+    return pkg.generate_resources(config_str)
+
+
+def scale_by_app(arm):
+    """Map containerApp name -> its template.scale block."""
+    return {
+        r["name"]: r["properties"]["template"]["scale"]
+        for r in arm["resources"]
+        if r.get("type") == "Microsoft.App/containerApps"
+    }
+
+
+# (replica override param, containerApp name)
+CASES = [
+    ("control-replicas", "control"),
+    ("triples-replicas", "triples"),
+    ("rows-replicas", "rows"),
+]
+
+
+@pytest.mark.parametrize("param,app", CASES, ids=[c[1] for c in CASES])
+def test_default_replicas_is_one(param, app):
+    """Without an override, each app pins min/max replicas to 1."""
+    scales = scale_by_app(render_aca(minimal_config([])))
+    assert scales[app] == {"minReplicas": 1, "maxReplicas": 1}
+
+
+@pytest.mark.parametrize("param,app", CASES, ids=[c[1] for c in CASES])
+def test_replica_override_applies(param, app):
+    """An override flows through to the app's scale.min/maxReplicas."""
+    scales = scale_by_app(render_aca(minimal_config([], overrides={param: 3})))
+    assert scales[app] == {"minReplicas": 3, "maxReplicas": 3}
+
+
+def test_override_is_scoped_to_one_app():
+    """Overriding one app's replicas leaves the others at the default."""
+    scales = scale_by_app(
+        render_aca(minimal_config([], overrides={"control-replicas": 4}))
+    )
+    assert scales["control"] == {"minReplicas": 4, "maxReplicas": 4}
+    assert scales["triples"] == {"minReplicas": 1, "maxReplicas": 1}
+    assert scales["rows"] == {"minReplicas": 1, "maxReplicas": 1}

--- a/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
@@ -121,7 +121,7 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
             ],
         },
 
-        add:: function()
+        add:: function(replicas=1)
             local cpuRaw =
                 if std.objectHas(container, "cpuLimit") then container.cpuLimit
                 else if std.objectHas(container, "cpuReservation") then container.cpuReservation
@@ -220,8 +220,8 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
                             ),
                         ],
                         scale: {
-                            minReplicas: 1,
-                            maxReplicas: 1,
+                            minReplicas: replicas,
+                            maxReplicas: replicas,
                         },
                     } + (
                         if std.length(azureFileVolumes) > 0 then
@@ -381,11 +381,12 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
         name: name,
         containers: containers,
+        replicas: 1,
 
-        with_replicas:: function(n) self,
+        with_replicas:: function(n) self + { replicas: n },
 
         add:: function() std.flattenArrays(
-            [ c.add() for c in cont.containers ]
+            [ c.add(cont.replicas) for c in cont.containers ]
         ),
 
     },


### PR DESCRIPTION
The ACA engine ignored replica counts: containerSet.with_replicas was a no-op and each containerApp hardcoded minReplicas/maxReplicas to 1, so the *-replicas override params (honoured by the k8s/compose engines) had no effect on ACA output. Store the count on the containerSet and pass it down to each container's scale block, pinning min and max to it as k8s does for fixed replicas.