### PR TITLE
Raise document-decoder memory to 1400M

### DIFF
--- a/trustgraph_configurator/templates/2.5/core/document-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/document-decoder.jsonnet
@@ -8,8 +8,8 @@ local images = import "values/images.jsonnet";
     parameters +:: {
         "document-decoder-cpu-limit": "0.5",
         "document-decoder-cpu-reservation": "0.1",
-        "document-decoder-memory-limit": "512M",
-        "document-decoder-memory-reservation": "512M",
+        "document-decoder-memory-limit": "1400M",
+        "document-decoder-memory-reservation": "1400M",
         "document-decoder-replicas": 1,
     },
 


### PR DESCRIPTION
512M was too tight for the decoder; bump the default limit and reservation.