### PR TITLE
maint: bump trustgraph-ui to 0.3.6

### DIFF
--- a/trustgraph_configurator/templates/2.6/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.6/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.3.5",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.6",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Bump `trustgraph-ui` from 0.3.5 to 0.3.6
- Reduces upload chunk size from 5MB to 2MB to stay within Pulsar's ~3MB message size limit (trustgraph-ui#19)

## Test plan
- [ ] Verify file uploads succeed on Pulsar deployments
