### PR TITLE
Fix Cassandra cluster split-brain on cold boot

### DIFF
--- a/trustgraph_configurator/templates/2.6/backends/cassandra-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.6/backends/cassandra-cluster.jsonnet
@@ -58,13 +58,26 @@ secrets + {
             local clusterName = self["cluster-name"];
             local peers = $["cassandra-peers"];
 
-            local seeds = "cassandra";
+            local nodeName = function(index)
+                if index == 0 then "cassandra"
+                else "cassandra-peer-%d" % index;
+
+            local nodeFqdn = function(index)
+                "%s.cassandra.trustgraph.svc.cluster.local" %
+                    nodeName(index);
+
+            // Two fixed seeds by FQDN so every pod contacts the same
+            // deterministic set. Using the bare headless service name
+            // resolves to all pod IPs and causes split-brain when pods
+            // race during bootstrap.
+            local seedCount = std.min(2, peers + 1);
+            local seeds = std.join(",", [
+                nodeFqdn(i) for i in std.range(0, seedCount - 1)
+            ]);
 
             local mkNode = function(index)
 
-                local name =
-                    if index == 0 then "cassandra"
-                    else "cassandra-peer-%d" % index;
+                local name = nodeName(index);
 
                 local vol = engine.volume(name).with_size("20G");
 
@@ -90,8 +103,7 @@ secrets + {
                 [ vol, containerSet ];
 
             local memberNames = [
-                if i == 0 then "cassandra"
-                else "cassandra-peer-%d" % i
+                nodeName(i)
                 for i in std.range(0, peers)
             ];
 
@@ -102,6 +114,7 @@ secrets + {
 
             local svc =
                 engine.headlessService("cassandra", "cassandra", memberNames)
+                .with_publish_not_ready_addresses()
                 .with_port(9042, 9042, "cql")
                 .with_port(7000, 7000, "gossip");
 

--- a/trustgraph_configurator/templates/2.6/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/aca.jsonnet
@@ -278,6 +278,8 @@ local toArmParam = function(s) std.strReplace(s, "-", "_");
 
         with_port:: function(src, dest, name) self,
 
+        with_publish_not_ready_addresses:: function() self,
+
         add:: function() [],
 
     },

--- a/trustgraph_configurator/templates/2.6/engine/compose.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/compose.jsonnet
@@ -182,6 +182,8 @@
                 ports: super.ports + [dest],
             },
 
+        with_publish_not_ready_addresses:: function() self,
+
         add:: function()
             if std.length(service.ports) == 0
                || std.length(members) == 0 then {}

--- a/trustgraph_configurator/templates/2.6/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/k8s.jsonnet
@@ -306,6 +306,7 @@
 
         name: name,
         membership: membership,
+        publishNotReady: false,
 
         ports: [],
 
@@ -316,6 +317,9 @@
                         { src: src, dest: dest, name: name }
                     ]
                 },
+
+        with_publish_not_ready_addresses:: function()
+            self + { publishNotReady: true },
 
         add:: function() [
 
@@ -340,7 +344,11 @@
                             }
                             for port in service.ports
                         ],
-                    }
+                    } + (
+                        if service.publishNotReady
+                        then { publishNotReadyAddresses: true }
+                        else {}
+                    )
                 }
             ],
 

--- a/trustgraph_configurator/templates/2.6/engine/noop.jsonnet
+++ b/trustgraph_configurator/templates/2.6/engine/noop.jsonnet
@@ -55,6 +55,7 @@
 
     headlessService:: function(name, membership, members=[]) {
         with_port:: function(src, dest, name) self + {},
+        with_publish_not_ready_addresses:: function() self + {},
         add:: function() {},
     },
 


### PR DESCRIPTION
Use fixed FQDN seeds instead of the bare headless service name which resolves to all pod IPs and causes each node to bootstrap as its own cluster founder.  Add publishNotReadyAddresses to the headless service so seed FQDNs resolve before pods are Ready during bootstrap.