### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.6

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.5",
+            "version": "2.6.6",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.6
- Picks up GLM (Zhipu AI) variant for the OpenAI processor (trustgraph#1009)

## Test plan
- [x] Verify GLM variant works with `--variant glm`
