### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.10

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.8",
+            "version": "2.6.10",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.10
- 2.6.9: Cross-encoder reranking added to Document-RAG with two-limit control (fetch_limit + doc_limit) (trustgraph#1011)
- 2.6.10: Wire variant into remaining streaming integration test mocks (trustgraph#1013)

## Test plan
- [x] Verify Document-RAG reranking with fetch_limit parameter
- [x] Confirm streaming tests pass
