### PR TITLE
Fix test configs and query-triples service name

### DIFF
--- a/tests/configs/cloud-aws.json
+++ b/tests/configs/cloud-aws.json
@@ -16,6 +16,10 @@
         "parameters": {}
     },
     {
+        "name": "cassandra",
+        "parameters": {}
+    },
+    {
         "name": "trustgraph-base",
         "parameters": {}
     },

--- a/tests/configs/complex-rag.json
+++ b/tests/configs/complex-rag.json
@@ -21,15 +21,12 @@
         "parameters": {}
     },
     {
-        "name": "triple-store-cassandra",
+        "name": "cassandra",
         "parameters": {}
     },
     {
-        "name": "override-recursive-chunker",
-        "parameters": {
-            "chunk-size": 2000,
-            "chunk-overlap": 100
-        }
+        "name": "triple-store-cassandra",
+        "parameters": {}
     },
     {
         "name": "trustgraph-base",

--- a/tests/configs/minimal.json
+++ b/tests/configs/minimal.json
@@ -13,6 +13,10 @@
         }
     },
     {
+        "name": "cassandra",
+        "parameters": {}
+    },
+    {
         "name": "trustgraph-base",
         "parameters": {}
     },

--- a/tests/configs/multi-service.json
+++ b/tests/configs/multi-service.json
@@ -20,6 +20,10 @@
         "parameters": {}
     },
     {
+        "name": "cassandra",
+        "parameters": {}
+    },
+    {
         "name": "triple-store-cassandra",
         "parameters": {}
     },

--- a/trustgraph_configurator/templates/2.5/triple-store/falkordb.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/falkordb.jsonnet
@@ -64,7 +64,7 @@ falkordb + {
             );
 
             local service =
-                engine.internalService("store-triples", containerSet)
+                engine.internalService("query-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/memgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/memgraph.jsonnet
@@ -69,7 +69,7 @@ memgraph + {
             );
 
             local service =
-                engine.internalService("store-triples", containerSet)
+                engine.internalService("query-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([

--- a/trustgraph_configurator/templates/2.5/triple-store/neo4j.jsonnet
+++ b/trustgraph_configurator/templates/2.5/triple-store/neo4j.jsonnet
@@ -64,7 +64,7 @@ neo4j + {
             );
 
             local service =
-                engine.internalService("store-triples", containerSet)
+                engine.internalService("query-triples", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([


### PR DESCRIPTION
- Add mandatory cassandra backend to all four test configs
- Remove obsolete override-recursive-chunker from complex-rag.json
- Fix copy-paste bug in neo4j, memgraph, falkordb triple-stores: query-triples internalService was incorrectly named "store-triples", causing a selector/label mismatch on K8s