### PR TITLE
maint: increase RAG memory limits from 256M to 640M

### DIFF
--- a/trustgraph_configurator/templates/2.6/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.6/core/rag.jsonnet
@@ -18,8 +18,8 @@ local url = import "values/url.jsonnet";
         "prompt-rag-concurrency": 1,
         "rag-cpu-limit": "0.5",
         "rag-cpu-reservation": "0.1",
-        "rag-memory-limit": "256M",
-        "rag-memory-reservation": "256M",
+        "rag-memory-limit": "640M",
+        "rag-memory-reservation": "640M",
         "rag-replicas": 1,
     },
 


### PR DESCRIPTION
## Summary
- Increase RAG container memory limit and reservation from 256M to 640M to accommodate reranker memory usage

## Test plan
- [ ] Verify RAG container starts without OOM under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)