### PR TITLE
Fix dialog output missing MCP server component

### DIFF
--- a/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
+++ b/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
@@ -133,6 +133,15 @@
   );
 
   /* ─────────────────────────────────────────────────────────────
+   * MCP Server (conditional)
+   * ───────────────────────────────────────────────────────────── */
+  $mcp_components := (
+    mcp_server.enabled
+    ? [ $component("mcp-server") ]
+    : []
+  );
+
+  /* ─────────────────────────────────────────────────────────────
    * Base Configuration
    * ───────────────────────────────────────────────────────────── */
   $base_components := [
@@ -147,16 +156,19 @@
       $append(
         $append(
           $append(
-            $base_components,
-            $infrastructure
+            $append(
+              $base_components,
+              $infrastructure
+            ),
+            $backend_components
           ),
-          $backend_components
+          $model_components
         ),
-        $model_components
+        $ocr_components
       ),
-      $ocr_components
+      $embeddings_components
     ),
-    $embeddings_components
+    $mcp_components
   );
 
   /* ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
The MCP server toggle (version >= 2.4) was collected in wizard state but never emitted in the JSONata output transform. Add a $mcp_components conditional section that produces the "mcp-server" component when mcp_server.enabled is true, and append it to the templates assembly chain.