### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.14

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.11",
+            "version": "2.6.14",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 version to 2.6.14
- 2.6.12: Remove fragile test import (trustgraph#1017)
- 2.6.13: Add tg-export-workspace / tg-import-workspace bundle commands (trustgraph#1019)
- 2.6.14: Filter schema predicates and cap GraphRAG reranker input with max-reranker-input parameter (trustgraph#1021)

## Test plan
- [x] Verify workspace export/import round-trips correctly
- [x] Verify GraphRAG reranker filtering with schema-heavy graphs

