### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.8

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.7",
+            "version": "2.6.8",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.8
- Simplifies DashScope variant, routes all API calls through variant methods instead of httpx bypass (trustgraph#1012)

## Test plan
- [x] Verify DashScope and Qwen variants still function correctly
