### PR TITLE
maint: bump trustgraph-ui to 0.3.2

### DIFF
--- a/trustgraph_configurator/templates/2.6/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.6/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.3.0",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.2",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.0",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Bump `trustgraph-ui` image from 0.3.0 to 0.3.2 in 2.6 template

## Test plan
- [x] Verify configurator generates correct image reference
- [x] Deploy and confirm UI loads at new version
