### PR TITLE
Wire Cassandra and Qdrant replication factor through to store creators

### DIFF
--- a/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
@@ -25,6 +25,11 @@ local images = import "values/images.jsonnet";
 
 {
 
+    // Replication factor for keyspaces the consumers create. Defaults to the
+    // ring size (default 2 peers + seed = 3); keep <= node count if you change
+    // peers. Overrides the single-node default of 1 from cassandra.jsonnet.
+    "cassandra-replication-factor":: 3,
+
     "cassandra" +: {
 
         // Memory settings (can be overridden by memory-profile)

--- a/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra.jsonnet
@@ -28,4 +28,11 @@
             )
         else null,
 
+    // Replication factor used when a consumer CREATES a keyspace. 1 (single
+    // node) by default; cassandra-cluster raises it to match its ring size.
+    // Consumers fold this into the cassandra_replication_factor launch param in
+    // self-hosted mode, and omit it in external mode so the operator's
+    // CASSANDRA_REPLICATION_FACTOR env wins (precedence: param -> env -> 1).
+    "cassandra-replication-factor":: 1,
+
 }

--- a/trustgraph_configurator/templates/2.5/backends/qdrant-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/qdrant-cluster.jsonnet
@@ -9,13 +9,19 @@ local images = import "values/images.jsonnet";
 // untouched and keep addressing host "qdrant" on 6333 (url.qdrant), so
 // node 0 deliberately keeps the name "qdrant".
 //
-// Caveat: enabling cluster mode forms consensus but does NOT shard or
-// replicate data. The TrustGraph storage processor creates single-shard
-// collections (no shard_number/replication_factor knob), so for now all
-// data lives on node 0. This is a scaffold for developing a sharding /
-// replication strategy later.
+// Enabling cluster mode forms Raft consensus; the embedding-store WRITE
+// processors then create collections with the shard_number /
+// replication_factor below so data is sharded and replicated across the
+// ring. Both default to the ring size; keep replication_factor <= node
+// count if you change peers.
 
 {
+
+    // Collection geometry the write processors apply when creating
+    // collections. Ring size = default 2 peers + bootstrap = 3. Overrides
+    // the single-node defaults of 1 from qdrant.jsonnet.
+    "qdrant-replication-factor":: 3,
+    "qdrant-shard-number":: 3,
 
     "qdrant" +: {
 

--- a/trustgraph_configurator/templates/2.5/backends/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/qdrant.jsonnet
@@ -2,6 +2,13 @@ local images = import "values/images.jsonnet";
 
 {
 
+    // Collection geometry applied by the embedding-store WRITE processors when
+    // they create collections. Both default to 1 (single node); qdrant-cluster
+    // raises them to the ring size. The writers fold these into the
+    // qdrant_replication_factor / qdrant_shard_number launch params.
+    "qdrant-replication-factor":: 1,
+    "qdrant-shard-number":: 1,
+
     "qdrant" +: {
 
         // Memory settings (can be overridden by memory-profile)

--- a/trustgraph_configurator/templates/2.5/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.5/core/control.jsonnet
@@ -70,9 +70,20 @@ local cassandra = import "backends/cassandra.jsonnet";
             // secrets; null when self-hosted (host "cassandra", no auth).
             local cassandraSecrets = $["cassandra-env-secrets"](engine);
 
+            // Replication factor for the keyspaces control's processors create.
+            // Set in self-hosted mode; omitted in external mode so the
+            // CASSANDRA_REPLICATION_FACTOR env secret takes effect. control
+            // never sets cassandra_host (processor defaults to "cassandra").
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else {
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
+
             local librarianParams = {
                  id: "librarian",
-            } + $["object-store-params"] + $["pub-sub-params"];
+            } + $["object-store-params"] + $["pub-sub-params"] + cassandraParams;
 
             local init = "trustgraph.bootstrap.initialisers";
 
@@ -134,7 +145,7 @@ local cassandra = import "backends/cassandra.jsonnet";
                                 class: "trustgraph.config.service.Processor",
                                 params:  {
                                     id: "config-svc",
-                                } + $["pub-sub-params"],
+                                } + $["pub-sub-params"] + cassandraParams,
                             },
                             {
                                 class: "trustgraph.flow.service.Processor",
@@ -146,13 +157,13 @@ local cassandra = import "backends/cassandra.jsonnet";
                                 class: "trustgraph.cores.service.Processor",
                                 params: {
                                     id: "knowledge",
-                                } + $["pub-sub-params"],
+                                } + $["pub-sub-params"] + cassandraParams,
                             },
                             {
                                 class: "trustgraph.storage.knowledge.store.Processor",
                                 params: {
                                     id: "kg-store",
-                                } + $["pub-sub-params"],
+                                } + $["pub-sub-params"] + cassandraParams,
                             },
                             {
                                 class: "trustgraph.metering.Processor",
@@ -173,7 +184,7 @@ local cassandra = import "backends/cassandra.jsonnet";
                                     bootstrap_mode: "token",
                                     // Bootstrap token is set by
                                     // IAM_BOOTSTRAP_TOKEN
-                                } + $["pub-sub-params"],
+                                } + $["pub-sub-params"] + cassandraParams,
                             },
                             {
                                 class: "trustgraph.bootstrap.bootstrapper.Processor",

--- a/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/row-store/cassandra.jsonnet
@@ -27,11 +27,16 @@ cassandra + {
         create:: function(engine)
 
             // External Cassandra supplies host/creds via env secrets; in that
-            // case omit cassandra_host so the processor reads CASSANDRA_HOST.
+            // case omit cassandra_host (and replication factor) so the processor
+            // reads CASSANDRA_HOST / CASSANDRA_REPLICATION_FACTOR from env.
             local cassandraSecrets = $["cassandra-env-secrets"](engine);
             local cassandraParams =
                 if cassandraSecrets != null then {}
-                else { cassandra_host: "cassandra" };
+                else {
+                    cassandra_host: "cassandra",
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
 
             local cfgVol = engine.configVolume(
                 "rows-launch-cfg", "launch/rows",

--- a/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/cassandra.jsonnet
@@ -27,11 +27,16 @@ cassandra + {
         create:: function(engine)
 
             // External Cassandra supplies host/creds via env secrets; in that
-            // case omit cassandra_host so the processor reads CASSANDRA_HOST.
+            // case omit cassandra_host (and replication factor) so the processor
+            // reads CASSANDRA_HOST / CASSANDRA_REPLICATION_FACTOR from env.
             local cassandraSecrets = $["cassandra-env-secrets"](engine);
             local cassandraParams =
                 if cassandraSecrets != null then {}
-                else { cassandra_host: "cassandra" };
+                else {
+                    cassandra_host: "cassandra",
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
 
             local cfgVol = engine.configVolume(
                 "triples-launch-cfg", "launch/triples",

--- a/trustgraph_configurator/templates/2.5/vector-store/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.5/vector-store/qdrant.jsonnet
@@ -26,6 +26,15 @@ qdrant + {
 
         create:: function(engine)
 
+            // Collection geometry applied only by the WRITE processors when
+            // they create collections. 1/1 single-node by default;
+            // qdrant-cluster raises both to the ring size. Query processors
+            // don't create collections, so they don't take these.
+            local collectionParams = {
+                qdrant_replication_factor: $["qdrant-replication-factor"],
+                qdrant_shard_number: $["qdrant-shard-number"],
+            };
+
             local cfgVol = engine.configVolume(
                 "vector-store-cfg", "launch/vector-store",
 		{
@@ -43,7 +52,7 @@ qdrant + {
                                 params: {
                                     id: "doc-embeddings-write",
                                     store_uri: url.qdrant,
-                                } + $["pub-sub-params"],
+                                } + collectionParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.query.graph_embeddings.qdrant.Processor",
@@ -57,7 +66,7 @@ qdrant + {
                                 params: {
                                     id: "graph-embeddings-write",
                                     store_uri: url.qdrant,
-                                } + $["pub-sub-params"],
+                                } + collectionParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.query.row_embeddings.qdrant.Processor",
@@ -71,7 +80,7 @@ qdrant + {
                                 params: {
                                     id: "row-embeddings-write",
                                     store_uri: url.qdrant,
-                                } + $["pub-sub-params"],
+                                } + collectionParams + $["pub-sub-params"],
                             },
                         ]
                     })


### PR DESCRIPTION
Cassandra: cassandra-replication-factor hook (default 1), raised to ring size by cassandra-cluster, folded into the keyspace-creating processors in control, triples and rows; omitted in external mode so the operator's CASSANDRA_REPLICATION_FACTOR env wins.

Qdrant: qdrant-replication-factor / qdrant-shard-number hooks (default 1), raised to ring size by qdrant-cluster, folded into the three embedding-store write processors that create collections.