### PR TITLE
Make cluster peers and replication factors config-tunable

### DIFF
--- a/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
@@ -25,9 +25,15 @@ local images = import "values/images.jsonnet";
 
 {
 
+    // Number of peer nodes in addition to the seed node. 2 peers -> a
+    // 3-node ring. Top-level (not inside "cassandra") so it can be set
+    // from a config entry's parameters, alongside cassandra-replication-factor.
+    "cassandra-peers":: 2,
+
     // Replication factor for keyspaces the consumers create. Defaults to the
     // ring size (default 2 peers + seed = 3); keep <= node count if you change
-    // peers. Overrides the single-node default of 1 from cassandra.jsonnet.
+    // cassandra-peers. Overrides the single-node default of 1 from
+    // cassandra.jsonnet.
     "cassandra-replication-factor":: 3,
 
     "cassandra" +: {
@@ -40,17 +46,13 @@ local images = import "values/images.jsonnet";
         // Ring identity; must match across all nodes.
         "cluster-name":: "TrustGraph",
 
-        // Number of peer nodes in addition to the seed node.
-        // 2 peers -> a 3-node ring.
-        "peers":: 2,
-
         create:: function(engine)
 
             local memLimit = self["memory-limit"];
             local memReserv = self["memory-reservation"];
             local heap = self["heap"];
             local clusterName = self["cluster-name"];
-            local peers = self["peers"];
+            local peers = $["cassandra-peers"];
 
             // All nodes gossip-bootstrap through the seed (node 0).
             local seeds = "cassandra";

--- a/trustgraph_configurator/templates/2.5/backends/garage-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/garage-cluster.jsonnet
@@ -37,6 +37,15 @@ local url = import "values/url.jsonnet";
         object_store_region: $.garage.region,
     },
 
+    // Number of peer nodes in addition to the primary. 2 peers -> a 3-node
+    // cluster. Top-level (not inside "garage") so it can be set from a
+    // config entry's parameters, alongside garage-replication-factor.
+    "garage-peers":: 2,
+
+    // S3 data replication factor written into garage.toml. Default 3 (3
+    // nodes -> 3-way replication). Keep <= node count (garage-peers + 1).
+    "garage-replication-factor":: 3,
+
     garage +: {
 
         // Garage S3 credentials (override for anything non-dev).
@@ -46,16 +55,9 @@ local url = import "values/url.jsonnet";
         "admin-token":: "batts-rockhearted-unpartially",
         region:: "garage",
 
-        // 3 nodes across 3 zones -> 3-way replication.
-        "replication-factor":: "3",
-
         // Storage volume sizes (data-size also used as layout capacity).
         "meta-size":: "2G",
         "data-size":: "5G",
-
-        // Number of peer nodes in addition to the primary.
-        // 2 peers -> a 3-node cluster.
-        "peers":: 2,
 
         create:: function(engine)
 
@@ -64,10 +66,10 @@ local url = import "values/url.jsonnet";
             local rpcSecret = self["rpc-secret"];
             local adminToken = self["admin-token"];
             local region = self.region;
-            local replicationFactor = self["replication-factor"];
+            local replicationFactor = $["garage-replication-factor"];
             local metaSize = self["meta-size"];
             local dataSize = self["data-size"];
-            local peers = self["peers"];
+            local peers = $["garage-peers"];
 
             // Node 0 keeps the name "garage" (the S3 endpoint clients use);
             // peers are garage-peer-N.

--- a/trustgraph_configurator/templates/2.5/backends/qdrant-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/qdrant-cluster.jsonnet
@@ -17,9 +17,16 @@ local images = import "values/images.jsonnet";
 
 {
 
+    // Number of peer nodes in addition to the bootstrap node. 2 peers ->
+    // a 3-node cluster (sensible quorum). Top-level (not inside "qdrant")
+    // so it can be set from a config entry's parameters, alongside
+    // qdrant-replication-factor / qdrant-shard-number.
+    "qdrant-peers":: 2,
+
     // Collection geometry the write processors apply when creating
     // collections. Ring size = default 2 peers + bootstrap = 3. Overrides
-    // the single-node defaults of 1 from qdrant.jsonnet.
+    // the single-node defaults of 1 from qdrant.jsonnet. Keep <= node count
+    // if you change qdrant-peers.
     "qdrant-replication-factor":: 3,
     "qdrant-shard-number":: 3,
 
@@ -29,15 +36,11 @@ local images = import "values/images.jsonnet";
         "memory-limit":: "1024M",
         "memory-reservation":: "1024M",
 
-        // Number of peer nodes in addition to the bootstrap node.
-        // 2 peers -> a 3-node cluster (sensible quorum).
-        "peers":: 2,
-
         create:: function(engine)
 
             local memLimit = self["memory-limit"];
             local memReserv = self["memory-reservation"];
-            local peers = self["peers"];
+            local peers = $["qdrant-peers"];
 
             // P2P/consensus endpoint of the bootstrap node (node 0).
             local bootstrapUri = "http://qdrant:6335";


### PR DESCRIPTION
Move the peers and replication/shard knobs in cassandra-cluster, qdrant-cluster and garage-cluster to top-level <store>-prefixed hidden hooks read via $[...], so they can be set from a component's parameters block. garage-replication-factor is now an integer for consistency. Defaults unchanged (3-node rings, RF 3).