### PR TITLE
feat: add with_params helper to Pulsar module

### DIFF
--- a/trustgraph_configurator/templates/2.6/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.6/pubsub/pulsar.jsonnet
@@ -36,6 +36,15 @@ local url = import "values/url.jsonnet";
     "prometheus-config"::
         importstr "prometheus/prometheus-pulsar.yml",
 
+    with_params:: function(pars)
+        self + {
+            "pulsar" +: std.foldl(
+                function(obj, par) obj + { [par.key]:: par.value },
+                std.objectKeysValues(pars),
+                {}
+            ),
+        },
+
     "pulsar" +: {
 
         // Zookeeper memory settings (can be overridden by memory-profile)


### PR DESCRIPTION
## Summary
- Add `with_params` function to Pulsar pub-sub module
- Enables parameter injection into Pulsar sub-object via the same pattern used by decode-config components

## Test plan
- [x] Verify Pulsar config renders correctly with and without parameter overrides
