### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.7

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.6",
+            "version": "2.6.7",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.7
- Adds DashScope variant for Alibaba Cloud DashScope API (trustgraph#1010)

## Test plan
- [x] Verify DashScope variant works with `--variant dashscope`
