### PR TITLE
feat: wire cross-encoder reranker into Document-RAG flow (#878)

### DIFF
--- a/trustgraph_configurator/templates/2.6/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.6/flows/document-store.jsonnet
@@ -14,9 +14,10 @@ local librarian_response = helpers.librarian_response;
 // Import shared services
 local llm_services = import "llm-services.jsonnet";
 local embeddings_service = import "embeddings-service.jsonnet";
+local reranker_service = import "reranker-service.jsonnet";
 
 // Merge shared services with document store configuration
-llm_services + embeddings_service + {
+llm_services + embeddings_service + reranker_service + {
 
     // External interfaces for document store
     "interfaces" +: {
@@ -51,6 +52,8 @@ llm_services + embeddings_service + {
                 "prompt-response": response("prompt-rag:{workspace}:{id}"),
                 "document-embeddings-request": request("document-embeddings:{workspace}:{id}"),
                 "document-embeddings-response": response("document-embeddings:{workspace}:{id}"),
+                "reranker-request": request("reranker:{workspace}:{id}"),
+                "reranker-response": response("reranker:{workspace}:{id}"),
                 explainability: flow("triples-store:{workspace}:{id}"),
                 "librarian-request": librarian_request,
                 "librarian-response": librarian_response,


### PR DESCRIPTION
Companion to **trustgraph-ai/trustgraph#1011** (#878).

Imports `reranker-service.jsonnet` into `document-store.jsonnet` and adds the `reranker-request`/`reranker-response` topics to the `document-rag` flow, so the Document-RAG processor can reach the shared FlashRank reranker. Mirrors how #279 wired the reranker into GraphRAG via `graph-store.jsonnet`. The shared reranker service deployed by #279 is reused as-is.

**Required, not optional:** the monorepo PR registers `RerankerClientSpec`, which makes these topics required at flow construction — without this change the document-rag flow raises a `KeyError`. Please merge the two together.

4-line change to `templates/2.6/flows/document-store.jsonnet`; configurator tests pass.
