### PR TITLE
Headless service for Cassandra cluster on K8s

### DIFF
--- a/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.5/backends/cassandra-cluster.jsonnet
@@ -1,25 +1,22 @@
 local images = import "values/images.jsonnet";
 local secrets = import "cassandra-secrets.jsonnet";
 
-// Distributed (multi-node) Cassandra: a seed node plus N peers forming a
-// gossip ring.
+// Distributed (multi-node) Cassandra: N nodes forming a gossip ring
+// behind a single headless service.
 //
 // Slots in like a memory profile: include AFTER the cassandra-backed
 // store (triple-store-cassandra / row-store-cassandra) in the config. It
 // overrides the single-node "cassandra" deployment's create:: with a
-// multi-node topology. The storage processors are untouched and keep
-// addressing host "cassandra" (cassandra_host), so node 0 deliberately
-// keeps that name and acts as the sole seed; the rest of the ring is
-// discovered via gossip.
+// multi-node topology. Consumers address host "cassandra" which, on K8s,
+// is a headless service that resolves to all node pod IPs; on Compose
+// it resolves to node 0 (the container named "cassandra").
 //
-// Caveat 1 (startup ordering): unlike Qdrant's Raft, Cassandra
-// discourages bootstrapping multiple nodes simultaneously, and the
-// engine has no depends_on/healthchecks - all nodes start at once and
-// rely on restart:on-failure retries. For a small dev ring this usually
-// settles after a few restart cycles, but it can be racy. If you hit
-// schema/token disagreements, bring the nodes up staggered (seed first).
+// On K8s each node sets hostname + subdomain so individual pods are
+// addressable as <hostname>.cassandra (e.g. cassandra-peer-1.cassandra).
+// CASSANDRA_SEEDS=cassandra resolves to any live node's pod IP, so the
+// ring can bootstrap without a fixed seed ordering.
 //
-// Caveat 2 (data): forming the ring does not replicate data. The
+// Caveat (data): forming the ring does not replicate data. The
 // TrustGraph processors create keyspaces with replication_factor 1, so
 // for now data still lives on one node. This is a scaffold for
 // developing a replication strategy later.
@@ -61,17 +58,12 @@ secrets + {
             local clusterName = self["cluster-name"];
             local peers = $["cassandra-peers"];
 
-            // All nodes gossip-bootstrap through the seed (node 0).
             local seeds = "cassandra";
 
-            // Build a single Cassandra node. Node 0 is the seed and keeps
-            // the name "cassandra" so cassandra_host keeps resolving;
-            // peers are cassandra-peer-N.
             local mkNode = function(index)
 
-                local isSeed = index == 0;
                 local name =
-                    if isSeed then "cassandra"
+                    if index == 0 then "cassandra"
                     else "cassandra-peer-%d" % index;
 
                 local vol = engine.volume(name).with_size("20G");
@@ -81,13 +73,10 @@ secrets + {
                         .with_image(images.cassandra)
                         .with_user(999)
                         .with_group(999)
+                        .with_membership("cassandra")
+                        .with_hostname(name)
+                        .with_subdomain("cassandra")
                         .with_environment({
-                            // No skip_wait_for_gossip_to_settle here: the
-                            // single-node base sets it to 0 (skip the
-                            // wait) for fast dev startup, but in a ring
-                            // we want each node to wait for gossip to
-                            // converge before proceeding, which is the
-                            // default when the flag is absent.
                             JVM_OPTS: "-Xms%s -Xmx%s" % [heap, heap],
                             CASSANDRA_CLUSTER_NAME: clusterName,
                             CASSANDRA_SEEDS: seeds,
@@ -98,22 +87,25 @@ secrets + {
 
                 local containerSet = engine.containers(name, [ container ]);
 
-                // Internal-only service. 9042 is the CQL client port;
-                // 7000 is the inter-node gossip channel and must stay
-                // internal.
-                local service =
-                    engine.internalService(name, containerSet)
-                    .with_port(9042, 9042, "cql")
-                    .with_port(7000, 7000, "gossip");
+                [ vol, containerSet ];
 
-                [ vol, containerSet, service ];
+            local memberNames = [
+                if i == 0 then "cassandra"
+                else "cassandra-peer-%d" % i
+                for i in std.range(0, peers)
+            ];
 
             local nodes = std.flattenArrays([
                 mkNode(i)
                 for i in std.range(0, peers)
             ]);
 
-            engine.resources(nodes)
+            local svc =
+                engine.headlessService("cassandra", "cassandra", memberNames)
+                .with_port(9042, 9042, "cql")
+                .with_port(7000, 7000, "gossip");
+
+            engine.resources(nodes + [svc])
 
     },
 

--- a/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/aca.jsonnet
@@ -75,6 +75,12 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
         with_entrypoint:: function(x) self + { entrypoint: x },
 
+        with_membership:: function(group) self,
+
+        with_hostname:: function(h) self,
+
+        with_subdomain:: function(s) self,
+
         with_environment:: function(x) self + {
             environment: super.environment + [
                 { name: v.key, value: v.value }
@@ -262,6 +268,15 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
                 ports: service.ports,
                 external: false,
             }],
+
+    },
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        with_port:: function(src, dest, name) self,
+
+        add:: function() [],
 
     },
 

--- a/trustgraph_configurator/templates/2.5/engine/compose.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/compose.jsonnet
@@ -55,6 +55,12 @@
             else
               { cap_add: [x], },
 
+        with_membership:: function(group) self,
+
+        with_hostname:: function(h) self,
+
+        with_subdomain:: function(s) self,
+
         with_environment:: function(x) self +
             if std.objectHas(container, "environment") then
               { environment: container.environment + x }
@@ -157,6 +163,35 @@
                             for port in service.ports
                         ],
                     },
+                },
+            },
+
+    },
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        local service = self,
+
+        ports: [],
+
+        with_port:: function(src, dest, name)
+            self + {
+                ports: super.ports + [dest],
+            },
+
+        add:: function()
+            if std.length(service.ports) == 0
+               || std.length(members) == 0 then {}
+            else {
+                services +: {
+                    [m] +: {
+                        expose: [
+                            "%d" % [port]
+                            for port in service.ports
+                        ],
+                    }
+                    for m in members
                 },
             },
 

--- a/trustgraph_configurator/templates/2.5/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/k8s.jsonnet
@@ -34,6 +34,12 @@
 
         with_entrypoint:: function(x) self + { entrypoint: x },
 
+        with_membership:: function(group) self + { membership: group },
+
+        with_hostname:: function(h) self + { podHostname: h },
+
+        with_subdomain:: function(s) self + { podSubdomain: s },
+
         with_environment:: function(x) self + {
             environment: super.environment + [
                 {
@@ -113,7 +119,11 @@
                             metadata: {
                                 labels: {
                                     app: container.name,
-                                }
+                                } + (
+                                    if std.objectHas(container, "membership")
+                                    then { membership: container.membership }
+                                    else {}
+                                ),
                             },
                             spec: {
                                 enableServiceLinks: false,
@@ -211,6 +221,14 @@
                                     } else {}),
                             }
                             else {}
+                        ) + (
+                            if std.objectHas(container, "podHostname")
+                            then { hostname: container.podHostname }
+                            else {}
+                        ) + (
+                            if std.objectHas(container, "podSubdomain")
+                            then { subdomain: container.podSubdomain }
+                            else {}
                         )
                     },
                 } + {}
@@ -268,6 +286,53 @@
     },
 
     service:: self.internalService,
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        local service = self,
+
+        name: name,
+        membership: membership,
+
+        ports: [],
+
+        with_port::
+            function(src, dest, name)
+                self + {
+                    ports: super.ports + [
+                        { src: src, dest: dest, name: name }
+                    ]
+                },
+
+        add:: function() [
+
+                {
+
+                    apiVersion: "v1",
+                    kind: "Service",
+                    metadata: {
+                        name: service.name,
+                        namespace: "trustgraph",
+                    },
+                    spec: {
+                        clusterIP: "None",
+                        selector: {
+                            membership: service.membership,
+                        },
+                        ports: [
+                            {
+                                port: port.src,
+                                targetPort: port.dest,
+                                name: port.name,
+                            }
+                            for port in service.ports
+                        ],
+                    }
+                }
+            ],
+
+    },
 
     volume:: function(name)
     {

--- a/trustgraph_configurator/templates/2.5/engine/noop.jsonnet
+++ b/trustgraph_configurator/templates/2.5/engine/noop.jsonnet
@@ -23,6 +23,12 @@
 
         with_capability:: function(x) self + {},
 
+        with_membership:: function(group) self + {},
+
+        with_hostname:: function(h) self + {},
+
+        with_subdomain:: function(s) self + {},
+
         with_environment:: function(x) self + {},
 
         with_device:: function(hdev, cdev) self + {},
@@ -41,6 +47,11 @@
     },
 
     internalService:: function(name, containers) {
+        with_port:: function(src, dest, name) self + {},
+        add:: function() {},
+    },
+
+    headlessService:: function(name, membership, members=[]) {
         with_port:: function(src, dest, name) self + {},
         add:: function() {},
     },


### PR DESCRIPTION
The Cassandra cluster's per-node ClusterIP services caused gossip failures on K8s: CASSANDRA_SEEDS resolved to a virtual ClusterIP that didn't match the seed's listen_address (pod IP), so nodes couldn't reconcile identities and the shadow round failed with "Unable to gossip with any peers".

Replace per-node services with a single headless service (clusterIP: None) that resolves directly to pod IPs. All nodes share a "membership" label; each pod sets hostname + subdomain for individual addressability (<name>.cassandra). On Compose the new engine methods are no-ops; headlessService accepts a members list to preserve expose entries.

Engine API additions (k8s, compose, aca, noop):
- container: with_membership, with_hostname, with_subdomain
- headlessService(name, membership, members=[])