### PR TITLE
Engine layer — added with_image_pull_secret method

### DIFF
--- a/trustgraph_configurator/templates/2.6/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.6/core/control.jsonnet
@@ -51,6 +51,10 @@ local url = import "values/url.jsonnet";
 
         local controlImage = self["control-image"],
         local iamProcessorClass = self["iam-processor-class"],
+        local imagePullSecret =
+            if std.objectHas(self, "image-pull-secret")
+            then self["image-pull-secret"]
+            else null,
 
         create:: function(engine)
 
@@ -216,7 +220,7 @@ local url = import "values/url.jsonnet";
 		}
             );
 
-            local baseContainer =
+            local baseContainerNoSecret =
                 engine.container("control")
                     .with_image(controlImage)
                     .with_command([
@@ -235,6 +239,12 @@ local url = import "values/url.jsonnet";
                     )
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
+
+            local baseContainer =
+                if imagePullSecret != null then
+                    baseContainerNoSecret
+                        .with_image_pull_secret(imagePullSecret)
+                else baseContainerNoSecret;
 
             // Attach object-store and Cassandra env secrets only if a backend
             // populated them.

--- a/trustgraph_configurator/templates/2.6/core/rbac-iam.jsonnet
+++ b/trustgraph_configurator/templates/2.6/core/rbac-iam.jsonnet
@@ -5,6 +5,7 @@ local images = import "values/images.jsonnet";
     "control" +: {
         "control-image":: images.trustgraph_enterprise,
         "iam-processor-class":: "trustgraph.rbac.service.Processor",
+        "image-pull-secret":: "private-registry-credentials",
     },
 
 }

--- a/trustgraph_configurator/templates/2.6/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/aca.jsonnet
@@ -63,6 +63,8 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
         with_image:: function(x) self + { image: x },
 
+        with_image_pull_secret:: function(name) self,
+
         with_user:: function(x) self + { uid: x },
 
         with_group:: function(x) self + { gid: x },

--- a/trustgraph_configurator/templates/2.6/engine/compose.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/compose.jsonnet
@@ -17,6 +17,8 @@
 
         with_image:: function(x) self + { image: x },
 
+        with_image_pull_secret:: function(name) self,
+
         // user/group combine into compose's "uid[:gid]" string field;
         // call order is user-then-group (a later with_user would
         // overwrite the combined value, but patterns conventionally

--- a/trustgraph_configurator/templates/2.6/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/k8s.jsonnet
@@ -13,8 +13,13 @@
         bindMounts: [],
         supplementalGroups: [],
         environment: [],
+        imagePullSecrets: [],
 
         with_image:: function(x) self + { image: x },
+
+        with_image_pull_secret:: function(name) self + {
+            imagePullSecrets: super.imagePullSecrets + [name],
+        },
 
         // k8s deliberately ignores `with_user`: the running UID is
         // determined by the image's USER directive. `with_group(gid)`
@@ -228,6 +233,13 @@
                         ) + (
                             if std.objectHas(container, "podSubdomain")
                             then { subdomain: container.podSubdomain }
+                            else {}
+                        ) + (
+                            if std.length(container.imagePullSecrets) > 0
+                            then { imagePullSecrets: [
+                                { name: s }
+                                for s in container.imagePullSecrets
+                            ] }
                             else {}
                         )
                     },

--- a/trustgraph_configurator/templates/2.6/engine/noop.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/noop.jsonnet
@@ -7,6 +7,8 @@
 
         with_image:: function(x) self + {},
 
+        with_image_pull_secret:: function(name) self + {},
+
         with_user:: function(x) self + {},
 
         with_group:: function(x) self + {},


### PR DESCRIPTION
Engine layer — added with_image_pull_secret method:
- engine/k8s.jsonnet — Added imagePullSecrets array to container state, with_image_pull_secret builder method, and rendering of imagePullSecrets in the pod spec when non-empty.
- engine/noop.jsonnet, engine/compose.jsonnet, engine/aca.jsonnet - Added with_image_pull_secret as a no-op for interface consistency.

Template layer — wired it up for enterprise:
- core/rbac-iam.jsonnet — Added "image-pull-secret":: "private-registry-credentials" to the control object override.
- core/control.jsonnet — Reads the optional image-pull-secret field and calls with_image_pull_secret on the container when set. Non-enterprise deployments are unaffected (defaults to null).

Effect: When rbac-iam is included, the control pod's Deployment gets imagePullSecrets: `[{name: "private-registry-credentials"}]` directly in its pod spec, so it can pull the private trustgraph-enterprise image without relying on the ServiceAccount being patched first.