### PR TITLE
feat: add variant and thinking params to OpenAI config

### DIFF
--- a/trustgraph_configurator/templates/2.6/llm/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.6/llm/openai.jsonnet
@@ -12,6 +12,8 @@ local models = import "parameters/openai.jsonnet";
 
     "openai-max-output-tokens":: 4096,
     "openai-temperature":: 0.0,
+    "openai-variant":: "openai",
+    "openai-thinking":: "off",
     "openai-models":: models,
 
     "llm-models" +:: $["openai-models"],
@@ -54,6 +56,8 @@ local models = import "parameters/openai.jsonnet";
                                     concurrency: textCompletionConc,
                                     max_output_tokens: $["openai-max-output-tokens"],
                                     temperature: $["openai-temperature"],
+                                    variant: $["openai-variant"],
+                                    thinking: $["openai-thinking"],
                                 } + $["pub-sub-params"],
                             },
                             {
@@ -63,6 +67,8 @@ local models = import "parameters/openai.jsonnet";
                                     concurrency: textCompletionRagConc,
                                     max_output_tokens: $["openai-max-output-tokens"],
                                     temperature: $["openai-temperature"],
+                                    variant: $["openai-variant"],
+                                    thinking: $["openai-thinking"],
                                 } + $["pub-sub-params"],
                             },
                         ]

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Add `variant` and `thinking` parameters to OpenAI LLM processor config
- Supports provider-specific API variants (openai, deepseek, qwen, mistral, llama) and optional reasoning mode
- Defaults to `variant=openai`, `thinking=off` for backward compatibility
- Bump TrustGraph 2.6 to 2.6.5

## Test plan
- [ ] Deploy with default params and verify identical behaviour to before
- [ ] Test with `--variant deepseek --thinking high`
