### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.11

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.10",
+            "version": "2.6.11",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.11
- Direction-aware reranker text in GraphRAG hop-and-filter eliminates duplicate reranker texts when traversing shared nodes (trustgraph#1016)

## Test plan
- [x] Verify GraphRAG traversal produces distinct reranker texts per direction
