### PR TITLE
Floor ACK disks to 20GiB, accounting for decimal units

### DIFF
--- a/trustgraph_configurator/templates/2.5/engine/ack-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/ack-k8s.jsonnet
@@ -1,18 +1,21 @@
 
 local k8s = import "k8s.jsonnet";
 
-// Alibaba Cloud ACK cloud disks have a 20 GiB minimum size.
+// Alibaba Cloud ACK cloud disks have a 20 GiB minimum size. The CSI driver
+// measures the floor in binary GiB, so a decimal "20G" request (~18.6 GiB) is
+// rejected. parseGib converts every unit to GiB - decimal G/M via the 1000 vs
+// 1024 ratio - so floorSize lifts anything short of 20 GiB up to "20Gi".
 local minGib = 20;
 
 local parseGib = function(s)
     if std.endsWith(s, "Gi") then
         std.parseJson(std.substr(s, 0, std.length(s) - 2))
-    else if std.endsWith(s, "G") then
-        std.parseJson(std.substr(s, 0, std.length(s) - 1))
     else if std.endsWith(s, "Mi") then
         std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) * 1000000000 / 1073741824
     else if std.endsWith(s, "M") then
-        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) * 1000000 / 1073741824
     else 0;
 
 local floorSize = function(s)


### PR DESCRIPTION
parseGib was treating decimal G/M as binary Gi/Mi, so a "20G" request (~18.6 GiB) cleared the 20 GiB floor and was rejected by the cloud_essd provisioner. Convert decimal units properly so sub-minimum sizes round up to "20Gi".