### PR TITLE
feat: add TrustGraph 2.7 template tree, promote 2.6 to stable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import pytest
 # =============================================================================
 # Version Configuration - Update these when adding new template versions
 # =============================================================================
-TESTED_VERSIONS = ["2.5", "2.6"]
-PRIMARY_VERSION = "2.6"  # Used when only one version is tested
+TESTED_VERSIONS = ["2.6", "2.7"]
+PRIMARY_VERSION = "2.7"  # Used when only one version is tested
 import sys
 import json
 import tempfile

--- a/trustgraph_configurator/resources/2.7/grafana/dashboards/log-dashboard.json
+++ b/trustgraph_configurator/resources/2.7/grafana/dashboards/log-dashboard.json
@@ -1,0 +1,178 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cf6m73l5rnvuod"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 33,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "never",
+        "stacking": "normal",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cf6m73l5rnvuod"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "topk(5, sum by (processor) (count_over_time({severity=~\"error|critical\"} [$__auto])))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error volume",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "cf6m73l5rnvuod"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "cf6m73l5rnvuod"
+          },
+          "direction": "backward",
+          "editorMode": "builder",
+          "expr": "{severity=~\"error|critical\"} |= ``",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log errors",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Logs",
+  "uid": "4bdce405-0dd3-4a14-9a8f-792152ebebba",
+  "version": 13
+}

--- a/trustgraph_configurator/resources/2.7/grafana/dashboards/overview-dashboard-pulsar.json
+++ b/trustgraph_configurator/resources/2.7/grafana/dashboards/overview-dashboard-pulsar.json
@@ -1,0 +1,1403 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "producer_count_total{processor=\"chunker\",name=\"output\"}\n- ignoring(instance, job, processor, name, status)\nprocessing_count_total{processor=\"kg-extract-relationships\", name=\"input\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Knowledge extraction backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(producer_count_total{processor=\"graph-embeddings\",name=\"output\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\"ge-write\",name=\"input\"} >= 2)\nor\n(0 * (producer_count_total{processor=\"graph-embeddings\",name=\"output\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\"ge-write\",name=\"input\"}))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Graph embeddings backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(clamp_min(\n  (\n    producer_count_total{processor=\"kg-extract-definitions\",name=\"triples\"}\n    + on(flow)\n    producer_count_total{processor=\"kg-extract-relationships\",name=\"triples\"}\n  )\n  - on(flow) processing_count_total{processor=\"triples-write\",name=\"input\"},\n  0\n) >= 2) or (0 * clamp_min(\n  (\n    producer_count_total{processor=\"kg-extract-definitions\",name=\"triples\"}\n    + on(flow)\n    producer_count_total{processor=\"kg-extract-relationships\",name=\"triples\"}\n  )\n  - on(flow) processing_count_total{processor=\"triples-write\",name=\"input\"},\n  0\n))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Triples backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 7,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(le) (rate(text_completion_duration_bucket[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "99%",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "LLM latency",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "calculate": false,
+        "cellGap": 5,
+        "cellValues": {
+          "unit": ""
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisLabel": "processing status",
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(status) (rate(processing_count_total{status!=\"success\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error rate",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(processor) (rate(request_latency_count{processor!=\"config-svc\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pulsar_msg_backlog{topic!=\"persistent://tg/config/config\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Pub/sub backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "semi-dark-green",
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by(le) (chunk_size_bucket)",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": true,
+          "legendFormat": "{{le}}",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Chunk size",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(job) (increase(rate_limit_count_total[$__rate_interval]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Rate limit events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-blue",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(process_cpu_seconds_total[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "GB",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "process_resident_memory_bytes / 1073741824",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "hideFrom": {
+              "viz": false
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 39
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (model) (tokens_total)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Models in use",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 39
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(model, direction)  (rate(tokens_total[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} - {{direction}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Tokens",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "$",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 39
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(direction, model) (rate(tokens_total[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} - {{direction}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Token cost",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Overview (Pulsar)",
+  "uid": "ad77jv9",
+  "version": 1
+}

--- a/trustgraph_configurator/resources/2.7/grafana/dashboards/overview-dashboard-rabbitmq.json
+++ b/trustgraph_configurator/resources/2.7/grafana/dashboards/overview-dashboard-rabbitmq.json
@@ -1,0 +1,1403 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "producer_count_total{processor=\"chunker\",name=\"output\"}\n- ignoring(instance, job, processor, name, status)\nprocessing_count_total{processor=\"kg-extract-relationships\", name=\"input\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Knowledge extraction backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(producer_count_total{processor=\"graph-embeddings\",name=\"output\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\"ge-write\",name=\"input\"} >= 2)\nor\n(0 * (producer_count_total{processor=\"graph-embeddings\",name=\"output\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\"ge-write\",name=\"input\"}))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Graph embeddings backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(clamp_min(\n  (\n    producer_count_total{processor=\"kg-extract-definitions\",name=\"triples\"}\n    + on(flow)\n    producer_count_total{processor=\"kg-extract-relationships\",name=\"triples\"}\n  )\n  - on(flow) processing_count_total{processor=\"triples-write\",name=\"input\"},\n  0\n) >= 2) or (0 * clamp_min(\n  (\n    producer_count_total{processor=\"kg-extract-definitions\",name=\"triples\"}\n    + on(flow)\n    producer_count_total{processor=\"kg-extract-relationships\",name=\"triples\"}\n  )\n  - on(flow) processing_count_total{processor=\"triples-write\",name=\"input\"},\n  0\n))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Triples backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 7,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(le) (rate(text_completion_duration_bucket[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "99%",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "LLM latency",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "calculate": false,
+        "cellGap": 5,
+        "cellValues": {
+          "unit": ""
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisLabel": "processing status",
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(status) (rate(processing_count_total{status!=\"success\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Error rate",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(processor) (rate(request_latency_count{processor!=\"config-svc\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "  label_replace(                                                                                                                                                                                                             \n    rabbitmq_queue_messages{queue!~\"tg.state.config.*|amq.gen-.*\"},                                                                                                                                                          \n    \"short\", \"$2:$1:$3\", \"queue\", \"^([^.]+)\\\\.([^.]+)\\\\.([^.]+)\\\\..+$\"                                                                                                                                                       \n  )                                                                                                                                                                                                                          \n",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{short}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Pub/sub backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "semi-dark-green",
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by(le) (chunk_size_bucket)",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": true,
+          "legendFormat": "{{le}}",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Chunk size",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(job) (increase(rate_limit_count_total[$__rate_interval]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Rate limit events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-blue",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(process_cpu_seconds_total[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "GB",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "process_resident_memory_bytes / 1073741824",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "hideFrom": {
+              "viz": false
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 39
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (model) (tokens_total)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Models in use",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 39
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(model, direction)  (rate(tokens_total[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} - {{direction}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Tokens",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "$",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 39
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f6b18033-5918-4e05-a1ca-4cb30343b129"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(direction, model) (rate(tokens_total[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{model}} - {{direction}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Token cost",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Overview (RabbitMQ)",
+  "uid": "adkxj6x",
+  "version": 1
+}

--- a/trustgraph_configurator/resources/2.7/grafana/provisioning/dashboard.yml
+++ b/trustgraph_configurator/resources/2.7/grafana/provisioning/dashboard.yml
@@ -1,0 +1,17 @@
+
+apiVersion: 1
+
+providers:
+
+  - name: 'trustgraph.ai'
+    orgId: 1
+    folder: 'TrustGraph'
+    folderUid: 'b6c5be90-d432-4df8-aeab-737c7b151228'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false
+

--- a/trustgraph_configurator/resources/2.7/grafana/provisioning/datasource.yml
+++ b/trustgraph_configurator/resources/2.7/grafana/provisioning/datasource.yml
@@ -1,0 +1,36 @@
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    # <string> Sets a custom UID to reference this
+    # data source in other parts of the configuration.
+    # If not specified, Grafana generates one.
+    uid: 'f6b18033-5918-4e05-a1ca-4cb30343b129'
+
+    url: http://prometheus:9090
+
+    basicAuth: false
+    withCredentials: false
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    # <string> Sets a custom UID to reference this
+    # data source in other parts of the configuration.
+    # If not specified, Grafana generates one.
+    uid: 'cf6m73l5rnvuod'
+
+    url: http://loki:3100
+
+    basicAuth: false
+    withCredentials: false
+    editable: true
+

--- a/trustgraph_configurator/resources/2.7/loki/local-config.yaml
+++ b/trustgraph_configurator/resources/2.7/loki/local-config.yaml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+ingester:
+  lifecycler:
+    join_after: 2s
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false
+

--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
@@ -1,0 +1,97 @@
+global:
+
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'trustgraph'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+
+  # The job name is added as a label `job=<job_name>` to any timeseries
+  # scraped from this config.
+
+  # TrustGraph services in processor groups
+  - job_name: 'control'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'control:8000'
+
+  - job_name: 'ingest'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'ingest:8000'
+
+  - job_name: 'rag'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'rag:8000'
+
+  - job_name: 'embeddings'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'embeddings:8000'
+
+  - job_name: 'vector-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'vector-store:8000'
+
+  - job_name: 'row-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'row-store:8000'
+
+  - job_name: 'triple-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'triple-store:8000'
+
+  - job_name: 'text-completion'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'text-completion:8000'
+
+  # TrustGraph services standalone
+  - job_name: 'api-gateway'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'api-gateway-metrics:8000'
+
+  - job_name: 'mcp-server'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'mcp-server:8000'
+
+  - job_name: 'document-decoder'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'document-decoder:8000'
+
+  # Non-Trustgraph services
+  - job_name: 'garage'
+    metrics_path: '/metrics'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'garage:3903'
+
+  - job_name: 'pulsar'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'pulsar:8080'

--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-rabbitmq.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-rabbitmq.yml
@@ -1,0 +1,98 @@
+global:
+
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'trustgraph'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+
+  # The job name is added as a label `job=<job_name>` to any timeseries
+  # scraped from this config.
+
+  # TrustGraph services in processor groups
+  - job_name: 'control'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'control:8000'
+
+  - job_name: 'ingest'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'ingest:8000'
+
+  - job_name: 'rag'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'rag:8000'
+
+  - job_name: 'embeddings'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'embeddings:8000'
+
+  - job_name: 'vector-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'vector-store:8000'
+
+  - job_name: 'row-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'row-store:8000'
+
+  - job_name: 'triple-store'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'triple-store:8000'
+
+  - job_name: 'text-completion'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'text-completion:8000'
+
+  # TrustGraph services standalone
+  - job_name: 'api-gateway'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'api-gateway-metrics:8000'
+
+  - job_name: 'mcp-server'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'mcp-server:8000'
+
+  - job_name: 'document-decoder'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'document-decoder:8000'
+
+  # Non-Trustgraph services
+  - job_name: 'garage'
+    metrics_path: '/metrics'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'garage:3903'
+
+  - job_name: 'rabbitmq'
+    metrics_path: '/metrics/per-object'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'rabbitmq:15692'

--- a/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
@@ -18,16 +18,21 @@ steps:
     input:
       type: select
       options:
+        - label: "TrustGraph 2.7"
+          value: "2.7"
+          description: "Placeholder for pre-release"
+          badge: pre-release
+          recommended: false
         - label: "TrustGraph 2.6"
           value: "2.6"
           description: "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval"
-          badge: pre-release
-          recommended: false
+          badge: stable
+          recommended: true
         - label: "TrustGraph 2.5"
           value: "2.5"
           description: "Updates to SPARQL query support"
           badge: stable
-          recommended: true
+          recommended: false
         - label: "TrustGraph 2.4"
           value: "2.4"
           description: "New UX, IAM & data separation through workspaces"

--- a/trustgraph_configurator/templates/2.7/README.md
+++ b/trustgraph_configurator/templates/2.7/README.md
@@ -1,0 +1,125 @@
+
+# TrustGraph template generation
+
+There are two utilities here:
+
+- `generate`: Generates a single Docker Compose launch configuration
+  based on configuration you provide.
+- `generate-all`: Generates the release bundle for releases.  You won't
+  need to use this unless you are managing releases.
+  
+## `generate-all`
+
+Previously, this generates a full set of all vector DB / triple store / LLM
+combinations, and put them in a single ZIP file.  But this got out of
+hand, so at the time of writing, this generates a single configuraton
+using Qdrant vector DB, Ollama LLM support and Cassandra for a triple store.
+
+The combinations are contained withing the code, it takes two arguments:
+- output ZIP file (is over-written)
+- TrustGraph version number
+
+```
+templates/generate-all output.zip 0.18.11
+```
+
+## `generate`
+
+This utility takes a configuration file describing the components to bundle,
+and outputs a Docker Compose YAML file.
+
+### Input configuration
+
+The input configuration is a JSON file, an array of components to pull into
+the configuration.  For each component, there is a name and a (possibly empty)
+object describing addtional parameters for that component.
+
+Example:
+
+```
+[
+    {
+        "name": "cassandra",
+        "parameters": {}
+    },
+    {
+        "name": "pulsar",
+        "parameters": {}
+    },
+    {
+        "name": "qdrant",
+        "parameters": {}
+    },
+    {
+        "name": "embeddings-hf",
+        "parameters": {}
+    },
+    {
+        "name": "graph-rag",
+        "parameters": {}
+    },
+    {
+        "name": "grafana",
+        "parameters": {}
+    },
+    {
+        "name": "trustgraph",
+        "parameters": {}
+    },
+    {
+        "name": "googleaistudio",
+        "parameters": {
+            "googleaistudio-temperature": 0.3,
+            "googleaistudio-max-output-tokens": 2048,
+            "googleaistudio-model": "gemini-1.5-pro-002"
+        }
+    },
+    {
+        "name": "prompt-template",
+        "parameters": {}
+    },
+    {
+        "name": "override-recursive-chunker",
+        "parameters": {
+            "chunk-size": 1000,
+            "chunk-overlap": 50
+        }
+    },
+    {
+        "name": "workbench-ui",
+        "parameters": {}
+    },
+    {
+        "name": "agent-manager-react",
+        "parameters": {}
+    }
+]
+```
+
+If you want to make your own configuration you could try changing the
+configuration above:
+- Components which are essential: pulsar, trustgraph, graph-rag, grafana,
+  agent-manager-react
+- You need a triple store, one of: cassandra, memgraph, falkordb, neo4j
+- You need a vector store, one of: qdrant, pinecone
+- You need an LLM, one of: azure, azure-openai, bedrock, claude, cohere,
+  llamafile, ollama, openai, vertexai.
+- You need an embeddings implementation, one of: embeddings-hf,
+  embeddings-ollama
+- Optionally add the Workbench tool: workbench-ui
+
+Components have over-ridable parameters, look in the component definition
+in `templates/components/` to see what you can override.
+
+### Invocation
+
+Two parameters:
+- The output ZIP file
+- The version number
+
+The configuration file described above is provided on standard input
+
+```
+templates/generate out.zip 0.18.9 < config.json
+```
+

--- a/trustgraph_configurator/templates/2.7/backends/cassandra-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/cassandra-cluster.jsonnet
@@ -1,0 +1,125 @@
+local images = import "values/images.jsonnet";
+local secrets = import "cassandra-secrets.jsonnet";
+
+// Distributed (multi-node) Cassandra: N nodes forming a gossip ring
+// behind a single headless service.
+//
+// Slots in like a memory profile: include AFTER the cassandra-backed
+// store (triple-store-cassandra / row-store-cassandra) in the config. It
+// overrides the single-node "cassandra" deployment's create:: with a
+// multi-node topology. Consumers address host "cassandra" which, on K8s,
+// is a headless service that resolves to all node pod IPs; on Compose
+// it resolves to node 0 (the container named "cassandra").
+//
+// On K8s each node sets hostname + subdomain so individual pods are
+// addressable as <hostname>.cassandra (e.g. cassandra-peer-1.cassandra).
+// CASSANDRA_SEEDS=cassandra resolves to any live node's pod IP, so the
+// ring can bootstrap without a fixed seed ordering.
+//
+// Caveat (data): forming the ring does not replicate data. The
+// TrustGraph processors create keyspaces with replication_factor 1, so
+// for now data still lives on one node. This is a scaffold for
+// developing a replication strategy later.
+
+secrets + {
+
+    // Number of peer nodes in addition to the seed node. 2 peers -> a
+    // 3-node ring. Top-level (not inside "cassandra") so it can be set
+    // from a config entry's parameters, alongside cassandra-replication-factor.
+    "cassandra-peers":: 2,
+
+    // Replication factor for keyspaces the consumers create. Defaults to the
+    // ring size (default 2 peers + seed = 3); keep <= node count if you change
+    // cassandra-peers. Overrides the single-node default of 1 from
+    // cassandra.jsonnet.
+    "cassandra-replication-factor":: 3,
+
+    // Per-node memory, settable via the override component's parameters.
+    // Declared independently from the single-node store (separate recipe);
+    // they happen to match today but neither file depends on the other.
+    parameters +:: {
+        "cassandra-heap": "700M",
+        "cassandra-memory-limit": "1400M",
+        "cassandra-memory-reservation": "1400M",
+    },
+
+    "cassandra" +: {
+
+        // Ring identity; must match across all nodes.
+        "cluster-name":: "TrustGraph",
+
+        create:: function(engine)
+
+            local pars = $.parameters;
+
+            local memLimit = pars["cassandra-memory-limit"];
+            local memReserv = pars["cassandra-memory-reservation"];
+            local heap = pars["cassandra-heap"];
+            local clusterName = self["cluster-name"];
+            local peers = $["cassandra-peers"];
+
+            local nodeName = function(index)
+                if index == 0 then "cassandra"
+                else "cassandra-peer-%d" % index;
+
+            local nodeFqdn = function(index)
+                "%s.cassandra.trustgraph.svc.cluster.local" %
+                    nodeName(index);
+
+            // Two fixed seeds by FQDN so every pod contacts the same
+            // deterministic set. Using the bare headless service name
+            // resolves to all pod IPs and causes split-brain when pods
+            // race during bootstrap.
+            local seedCount = std.min(2, peers + 1);
+            local seeds = std.join(",", [
+                nodeFqdn(i) for i in std.range(0, seedCount - 1)
+            ]);
+
+            local mkNode = function(index)
+
+                local name = nodeName(index);
+
+                local vol = engine.volume(name).with_size("20G");
+
+                local container =
+                    engine.container(name)
+                        .with_image(images.cassandra)
+                        .with_user(999)
+                        .with_group(999)
+                        .with_membership("cassandra")
+                        .with_hostname(name)
+                        .with_subdomain("cassandra")
+                        .with_environment({
+                            JVM_OPTS: "-Xms%s -Xmx%s" % [heap, heap],
+                            CASSANDRA_CLUSTER_NAME: clusterName,
+                            CASSANDRA_SEEDS: seeds,
+                        })
+                        .with_limits("1.0", memLimit)
+                        .with_reservations("0.5", memReserv)
+                        .with_volume_mount(vol, "/var/lib/cassandra");
+
+                local containerSet = engine.containers(name, [ container ]);
+
+                [ vol, containerSet ];
+
+            local memberNames = [
+                nodeName(i)
+                for i in std.range(0, peers)
+            ];
+
+            local nodes = std.flattenArrays([
+                mkNode(i)
+                for i in std.range(0, peers)
+            ]);
+
+            local svc =
+                engine.headlessService("cassandra", "cassandra", memberNames)
+                .with_publish_not_ready_addresses()
+                .with_port(9042, 9042, "cql")
+                .with_port(7000, 7000, "gossip");
+
+            engine.resources(nodes + [svc])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/cassandra-external.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/cassandra-external.jsonnet
@@ -1,0 +1,26 @@
+// External Cassandra (managed / secured cluster). Deploys nothing - it only
+// populates control's cassandra-secrets hook so every Cassandra consumer
+// (control, triples, rows) reads its connection settings from env-var secrets
+// supplied at deploy time, and omits the cassandra_host param so those env
+// vars take effect:
+//
+//   CASSANDRA_HOST     CASSANDRA_USERNAME
+//   CASSANDRA_PASSWORD CASSANDRA_REPLICATION_FACTOR
+//
+// Wire these via a K8s Secret named "cassandra" (keys host / username /
+// password / replication-factor), compose env, or the equivalent ACA secret
+// refs. replication-factor isn't secret but rides the same env bundle for
+// consistency.
+//
+// Mutually exclusive with cassandra-cluster - import one Cassandra backend.
+
+local secrets = import "cassandra-secrets.jsonnet";
+
+secrets + {
+    "cassandra-secrets" +:: {
+        CASSANDRA_HOST: "host",
+        CASSANDRA_USERNAME: "username",
+        CASSANDRA_PASSWORD: "password",
+        CASSANDRA_REPLICATION_FACTOR: "replication-factor",
+    },
+}

--- a/trustgraph_configurator/templates/2.7/backends/cassandra-secrets.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/cassandra-secrets.jsonnet
@@ -1,0 +1,31 @@
+// Shared Cassandra connection secrets. Deploys nothing: just the
+// ENV_VAR -> secret-key map (empty by default = self-hosted, no auth) and the
+// helper that turns it into engine env secrets.
+//
+// Included by each Cassandra backend (cassandra, cassandra-cluster,
+// cassandra-external) so these hooks always land in the merged config when a
+// backend is present. Consumers (control, triples, rows) then read
+// $["cassandra-env-secrets"] / $["cassandra-secrets"] straight off the merge -
+// they don't import this file.
+
+{
+
+    // ENV_VAR -> secret-key map. Empty => self-hosted (host "cassandra", no
+    // auth). cassandra-external populates it; +:: so component order in the
+    // config list never clobbers it.
+    "cassandra-secrets" +:: {},
+
+    // Build engine env secrets from the map, or null when empty. Consumers call
+    // this to attach the secrets to their container and to decide whether to
+    // omit the cassandra_host param (external mode lets CASSANDRA_HOST win).
+    "cassandra-env-secrets":: function(engine)
+        local m = $["cassandra-secrets"];
+        if std.length(m) > 0 then
+            std.foldl(
+                function(s, v) s.with_env_var(v, m[v]),
+                std.objectFields(m),
+                engine.envSecrets("cassandra")
+            )
+        else null,
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/cassandra.jsonnet
@@ -1,0 +1,73 @@
+local images = import "values/images.jsonnet";
+local secrets = import "cassandra-secrets.jsonnet";
+
+// Self-hosted single-node Cassandra. List as the "cassandra" component to
+// deploy it; consumers then talk to host "cassandra" with no auth. Mutually
+// exclusive with cassandra-external (managed/secured cluster) - import one.
+// cassandra-cluster overrides this single node with a multi-node ring.
+
+secrets + {
+
+    // Replication factor for keyspaces the consumers create. 1 for a single
+    // node; cassandra-cluster raises it to the ring size. Consumers read this
+    // in self-hosted mode and omit it in external mode (CASSANDRA_REPLICATION_
+    // FACTOR env wins).
+    "cassandra-replication-factor":: 1,
+
+    // Per-node memory, settable via the override component's parameters.
+    // Declared independently from cassandra-cluster (separate recipe).
+    parameters +:: {
+        "cassandra-heap": "700M",
+        "cassandra-memory-limit": "1400M",
+        "cassandra-memory-reservation": "1400M",
+    },
+
+    "cassandra" +: {
+
+        create:: function(engine)
+
+            // External Cassandra also selected (creds via env secrets): deploy
+            // nothing, external wins. Consumers read CASSANDRA_HOST etc.
+            if std.length($["cassandra-secrets"]) > 0 then
+                engine.resources([])
+            else
+
+            local pars = $.parameters;
+            local memLimit = pars["cassandra-memory-limit"];
+            local memReserv = pars["cassandra-memory-reservation"];
+            local heap = pars["cassandra-heap"];
+
+            local vol = engine.volume("cassandra").with_size("20G");
+
+            local container =
+                engine.container("cassandra")
+                    .with_image(images.cassandra)
+                    .with_user(999)
+                    .with_group(999)
+                    .with_environment({
+                        JVM_OPTS: "-Xms%s -Xmx%s -Dcassandra.skip_wait_for_gossip_to_settle=0" % [
+                            heap, heap,
+                        ],
+                    })
+                    .with_limits("1.0", memLimit)
+                    .with_reservations("0.5", memReserv)
+                    .with_port(9042, 9042, "cassandra")
+                    .with_volume_mount(vol, "/var/lib/cassandra");
+
+            local containerSet = engine.containers(
+                "cassandra", [ container ]
+            );
+
+            local service =
+                engine.internalService("cassandra", containerSet)
+                .with_port(9042, 9042, "api");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/ceph.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/ceph.jsonnet
@@ -1,0 +1,446 @@
+
+//
+// This majorly does not work
+//
+
+// This configuration fails primarily because it tries to treat Ceph
+// like a stateless web app. You are currently pointing mon host to a
+// generic service name (ceph-mon), but you aren't telling the Monitor
+// process to assume that service identity.
+
+// To make this work with the "Service Name" approach across any
+// engine, you need to fix the binding logic and the messenger protocol.
+
+// 1. The ceph.conf Fix
+
+// Need to enable Messenger v2 (modern) and tell the cluster to use
+// the service names for its initial quorum.
+
+//Change this section:
+// Ini, TOML
+
+// [global]
+// fsid = %s
+// mon initial members = mon0
+// mon host = ceph-mon:6789
+// ...
+
+// To this:
+// Ini, TOML
+
+// [global]
+// fsid = %s
+// # Use the actual service names as members
+// mon initial members = ceph-mon
+// # Explicitly use the Service name (VIP)
+// mon host = ceph-mon
+// # Force modern protocol
+// ms_bind_msgr2 = true
+// ms_bind_msgr1 = true
+
+// 2. The MON Environment & Command Fix
+
+// This is the most critical part. Your current config sets MON_IP:
+// "0.0.0.0". This causes the MON to bind to the Pod IP, which breaks
+// when the Pod restarts. You must force it to bind to the Service IP.
+
+// Update mon_env:
+// Code snippet
+
+// local mon_env = cluster_env + {
+//     CEPH_DAEMON: "MON",
+//     MON_NAME: "mon0",
+//     # Remove MON_IP: "0.0.0.0"
+//     # Add these:
+//     MON_ADDR: "ceph-mon", // This says to resolve the service name
+// };
+
+// Update mon_container command: You are currently wiping the MON data
+// on every start (rm -rf /var/lib/ceph/mon/*). Stop doing that. If you
+// wipe the data, you lose the cluster state and the OSDs will refuse to
+// talk to the "new" MON.
+
+// Code snippet
+
+// .with_command([
+//     "bash", "-c",
+//     # 1. Resolve the Service IP at runtime
+//     "export MON_IP=$(getent hosts ceph-mon | awk '{ print $1 }'); " +
+//     inject_mon_config + 
+//     # 2. Start the daemon telling it its PUBLIC address is the Service VIP
+//     "exec /opt/ceph-container/bin/entrypoint.sh"
+// ])
+
+// 3. Why your current config "Majorly does not work"
+
+// The "Wipe" Logic: By running rm -rf /var/lib/ceph/mon/* in the
+// MON container, you are creating a "New Cluster" every time the
+// container starts. Since the OSDs store the fsid and cluster
+// secrets, they will reject the "new" MON.
+
+// DNS Race Condition: Your OSD/MGR/RGW containers wait for
+// ceph-mon DNS, which is good. However, if ceph-mon resolves to a
+// Round Robin IP (multiple pods) rather than a stable ClusterIP, the
+// connection will be flaky.
+
+// Messenger Protocol: Without ms_bind_msgr2, Ceph defaults to the
+// old v1 protocol which is much more sensitive to NAT/Container IP
+// mismatches.
+
+// SUMMARY
+
+// Component: ceph.conf
+// Change: Add ms_bind_msgr2 = true
+// Why: Supports modern container networking better.
+
+// Component: MON Start
+// Change: Remove rm -rf
+// Why: Ceph MONs must keep their database to maintain the cluster.
+
+// Component: MON Address
+// Change: Use getent hosts ceph-mon
+// Why: Forces the MON to advertise the Service VIP instead of its own Pod IP.
+
+// Component: MON Keyring
+// Change: Ensure /etc/ceph/ceph.mon.keyring exists
+// Why: MONs need their specific key to start.
+
+local images = import "values/images.jsonnet";
+
+{
+    with:: function(key, value)
+        self + {
+            ["ceph-" + key]:: value,
+        },
+
+    // Ceph credentials and cluster settings
+    "ceph-access-key":: "object-user",
+    "ceph-secret-key":: "object-password",
+    "ceph-cluster-id":: "ceph",
+    "ceph-fsid":: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+
+    // Pool redundancy settings
+    // size: 2 = two replicas for fault tolerance
+    // min_size: 1 = allow degraded I/O if one OSD is down (prevents cluster freeze)
+    "ceph-pool-size":: "2",
+    "ceph-pool-min-size":: "1",
+
+    ceph +: {
+        create:: function(engine)
+            // Pre-Shared Cryptographic Material - Config-as-Code Approach
+            // These keys are generated once and distributed to all daemons
+            // This ensures cryptographic consistency across the shared-nothing architecture
+            local admin_key = "AQBpxSBlAAAAABAAU99V6D8vS7Uu9y1S8W0iBg==";
+            local mon_key = "AQBpxSBlAAAAABAAn7pL/pG9oT+X6vO7V1S6bg==";
+
+            // Ceph configuration file - rendered from Jsonnet variables
+            local ceph_conf = |||
+                [global]
+                fsid = %s
+                mon initial members = mon0
+                mon host = ceph-mon:6789
+                public network = 0.0.0.0/0
+                cluster network = 0.0.0.0/0
+                osd pool default size = %s
+                osd pool default min size = %s
+                osd crush chooseleaf type = 0
+                auth cluster required = cephx
+                auth service required = cephx
+                auth client required = cephx
+            ||| % [$["ceph-fsid"], $["ceph-pool-size"], $["ceph-pool-min-size"]];
+
+            // Admin keyring - distributed to all daemons
+            local admin_keyring = |||
+                [client.admin]
+                    key = %s
+                    caps mds = "allow *"
+                    caps mgr = "allow *"
+                    caps mon = "allow *"
+                    caps osd = "allow *"
+            ||| % [admin_key];
+
+            // Monitor keyring - used by MON for cluster operations
+            local mon_keyring = |||
+                [mon.]
+                    key = %s
+                    caps mon = "allow *"
+            ||| % [mon_key];
+
+            // Config injection command - writes files before entrypoint
+            local inject_config = "printf '%s' > /etc/ceph/ceph.conf; printf '%s' > /etc/ceph/ceph.client.admin.keyring; " % [ceph_conf, admin_keyring];
+            local inject_mon_config = inject_config + ("printf '%s' > /etc/ceph/ceph.mon.keyring; " % [mon_keyring]);
+
+            // Data volumes - sized appropriately for production workloads
+            local vol_mon = engine.volume("ceph-mon").with_size("20G");
+            local vol_mgr = engine.volume("ceph-mgr").with_size("20G");
+            local vol_osd = engine.volume("ceph-osd").with_size("100G");
+            local vol_rgw = engine.volume("ceph-rgw").with_size("20G");
+
+            // Isolated config volumes per daemon (ReadWriteOnce compatible)
+            // Each daemon gets its own non-shared config volume to support
+            // multi-node scheduling in K8s and other orchestrators
+            local vol_mon_config = engine.volume("ceph-mon-config").with_size("500M");
+            local vol_mgr_config = engine.volume("ceph-mgr-config").with_size("500M");
+            local vol_osd_config = engine.volume("ceph-osd-config").with_size("500M");
+            local vol_rgw_config = engine.volume("ceph-rgw-config").with_size("500M");
+            local vol_init_config = engine.volume("ceph-init-config").with_size("500M");
+
+            // Simplified cluster environment - Config-as-Code model
+            // No fetch logic needed - config is injected before entrypoint runs
+            local cluster_env = {
+                CLUSTER: $["ceph-cluster-id"],
+                FSID: $["ceph-fsid"],
+                KV_TYPE: "none",  // No external coordination
+            };
+
+            // MON-specific environment
+            // Config-as-Code: MON uses injected config files, not fetch logic
+            //
+            // CRITICAL: MON_DATA_AVAIL="0" forces fresh cluster bootstrap
+            // The ceph/daemon entrypoint script (variables_stack.sh) uses this as a gate:
+            // - MON_DATA_AVAIL="0" -> run mkfs, create new cluster with our FSID
+            // - MON_DATA_AVAIL="1" -> attempt to join existing cluster (infinite probe loop)
+            //
+            // Network configuration for monmap generation
+            local mon_env = cluster_env + {
+                CEPH_DAEMON: "MON",
+                MON_NAME: "mon0",
+                MON_PORT: "6789",
+                MON_DATA_AVAIL: "0",
+                MON_IP: "0.0.0.0",
+                NETWORK_AUTO_DETECT: "4",
+                CEPH_PUBLIC_NETWORK: "0.0.0.0/0",
+            };
+
+            // Simplified daemon environments - Config-as-Code model
+            // All daemons receive config via injection, not fetch from MON
+            // This eliminates "static mode" errors and networking complexity
+
+            // MGR-specific environment
+            local mgr_env = cluster_env + {
+                CEPH_DAEMON: "MGR",
+                MGR_NAME: "mgr0",
+            };
+
+            // OSD-specific environment
+            local osd_env = cluster_env + {
+                CEPH_DAEMON: "OSD",
+                OSD_TYPE: "directory",
+            };
+
+            // RGW-specific environment
+            local rgw_env = cluster_env + {
+                CEPH_DAEMON: "RGW",
+                RGW_NAME: "rgw0",
+                RGW_FRONTEND_PORT: "7480",
+            };
+
+            // MON (Monitor) container - cluster state and quorum
+            // Config-as-Code: Injects pre-shared keys before entrypoint
+            // CRITICAL: Wipes /var/lib/ceph/mon/* on every start to force fresh bootstrap
+            // This ensures MON always uses our FSID and doesn't inherit stale cluster state
+            local mon_container =
+                engine.container("ceph-mon")
+                    .with_image(images.ceph)
+                    .with_environment(mon_env)
+                    .with_command([
+                        "bash", "-c",
+                        "rm -rf /var/lib/ceph/mon/*; " +
+                        inject_mon_config +
+                        "exec /opt/ceph-container/bin/entrypoint.sh"
+                    ])
+                    .with_limits("1.0", "1536M")
+                    .with_reservations("0.5", "1024M")
+                    .with_port(6789, 6789, "mon")
+                    .with_port(3300, 3300, "mon-msgr2")
+                    .with_volume_mount(vol_mon, "/var/lib/ceph/mon")
+                    .with_volume_mount(vol_mon_config, "/etc/ceph");
+
+            // MGR (Manager) container - cluster management and dashboard
+            // Config-as-Code: Uses injected config files with pre-shared keys
+            // DNS wait ensures MON is available before MGR connects
+            local mgr_container =
+                engine.container("ceph-mgr")
+                    .with_image(images.ceph)
+                    .with_environment(mgr_env)
+                    .with_command([
+                        "bash", "-c",
+                        "until getent hosts ceph-mon; do echo 'Waiting for MON DNS...'; sleep 2; done; " +
+                        inject_config +
+                        "exec /opt/ceph-container/bin/entrypoint.sh"
+                    ])
+                    .with_limits("1.0", "1536M")
+                    .with_reservations("0.5", "1024M")
+                    .with_port(7000, 7000, "mgr")
+                    .with_port(8443, 8443, "dashboard")
+                    .with_port(9283, 9283, "prometheus")
+                    .with_volume_mount(vol_mgr, "/var/lib/ceph/mgr")
+                    .with_volume_mount(vol_mgr_config, "/etc/ceph");
+
+            // OSD (Object Storage Daemon) - actual data storage
+            // Config-as-Code: Uses injected config files with pre-shared keys
+            // Increased resources to prevent OOM during recovery operations
+            // DNS wait ensures MON is available before OSD connects
+            local osd_container =
+                engine.container("ceph-osd")
+                    .with_image(images.ceph)
+                    .with_environment(osd_env)
+                    .with_command([
+                        "bash", "-c",
+                        "until getent hosts ceph-mon; do echo 'Waiting for MON DNS...'; sleep 2; done; " +
+                        inject_config +
+                        "exec /opt/ceph-container/bin/entrypoint.sh"
+                    ])
+                    .with_limits("2.0", "4096M")
+                    .with_reservations("1.0", "2048M")
+                    .with_port(6800, 6800, "osd")
+                    .with_volume_mount(vol_osd, "/var/lib/ceph/osd")
+                    .with_volume_mount(vol_osd_config, "/etc/ceph");
+
+            // RGW (RADOS Gateway) - S3 API endpoint
+            // Config-as-Code: Uses injected config files with pre-shared keys
+            // DNS wait ensures MON is available before RGW connects
+            local rgw_container =
+                engine.container("ceph-rgw")
+                    .with_image(images.ceph)
+                    .with_environment(rgw_env)
+                    .with_command([
+                        "bash", "-c",
+                        "until getent hosts ceph-mon; do echo 'Waiting for MON DNS...'; sleep 2; done; " +
+                        inject_config +
+                        "exec /opt/ceph-container/bin/entrypoint.sh"
+                    ])
+                    .with_limits("1.0", "1536M")
+                    .with_reservations("0.5", "1024M")
+                    .with_port(7480, 7480, "s3")
+                    .with_volume_mount(vol_rgw, "/var/lib/ceph/radosgw")
+                    .with_volume_mount(vol_rgw_config, "/etc/ceph");
+
+            // Init container - one-time S3 user provisioning
+            // IMPORTANT: This container exits with code 0 after completion
+            // Orchestrator must NOT restart it (use K8s Job or Compose restart: "no")
+            // Config-as-Code: Uses injected config to run radosgw-admin commands
+            local init_container =
+                engine.container("ceph-init")
+                    .with_image(images.ceph)
+                    .with_environment({
+                        CLUSTER: $["ceph-cluster-id"],
+                        FSID: $["ceph-fsid"],
+                        KV_TYPE: "none",
+                        RGW_ACCESS_KEY: $["ceph-access-key"],
+                        RGW_SECRET_KEY: $["ceph-secret-key"],
+                    })
+                    .with_limits("0.5", "512M")
+                    .with_reservations("0.25", "256M")
+                    .with_volume_mount(vol_init_config, "/etc/ceph")
+                    .with_command([
+                        "bash", "-c",
+                        inject_config + |||
+                            set -e
+
+                            # Wait for cluster health
+                            echo "Waiting for Ceph cluster to be healthy..."
+                            MAX_ATTEMPTS=60
+                            ATTEMPT=0
+                            until ceph --cluster ${CLUSTER} health 2>/dev/null | grep -q "HEALTH_OK\|HEALTH_WARN"; do
+                                ATTEMPT=$((ATTEMPT+1))
+                                if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+                                    echo "ERROR: Cluster failed to become healthy after ${MAX_ATTEMPTS} attempts"
+                                    exit 1
+                                fi
+                                echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Cluster not ready, retrying in 5s..."
+                                sleep 5
+                            done
+                            echo "Cluster is healthy."
+
+                            # Wait for RGW availability
+                            echo "Waiting for RGW to be ready..."
+                            ATTEMPT=0
+                            until curl -sf http://ceph-rgw:7480 >/dev/null 2>&1; do
+                                ATTEMPT=$((ATTEMPT+1))
+                                if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+                                    echo "ERROR: RGW failed to become ready after ${MAX_ATTEMPTS} attempts"
+                                    exit 1
+                                fi
+                                echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: RGW not ready, retrying in 5s..."
+                                sleep 5
+                            done
+                            echo "RGW is ready."
+
+                            # Idempotent S3 user creation
+                            echo "Provisioning S3 user: ${RGW_ACCESS_KEY}"
+                            if radosgw-admin --cluster ${CLUSTER} user info --uid="${RGW_ACCESS_KEY}" >/dev/null 2>&1; then
+                                echo "User ${RGW_ACCESS_KEY} already exists, skipping creation."
+                            else
+                                echo "Creating new S3 user: ${RGW_ACCESS_KEY}"
+                                radosgw-admin --cluster ${CLUSTER} user create \
+                                    --uid="${RGW_ACCESS_KEY}" \
+                                    --display-name="Object Storage User" \
+                                    --access-key="${RGW_ACCESS_KEY}" \
+                                    --secret-key="${RGW_SECRET_KEY}"
+                                echo "S3 user created successfully."
+                            fi
+
+                            echo "Initialization complete. Exiting."
+                            exit 0
+                        |||,
+                    ]);
+
+            // Container sets - each daemon gets its own for K8s node distribution
+            local mon_containerSet = engine.containers("ceph-mon", [mon_container]);
+            local mgr_containerSet = engine.containers("ceph-mgr", [mgr_container]);
+            local osd_containerSet = engine.containers("ceph-osd", [osd_container]);
+            local rgw_containerSet = engine.containers("ceph-rgw", [rgw_container]);
+            local init_containerSet = engine.containers("ceph-init", [init_container]);
+
+            // Services - expose daemon ports for inter-daemon communication
+            local mon_service =
+                engine.internalService("ceph-mon", mon_containerSet)
+                    .with_port(6789, 6789, "mon")
+                    .with_port(3300, 3300, "mon-msgr2");
+
+            local mgr_service =
+                engine.internalService("ceph-mgr", mgr_containerSet)
+                    .with_port(7000, 7000, "mgr")
+                    .with_port(8443, 8443, "dashboard")
+                    .with_port(9283, 9283, "prometheus");
+
+            local osd_service =
+                engine.internalService("ceph-osd", osd_containerSet)
+                    .with_port(6800, 6800, "osd");
+
+            local rgw_service =
+                engine.internalService("ceph-rgw", rgw_containerSet)
+                    .with_port(7480, 7480, "s3");
+
+            engine.resources([
+
+                // Data volumes
+                vol_mon,
+                vol_mgr,
+                vol_osd,
+                vol_rgw,
+
+                // Config volumes (isolated, no sharing)
+                vol_mon_config,
+                vol_mgr_config,
+                vol_osd_config,
+                vol_rgw_config,
+                vol_init_config,
+
+                // Container sets
+                mon_containerSet,
+                mgr_containerSet,
+                osd_containerSet,
+                rgw_containerSet,
+                init_containerSet,
+
+                // Services
+                mon_service,
+                mgr_service,
+                osd_service,
+                rgw_service,
+
+            ])
+    },
+}

--- a/trustgraph_configurator/templates/2.7/backends/falkordb.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/falkordb.jsonnet
@@ -1,0 +1,40 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "falkordb" +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("falkordb").with_size("20G");
+
+            local container =
+                engine.container("falkordb")
+                    .with_image(images.falkordb)
+                    .with_user(999)
+                    .with_group(999)
+                    .with_limits("1.0", "768M")
+                    .with_reservations("0.5", "768M")
+                    .with_port(6379, 6379, "api")
+                    .with_port(3010, 3000, "ui")
+                    .with_volume_mount(vol, "/data");
+
+            local containerSet = engine.containers(
+                "falkordb", [ container ]
+            );
+
+            local service =
+                engine.internalService("falkordb", containerSet)
+                .with_port(6379, 6379, "api")
+                .with_port(3010, 3010, "ui");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+           ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/backends/garage-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/garage-cluster.jsonnet
@@ -1,0 +1,286 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// Distributed (multi-node) Garage: a primary node plus N peers forming an
+// S3-compatible cluster with real data replication.
+//
+// Slots in like a memory profile: include AFTER the garage-backed store
+// in the config. It overrides the single-node "garage" deployment's
+// create:: with a multi-node topology. The primary keeps the name
+// "garage" so url.garage (garage:3900) and the librarian/processors
+// connect unchanged; peers are garage-peer-N.
+//
+// Unlike Qdrant/Cassandra, Garage replication is a daemon-config setting
+// (replication_factor in garage.toml), so this is a pure-templates change
+// - no TrustGraph processor work needed for data to actually replicate.
+//
+// Membership is explicitly orchestrated by the garage-init container
+// (connect peers -> assign layout -> apply), so there is no gossip
+// startup race: the init script waits for every daemon before wiring the
+// cluster. Each node is placed in its own zone (dc1, dc2, ...) so the
+// replication factor can be satisfied across distinct failure domains.
+//
+// Note: replication-factor must be <= the number of nodes. The default
+// (3 nodes, factor 3) is balanced; adjust both together.
+
+{
+
+    // Point the librarian's object store at this cluster (control's
+    // object-store-params hook). Reads $.garage so it tracks cred overrides.
+    // Set here too - not just in garage.jsonnet - so importing garage-cluster
+    // on its own is a complete object-store path. Idempotent when both are
+    // imported: the value is identical.
+    "object-store-params" +:: {
+        object_store_endpoint: url.object_store,
+        object_store_access_key: $.garage["access-key"],
+        object_store_secret_key: $.garage["secret-key"],
+        object_store_region: $.garage.region,
+    },
+
+    // Number of peer nodes in addition to the primary. 2 peers -> a 3-node
+    // cluster. Top-level (not inside "garage") so it can be set from a
+    // config entry's parameters, alongside garage-replication-factor.
+    "garage-peers":: 2,
+
+    // S3 data replication factor written into garage.toml. Default 3 (3
+    // nodes -> 3-way replication). Keep <= node count (garage-peers + 1).
+    "garage-replication-factor":: 3,
+
+    garage +: {
+
+        // Garage S3 credentials (override for anything non-dev).
+        "access-key":: "GK000000000000000000000001",
+        "secret-key":: "b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427",
+        "rpc-secret":: "bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008",
+        "admin-token":: "batts-rockhearted-unpartially",
+        region:: "garage",
+
+        // Storage volume sizes (data-size also used as layout capacity).
+        "meta-size":: "2G",
+        "data-size":: "5G",
+
+        create:: function(engine)
+
+            local accessKey = self["access-key"];
+            local secretKey = self["secret-key"];
+            local rpcSecret = self["rpc-secret"];
+            local adminToken = self["admin-token"];
+            local region = self.region;
+            local replicationFactor = $["garage-replication-factor"];
+            local metaSize = self["meta-size"];
+            local dataSize = self["data-size"];
+            local peers = $["garage-peers"];
+
+            // Node 0 keeps the name "garage" (the S3 endpoint clients use);
+            // peers are garage-peer-N.
+            local nodeName = function(index)
+                if index == 0 then "garage"
+                else "garage-peer-%d" % index;
+
+            local nodeNames = [ nodeName(i) for i in std.range(0, peers) ];
+
+            // garage.toml. rpc_public_addr is per-node so peers advertise a
+            // routable address to each other.
+            local garageConf = function(publicHost) |||
+                metadata_dir = "/var/lib/garage/meta"
+                data_dir = "/var/lib/garage/data"
+
+                db_engine = "lmdb"
+
+                replication_factor = %s
+
+                compression_level = 1
+
+                rpc_bind_addr = "[::]:3901"
+                rpc_public_addr = "%s:3901"
+                rpc_secret = "%s"
+
+                [s3_api]
+                s3_region = "%s"
+                api_bind_addr = "[::]:3900"
+                root_domain = ".s3.garage.local"
+
+                [s3_web]
+                bind_addr = "[::]:3902"
+                root_domain = ".web.garage.local"
+                index = "index.html"
+
+                [k2v_api]
+                api_bind_addr = "[::]:3904"
+
+                [admin]
+                api_bind_addr = "[::]:3903"
+                admin_token = "%s"
+            ||| % [replicationFactor, publicHost, rpcSecret, region, adminToken];
+
+            // Build one Garage daemon node: own config + meta/data volumes.
+            local mkNode = function(index)
+
+                local name = nodeName(index);
+
+                local cfgVol = engine.configVolume(
+                    "garage-cfg-" + name, "garage/" + name,
+                    {
+                        "garage.toml": garageConf(name),
+                    }
+                );
+
+                local volMeta =
+                    engine.volume(name + "-meta").with_size(metaSize);
+                local volData =
+                    engine.volume(name + "-data").with_size(dataSize);
+
+                local container =
+                    engine.container(name)
+                        .with_image(images.garage)
+                        .with_user(1000)
+                        .with_group(1000)
+                        .with_command([
+                            "/garage", "-c", "/etc/garage/garage.toml",
+                            "server",
+                        ])
+                        .with_environment({
+                            RUST_LOG: "garage=info",
+                        })
+                        .with_limits("1.0", "512M")
+                        .with_reservations("0.5", "512M")
+                        .with_volume_mount(cfgVol, "/etc/garage/")
+                        .with_volume_mount(volMeta, "/var/lib/garage/meta")
+                        .with_volume_mount(volData, "/var/lib/garage/data");
+
+                local containerSet = engine.containers(name, [ container ]);
+
+                // Internal-only service. 3900 S3 / 3902 web / 3904 k2v are
+                // client ports; 3901 RPC and 3903 admin are how peers and
+                // the init container reach each node.
+                local service =
+                    engine.internalService(name, containerSet)
+                    .with_port(3900, 3900, "s3-api")
+                    .with_port(3901, 3901, "rpc")
+                    .with_port(3902, 3902, "web")
+                    .with_port(3903, 3903, "admin")
+                    .with_port(3904, 3904, "k2v");
+
+                [ cfgVol, volMeta, volData, containerSet, service ];
+
+            local nodeResources = std.flattenArrays([
+                mkNode(i)
+                for i in std.range(0, peers)
+            ]);
+
+            // Init container - connects peers, assigns the cluster layout
+            // and imports the S3 key. One-shot: exits 0 on success (the
+            // default on-failure restart won't re-run it).
+            local init_container =
+                engine.container("garage-init")
+                    .with_image("docker.io/alpine:3.23.2")
+                    .with_environment({
+                        GARAGE_ACCESS_KEY: accessKey,
+                        GARAGE_SECRET_KEY: secretKey,
+                        GARAGE_REGION: region,
+                        GARAGE_ADMIN_TOKEN: adminToken,
+                        GARAGE_RPC_SECRET: rpcSecret,
+                        GARAGE_DATA_SIZE: dataSize,
+                        // Space-separated node hostnames; node 0 is primary.
+                        GARAGE_NODES: std.join(" ", nodeNames),
+                        GARAGE_PRIMARY: "garage",
+                    })
+                    .with_limits("0.5", "256M")
+                    .with_reservations("0.25", "128M")
+                    .with_command([
+                        "sh", "-c", |||
+                            set -e
+
+                            echo "Installing curl, jq and downloading garage CLI..."
+                            apk add --no-cache curl jq
+                            curl -fsSL "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage" \
+                                -o /usr/local/bin/garage
+                            chmod +x /usr/local/bin/garage
+
+                            # Fetch a node's own ID via its Admin API.
+                            get_node_id() {
+                                curl -s -H "Authorization: Bearer ${GARAGE_ADMIN_TOKEN}" \
+                                    "http://$1:3903/v2/GetNodeInfo?node=self" \
+                                    | jq -r '.success | to_entries[0].value.nodeId'
+                            }
+
+                            # Wait for every daemon to answer on its admin port.
+                            for node in $GARAGE_NODES; do
+                                echo "Waiting for $node to be ready..."
+                                ATTEMPT=0
+                                until curl -s "http://${node}:3903/health" >/dev/null 2>&1; do
+                                    ATTEMPT=$((ATTEMPT+1))
+                                    if [ $ATTEMPT -ge 60 ]; then
+                                        echo "ERROR: $node not ready after 60 attempts"
+                                        exit 1
+                                    fi
+                                    sleep 2
+                                done
+                                echo "$node is ready."
+                            done
+
+                            PRIMARY_ID=$(get_node_id "$GARAGE_PRIMARY")
+                            if [ -z "$PRIMARY_ID" ] || [ "$PRIMARY_ID" = "null" ]; then
+                                echo "ERROR: could not get primary node ID"
+                                exit 1
+                            fi
+                            PRIMARY_RPC="${PRIMARY_ID}@${GARAGE_PRIMARY}:3901"
+                            echo "Primary RPC: ${PRIMARY_RPC}"
+
+                            # Connect every peer to the primary (idempotent).
+                            for node in $GARAGE_NODES; do
+                                [ "$node" = "$GARAGE_PRIMARY" ] && continue
+                                PEER_ID=$(get_node_id "$node")
+                                echo "Connecting peer $node (${PEER_ID})..."
+                                garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" \
+                                    node connect "${PEER_ID}@${node}:3901" || true
+                            done
+                            sleep 5
+
+                            # Assign layout once. Idempotent: skip if the
+                            # primary is already present in the layout.
+                            PRIMARY_SHORT=$(echo "$PRIMARY_ID" | cut -c1-16)
+                            LAYOUT=$(garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" layout show 2>&1 || true)
+                            if echo "$LAYOUT" | grep -q "$PRIMARY_SHORT"; then
+                                echo "Layout already assigned, skipping."
+                            else
+                                ZONE=1
+                                for node in $GARAGE_NODES; do
+                                    NID=$(get_node_id "$node")
+                                    echo "Assigning $node to zone dc${ZONE}..."
+                                    garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" \
+                                        layout assign "$NID" -z "dc${ZONE}" -c "$GARAGE_DATA_SIZE"
+                                    ZONE=$((ZONE+1))
+                                done
+                                echo "Applying layout..."
+                                garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" \
+                                    layout apply --version 1
+                                sleep 5
+                            fi
+
+                            # Import S3 key (idempotent) and grant bucket rights.
+                            if garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" key info "$GARAGE_ACCESS_KEY" >/dev/null 2>&1; then
+                                echo "Access key already exists, skipping import."
+                            else
+                                echo "Importing S3 access key ${GARAGE_ACCESS_KEY}..."
+                                garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" \
+                                    key import "$GARAGE_ACCESS_KEY" "$GARAGE_SECRET_KEY" --yes
+                            fi
+                            garage -h "$PRIMARY_RPC" -s "$GARAGE_RPC_SECRET" \
+                                key allow --create-bucket "$GARAGE_ACCESS_KEY"
+
+                            echo ""
+                            echo "Garage cluster initialization complete!"
+                            echo "S3 Endpoint: http://garage:3900 (region ${GARAGE_REGION})"
+                            exit 0
+                        |||,
+                    ]);
+
+            local init_containerSet =
+                engine.containers("garage-init", [ init_container ]);
+
+            engine.resources(nodeResources + [ init_containerSet ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/garage.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/garage.jsonnet
@@ -1,0 +1,262 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    // Point the librarian's object store at this Garage deployment by writing
+    // creds into its launch.yaml (control's object-store-params hook). Reads
+    // from $.garage so it tracks credential overrides (incl. garage-cluster).
+    "object-store-params" +:: {
+        object_store_endpoint: url.object_store,
+        object_store_access_key: $.garage["access-key"],
+        object_store_secret_key: $.garage["secret-key"],
+        object_store_region: $.garage.region,
+    },
+
+    garage +: {
+
+        // Garage S3 credentials - these are the actual access key ID and secret key
+        // Access Key ID must be in format: GK + 24 hex characters (12 bytes)
+        // Secret Key must be 64 hex characters (32 bytes)
+        // For production, generate secure random values and override these defaults
+        "access-key":: "GK000000000000000000000001",
+        "secret-key":: "b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427",
+        "rpc-secret":: "bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008",
+        // For a production system, override this value
+        "admin-token":: "batts-rockhearted-unpartially",
+        region:: "garage",
+        "replication-factor":: "1",  // Set to 1 for single-node, 3 for production
+
+        // Storage volume sizes
+        "meta-size":: "2G",    // Metadata volume size
+        "data-size":: "5G",    // Data volume size (also used for cluster layout capacity)
+
+        create:: function(engine)
+
+            local accessKey = self["access-key"];
+            local secretKey = self["secret-key"];
+            local rpcSecret = self["rpc-secret"];
+            local adminToken = self["admin-token"];
+            local region = self.region;
+            local replicationFactor = self["replication-factor"];
+            local metaSize = self["meta-size"];
+            local dataSize = self["data-size"];
+
+            // Garage daemon configuration file - TOML format
+            local garage_conf = |||
+                metadata_dir = "/var/lib/garage/meta"
+                data_dir = "/var/lib/garage/data"
+
+                db_engine = "lmdb"
+
+                replication_factor = %s
+
+                compression_level = 1
+
+                rpc_bind_addr = "[::]:3901"
+                rpc_public_addr = "[::]:3901"
+                rpc_secret = "%s"
+
+                [s3_api]
+                s3_region = "%s"
+                api_bind_addr = "[::]:3900"
+                root_domain = ".s3.garage.local"
+
+                [s3_web]
+                bind_addr = "[::]:3902"
+                root_domain = ".web.garage.local"
+                index = "index.html"
+
+                [k2v_api]
+                api_bind_addr = "[::]:3904"
+
+                [admin]
+                api_bind_addr = "[::]:3903"
+                admin_token = "%s"
+            ||| % [replicationFactor, rpcSecret, region, adminToken];
+
+            // Config volume - contains the rendered garage.toml
+            local cfgVol = engine.configVolume(
+                "garage-cfg", "garage",
+                {
+                    "garage.toml": garage_conf,
+                }
+            );
+
+            // Volumes - Garage stores metadata and data separately
+            local vol_meta = engine.volume("garage-meta").with_size(metaSize);
+            local vol_data = engine.volume("garage-data").with_size(dataSize);
+
+            // Main Garage daemon container
+            local garage_container =
+                engine.container("garage")
+                    .with_image(images.garage)
+                    .with_user(1000)
+                    .with_group(1000)
+                    .with_command([
+                        "/garage", "-c", "/etc/garage/garage.toml", "server"
+                    ])
+                    .with_environment({
+                        RUST_LOG: "garage=info",
+                    })
+                    .with_limits("1.0", "512M")
+                    .with_reservations("0.5", "512M")
+                    .with_port(3900, 3900, "s3-api")
+                    .with_port(3901, 3901, "rpc")
+                    .with_port(3902, 3902, "web")
+                    .with_port(3903, 3903, "admin")
+                    .with_port(3904, 3904, "k2v")
+                    .with_volume_mount(cfgVol, "/etc/garage/")
+                    .with_volume_mount(vol_meta, "/var/lib/garage/meta")
+                    .with_volume_mount(vol_data, "/var/lib/garage/data");
+
+            // Init container - configures cluster layout and creates S3 credentials
+            // IMPORTANT: This container exits with code 0 after completion
+            // Orchestrator must NOT restart it (use K8s Job or Compose restart: "no")
+            // Uses Alpine base image since garage container has no shell
+            local init_container =
+                engine.container("garage-init")
+                    .with_image("docker.io/alpine:3.23.2")
+                    .with_environment({
+                        GARAGE_ACCESS_KEY: accessKey,
+                        GARAGE_SECRET_KEY: secretKey,
+                        GARAGE_REGION: region,
+                        GARAGE_ADMIN_TOKEN: adminToken,
+                        GARAGE_RPC_SECRET: rpcSecret,
+                        GARAGE_DATA_SIZE: dataSize,
+                    })
+                    .with_limits("0.5", "256M")
+                    .with_reservations("0.25", "128M")
+                    .with_volume_mount(cfgVol, "/etc/garage/")
+                    .with_command([
+                        "sh", "-c", |||
+                            set -e
+
+                            # Install required tools
+                            echo "Installing curl, jq and downloading garage CLI..."
+                            apk add --no-cache curl jq
+
+                            # Download garage binary (v2.1.0) for remote management
+                            curl -fsSL "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage" \
+                                -o /usr/local/bin/garage
+                            chmod +x /usr/local/bin/garage
+
+                            echo "Waiting for Garage daemon to be ready..."
+                            MAX_ATTEMPTS=60
+                            ATTEMPT=0
+                            # Wait for /health to respond (even 503 is fine - means daemon is up)
+                            until curl -s http://garage:3903/health >/dev/null 2>&1; do
+                                ATTEMPT=$((ATTEMPT+1))
+                                if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+                                    echo "ERROR: Garage failed to become ready after ${MAX_ATTEMPTS} attempts"
+                                    exit 1
+                                fi
+                                echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Garage not ready, retrying in 2s..."
+                                sleep 2
+                            done
+                            echo "Garage daemon is ready."
+
+                            # Get the node ID via v2 Admin API
+                            echo "Getting Garage node ID via Admin API..."
+                            curl -s -H "Authorization: Bearer ${GARAGE_ADMIN_TOKEN}" \
+                                "http://garage:3903/v2/GetNodeInfo?node=self" > /tmp/garage-node-info.json
+
+                            # Extract node ID from response (the key in success map is the node ID)
+                            NODE_ID=$(jq -r '.success | to_entries[0].value.nodeId' /tmp/garage-node-info.json)
+                            echo "Node ID: ${NODE_ID}"
+
+                            if [ -z "$NODE_ID" ] || [ "$NODE_ID" = "null" ]; then
+                                echo "ERROR: Failed to retrieve node ID"
+                                exit 1
+                            fi
+
+                            # ===== LAYOUT MANAGEMENT VIA REMOTE RPC =====
+                            # Use garage CLI with -h and -s flags to connect remotely
+                            # -h requires format: <node-id>@<host>:<port>
+                            # -s provides the RPC secret
+
+                            # Construct full RPC identifier
+                            RPC_HOST="${NODE_ID}@garage:3901"
+                            echo "RPC Host: ${RPC_HOST}"
+
+                            # Check current layout to see if node is already assigned (idempotent)
+                            echo "Checking current cluster layout..."
+                            LAYOUT_OUTPUT=$(garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" layout show 2>&1)
+
+                            # Check if node already has a role assigned
+                            # Layout output shows abbreviated node ID (first 16 chars)
+                            NODE_ID_SHORT="${NODE_ID:0:16}"
+                            if echo "$LAYOUT_OUTPUT" | grep -q "$NODE_ID_SHORT"; then
+                                echo "Node ${NODE_ID_SHORT}... already assigned in layout, skipping."
+                            else
+                                echo "Assigning node to cluster layout..."
+                                # Assign node to zone dc1 with configured capacity
+                                garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" \
+                                    layout assign ${NODE_ID} -z dc1 -c ${GARAGE_DATA_SIZE}
+
+                                echo "Applying layout configuration..."
+                                # Get current staged version and apply
+                                garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" \
+                                    layout apply --version 1
+
+                                echo "Layout configured successfully."
+                                # Wait for layout to stabilize
+                                sleep 5
+                            fi
+
+                            # ===== KEY MANAGEMENT VIA REMOTE RPC =====
+
+                            # Check if key already exists (idempotent)
+                            # GARAGE_ACCESS_KEY is already a valid Garage Key ID (GK + 24 hex chars)
+                            if garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" key info "${GARAGE_ACCESS_KEY}" >/dev/null 2>&1; then
+                                echo "Access key ${GARAGE_ACCESS_KEY} already exists, skipping creation."
+                            else
+                                echo "Importing S3 access key: ${GARAGE_ACCESS_KEY}"
+
+                                # Import key with the provided credentials (both already in valid Garage format)
+                                # GARAGE_ACCESS_KEY = Key ID (GK + 24 hex chars)
+                                # GARAGE_SECRET_KEY = Secret (64 hex chars)
+                                garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" \
+                                    key import "${GARAGE_ACCESS_KEY}" "${GARAGE_SECRET_KEY}" --yes
+
+                                echo "Access key imported successfully."
+                            fi
+
+                            # Grant permissions to the key
+                            echo "Granting create-bucket permission to key..."
+                            garage -h "${RPC_HOST}" -s "${GARAGE_RPC_SECRET}" \
+                                key allow --create-bucket "${GARAGE_ACCESS_KEY}"
+
+                            echo ""
+                            echo "Garage initialization complete!"
+                            echo "S3 Endpoint: http://garage:3900"
+                            echo "Region: ${GARAGE_REGION}"
+                            exit 0
+                        |||,
+                    ]);
+
+            // Container sets
+            local garage_containerSet = engine.containers("garage", [garage_container]);
+            local init_containerSet = engine.containers("garage-init", [init_container]);
+
+            // Service - expose Garage ports
+            local garage_service =
+                engine.internalService("garage", garage_containerSet)
+                    .with_port(3900, 3900, "s3-api")
+                    .with_port(3901, 3901, "rpc")
+                    .with_port(3902, 3902, "web")
+                    .with_port(3903, 3903, "admin")
+                    .with_port(3904, 3904, "k2v");
+
+            engine.resources([
+                cfgVol,
+                vol_meta,
+                vol_data,
+                garage_containerSet,
+                init_containerSet,
+                garage_service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/memgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/memgraph.jsonnet
@@ -1,0 +1,70 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "memgraph" +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("memgraph").with_size("20G");
+
+            local container =
+                engine.container("memgraph")
+                    .with_image(images.memgraph_mage)
+                    .with_environment({
+                          MEMGRAPH: "--storage-properties-on-edges=true --storage-enable-edges-metadata=true"
+                    })
+                    .with_limits("1.0", "1000M")
+                    .with_reservations("0.5", "1000M")
+                    .with_port(7474, 7474, "api")
+                    .with_port(7687, 7687, "api2")
+                    .with_volume_mount(vol, "/var/lib/memgraph");
+
+            local containerSet = engine.containers(
+                "memgraph", [ container ]
+            );
+
+            local service =
+                engine.internalService("memgraph", containerSet)
+                .with_port(7474, 7474, "api")
+                .with_port(7687, 7687, "api2");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "memgraph-lab" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("lab")
+                    .with_image(images.memgraph_lab)
+                    .with_environment({
+                        QUICK_CONNECT_MG_HOST: "memgraph",
+                        QUICK_CONNECT_MG_PORT: "7687",
+                    })
+                    .with_limits("1.0", "512M")
+                    .with_reservations("0.5", "512M")
+                    .with_port(3010, 3000, "http");
+
+            local containerSet = engine.containers(
+                "lab", [ container ]
+            );
+
+            local service =
+                engine.internalService("memgraph", containerSet)
+                .with_port(3010, 3010, "http");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/milvus.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/milvus.jsonnet
@@ -1,0 +1,93 @@
+local images = import "values/images.jsonnet";
+local minio = import "backends/minio.jsonnet";
+
+minio {
+
+    etcd +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("etcd").with_size("20G");
+
+            local container =
+                engine.container("etcd")
+                    .with_image(images.etcd)
+                    .with_user(0)
+                    .with_group(0)
+                    .with_command([
+                        "etcd",
+                        "-advertise-client-urls=http://127.0.0.1:2379",
+                        "-listen-client-urls",
+                        "http://0.0.0.0:2379",
+                        "--data-dir",
+                        "/etcd",
+                    ])
+                    .with_environment({
+                        ETCD_AUTO_COMPACTION_MODE: "revision",
+                        ETCD_AUTO_COMPACTION_RETENTION: "1000",
+                        ETCD_QUOTA_BACKEND_BYTES: "4294967296",
+                        ETCD_SNAPSHOT_COUNT: "50000"
+                    })
+                    .with_limits("1.0", "128M")
+                    .with_reservations("0.25", "128M")
+                    .with_port(2379, 2379, "api")
+                    .with_volume_mount(vol, "/etcd");
+
+            local containerSet = engine.containers(
+                "etcd", [ container ]
+            );
+
+            local service =
+                engine.internalService("etcd", containerSet)
+                .with_port(2379, 2379, "api");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    milvus +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("milvus").with_size("20G");
+
+            local container =
+                engine.container("milvus")
+                    .with_image(images.milvus)
+                    .with_user(0)
+                    .with_group(0)
+                    .with_command([
+                        "milvus", "run", "standalone"
+                    ])
+                    .with_environment({
+                        ETCD_ENDPOINTS: "etcd:2379",
+                        MINIO_ADDRESS: "minio:9000",
+                    })
+                    .with_limits("1.0", "256M")
+                    .with_reservations("0.5", "256M")
+                    .with_port(9091, 9091, "api")
+                    .with_port(19530, 19530, "api2")
+                    .with_volume_mount(vol, "/var/lib/milvus");
+
+            local containerSet = engine.containers(
+                "milvus", [ container ]
+            );
+
+            local service =
+                engine.internalService("etcd", containerSet)
+                .with_port(9091, 9091, "api")
+                .with_port(19530, 19530, "api2");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/minio.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/minio.jsonnet
@@ -1,0 +1,50 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    minio +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("minio-data").with_size("20G");
+
+            local container =
+                engine.container("minio")
+                    .with_image(images.minio)
+                    .with_user(1000)
+                    .with_group(1000)
+                    .with_command([
+                        "minio",
+                        "server",
+                        "/minio_data",
+                        "--console-address",
+                        ":9001",
+                    ])
+                    .with_environment({
+                        MINIO_ROOT_USER: "minioadmin",
+                        MINIO_ROOT_PASSWORD: "minioadmin",
+                    })
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.25", "128M")
+                    .with_port(9000, 9000, "api")
+                    .with_port(9001, 9001, "console")
+                    .with_volume_mount(vol, "/minio_data");
+
+            local containerSet = engine.containers(
+                "minio", [ container ]
+            );
+
+            local service =
+                engine.internalService("minio", containerSet)
+                .with_port(9000, 9000, "api")
+                .with_port(9001, 9001, "console");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/neo4j.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/neo4j.jsonnet
@@ -1,0 +1,48 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "neo4j" +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("neo4j").with_size("20G");
+
+            local container =
+                engine.container("neo4j")
+                    .with_image(images.neo4j)
+                    .with_user(7474)
+                    .with_group(7474)
+                    .with_environment({
+                        NEO4J_AUTH: "neo4j/password",
+                        NEO4J_server_memory_pagecache_size: "512m",
+                        NEO4J_server_memory_heap_max__size: "512m",
+        //		NEO4J_server_bolt_listen__address: "0.0.0.0:7687",
+        //		NEO4J_server_default__listen__address: "0.0.0.0",
+        //		NEO4J_server_http_listen__address: "0.0.0.0:7474",
+                    })
+                    .with_limits("1.0", "1536M")
+                    .with_reservations("0.5", "1536M")
+                    .with_port(7474, 7474, "api")
+                    .with_port(7687, 7687, "api2")
+                    .with_volume_mount(vol, "/data");
+
+            local containerSet = engine.containers(
+                "neo4j", [ container ]
+            );
+
+            local service =
+                engine.internalService("neo4j", containerSet)
+                .with_port(7474, 7474, "api")
+                .with_port(7687, 7687, "api2");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+           ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/backends/object-store-s3.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/object-store-s3.jsonnet
@@ -1,0 +1,30 @@
+// External S3-compatible object store (AWS S3, Cloudflare R2, managed MinIO,
+// etc.). Deploys nothing - it only populates control's object-store-secrets
+// hook so the librarian reads every setting from env-var secrets supplied at
+// deploy time. It sets no object-store-params, so launch.yaml stays free of
+// object_store_* and the librarian falls through to its env-var path.
+//
+//   OBJECT_STORE_ENDPOINT    OBJECT_STORE_ACCESS_KEY
+//   OBJECT_STORE_SECRET_KEY  OBJECT_STORE_REGION    OBJECT_STORE_USE_SSL
+//
+// Fail-secure: nothing is baked into the rendered config. If the secret /
+// environment is not supplied at deploy, the librarian has no credentials and
+// denies access. Wire these via a K8s Secret named "object-store" (keys
+// endpoint / access-key / secret-key / region / use-ssl), compose env, or the
+// equivalent ACA secret refs.
+//
+// Mutually exclusive with garage / garage-cluster - import exactly one object
+// store backend.
+
+// The map is ENV_VAR -> secret-key; control builds the env-var secrets from
+// it (Secret named "object-store" with these keys).
+
+{
+    "object-store-secrets" +:: {
+        OBJECT_STORE_ENDPOINT: "endpoint",
+        OBJECT_STORE_ACCESS_KEY: "access-key",
+        OBJECT_STORE_SECRET_KEY: "secret-key",
+        OBJECT_STORE_REGION: "region",
+        OBJECT_STORE_USE_SSL: "use-ssl",
+    },
+}

--- a/trustgraph_configurator/templates/2.7/backends/pinecone.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/pinecone.jsonnet
@@ -1,0 +1,45 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "pinecone" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("pinecone")
+                    .with_image(images.pinecone)
+                    .with_environment({
+
+                        PORT: "5080",
+
+                        INDEX_TYPE: "serverless",
+
+                        // Dimension is fixed, 384 is right for miniLM
+                        // sentence embedding
+                        DIMENSION: 384,
+
+                        METRIC: "cosine"
+
+                    })
+                    .with_limits("1.0", "256M")
+                    .with_reservations("0.5", "256M")
+                    .with_port(5080, 5080, "api");
+
+            local containerSet = engine.containers(
+                "pinecone", [ container ]
+            );
+
+            local service =
+                engine.internalService("pinecone", containerSet)
+                .with_port(5080, 5080, "api");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/backends/qdrant-cluster.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/qdrant-cluster.jsonnet
@@ -1,0 +1,109 @@
+local images = import "values/images.jsonnet";
+
+// Distributed (multi-node) Qdrant: one bootstrap node plus N peers,
+// forming a Raft consensus cluster.
+//
+// Slots in like a memory profile: include AFTER vector-store-qdrant in
+// the config. It overrides the single-node "qdrant" deployment's
+// create:: with a multi-node topology. The storage/query processors are
+// untouched and keep addressing host "qdrant" on 6333 (url.qdrant), so
+// node 0 deliberately keeps the name "qdrant".
+//
+// Enabling cluster mode forms Raft consensus; the embedding-store WRITE
+// processors then create collections with the shard_number /
+// replication_factor below so data is sharded and replicated across the
+// ring. Both default to the ring size; keep replication_factor <= node
+// count if you change peers.
+
+{
+
+    // Number of peer nodes in addition to the bootstrap node. 2 peers ->
+    // a 3-node cluster (sensible quorum). Top-level (not inside "qdrant")
+    // so it can be set from a config entry's parameters, alongside
+    // qdrant-replication-factor / qdrant-shard-number.
+    "qdrant-peers":: 2,
+
+    // Collection geometry the write processors apply when creating
+    // collections. Ring size = default 2 peers + bootstrap = 3. Overrides
+    // the single-node defaults of 1 from qdrant.jsonnet. Keep <= node count
+    // if you change qdrant-peers.
+    "qdrant-replication-factor":: 3,
+    "qdrant-shard-number":: 3,
+
+    "qdrant" +: {
+
+        // Memory settings (can be overridden by memory-profile)
+        "memory-limit":: "1024M",
+        "memory-reservation":: "1024M",
+
+        create:: function(engine)
+
+            local memLimit = self["memory-limit"];
+            local memReserv = self["memory-reservation"];
+            local peers = $["qdrant-peers"];
+
+            // P2P/consensus endpoint of the bootstrap node (node 0).
+            local bootstrapUri = "http://qdrant:6335";
+
+            // Build a single Qdrant node. Node 0 is the bootstrap node
+            // and keeps the name "qdrant" so url.qdrant keeps resolving;
+            // peers are qdrant-peer-N.
+            local mkNode = function(index)
+
+                local isBootstrap = index == 0;
+                local name =
+                    if isBootstrap then "qdrant"
+                    else "qdrant-peer-%d" % index;
+                local selfUri = "http://%s:6335" % name;
+
+                local vol = engine.volume(name).with_size("20G");
+
+                // --uri tells peers how to reach this node; the bootstrap
+                // node must supply it. Peers also pass --bootstrap to
+                // discover the cluster.
+                local entrypoint =
+                    if isBootstrap then
+                        [ "./qdrant", "--uri", selfUri ]
+                    else
+                        [
+                            "./qdrant",
+                            "--bootstrap", bootstrapUri,
+                            "--uri", selfUri,
+                        ];
+
+                local container =
+                    engine.container(name)
+                        .with_image(images.qdrant)
+                        .with_user(1000)
+                        .with_group(1000)
+                        .with_environment({
+                            QDRANT__CLUSTER__ENABLED: "true",
+                        })
+                        .with_entrypoint(entrypoint)
+                        .with_limits("1.0", memLimit)
+                        .with_reservations("0.5", memReserv)
+                        .with_volume_mount(vol, "/qdrant/storage");
+
+                local containerSet = engine.containers(name, [ container ]);
+
+                // Internal-only service. 6333 REST / 6334 gRPC are the
+                // client ports; 6335 is the P2P/consensus channel and
+                // must stay internal.
+                local service =
+                    engine.internalService(name, containerSet)
+                    .with_port(6333, 6333, "api")
+                    .with_port(6334, 6334, "api2")
+                    .with_port(6335, 6335, "p2p");
+
+                [ vol, containerSet, service ];
+
+            local nodes = std.flattenArrays([
+                mkNode(i)
+                for i in std.range(0, peers)
+            ]);
+
+            engine.resources(nodes)
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/backends/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.7/backends/qdrant.jsonnet
@@ -1,0 +1,74 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    // Collection geometry applied by the embedding-store WRITE processors when
+    // they create collections. Both default to 1 (single node); qdrant-cluster
+    // raises them to the ring size. The writers fold these into the
+    // qdrant_replication_factor / qdrant_shard_number launch params.
+    "qdrant-replication-factor":: 1,
+    "qdrant-shard-number":: 1,
+
+    "qdrant" +: {
+
+        // Memory settings (can be overridden by memory-profile)
+        "memory-limit":: "1024M",
+        "memory-reservation":: "1024M",
+
+        // Mmap settings for low-memory mode (trades latency for memory)
+        // Set to null to disable, or string value to enable
+        "memmap-threshold-kb":: null,
+        "on-disk-payload":: null,
+
+        create:: function(engine)
+
+            // Capture memory settings into locals
+            local memLimit = self["memory-limit"];
+            local memReserv = self["memory-reservation"];
+            local mmapThreshold = self["memmap-threshold-kb"];
+            local onDiskPayload = self["on-disk-payload"];
+
+            local vol = engine.volume("qdrant").with_size("20G");
+
+            // Build environment with optional mmap settings
+            local baseEnv = {};
+            local env = baseEnv
+                + (if mmapThreshold != null then {
+                    QDRANT__STORAGE__MEMMAP_THRESHOLD_KB: mmapThreshold,
+                } else {})
+                + (if onDiskPayload != null then {
+                    QDRANT__STORAGE__ON_DISK_PAYLOAD: onDiskPayload,
+                } else {});
+
+            local container =
+                engine.container("qdrant")
+                    .with_image(images.qdrant)
+                    .with_user(1000)
+                    .with_group(1000)
+                    .with_limits("1.0", memLimit)
+                    .with_reservations("0.5", memReserv)
+                    .with_port(6333, 6333, "api")
+                    .with_port(6334, 6334, "api2")
+                    .with_volume_mount(vol, "/qdrant/storage")
+                    + (if std.length(env) > 0 then {
+                        environment+: env,
+                    } else {});
+
+            local containerSet = engine.containers(
+                "qdrant", [ container ]
+            );
+
+            local service =
+                engine.internalService("qdrant", containerSet)
+                .with_port(6333, 6333, "api")
+                .with_port(6334, 6334, "api2");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/components.jsonnet
+++ b/trustgraph_configurator/templates/2.7/components.jsonnet
@@ -1,0 +1,130 @@
+{
+
+   // Essentials
+   "trustgraph-base": import "core/trustgraph.jsonnet",
+   "rev-gateway": import "core/rev-gateway.jsonnet",
+   "pulsar": import "pubsub/pulsar.jsonnet",
+   "rabbitmq": import "pubsub/rabbitmq.jsonnet",
+   "kafka": import "pubsub/kafka.jsonnet",
+
+   // LLMs
+   "azure": import "llm/azure.jsonnet",
+   "azure-openai": import "llm/azure-openai.jsonnet",
+   "bedrock": import "llm/bedrock.jsonnet",
+   "claude": import "llm/claude.jsonnet",
+   "cohere": import "llm/cohere.jsonnet",
+   "googleaistudio": import "llm/googleaistudio.jsonnet",
+   "llamafile": import "llm/llamafile.jsonnet",
+   "lmstudio": import "llm/lmstudio.jsonnet",
+   "mistral": import "llm/mistral.jsonnet",
+   "ollama": import "llm/ollama.jsonnet",
+   "openai": import "llm/openai.jsonnet",
+   "vertexai": import "llm/vertexai.jsonnet",
+   "tgi": import "llm/tgi.jsonnet",
+   "vllm": import "llm/vllm.jsonnet",
+
+   // Embeddings
+   "embeddings-ollama": import "embeddings/embeddings-ollama.jsonnet",
+   "embeddings-hf": import "embeddings/embeddings-hf.jsonnet",
+   "embeddings-fastembed": import "embeddings/embeddings-fastembed.jsonnet",
+
+   // OCR options
+   "ocr": import "ocr/ocr.jsonnet",
+   "mistral-ocr": import "ocr/mistral-ocr.jsonnet",
+
+   // Vector stores
+   "vector-store-milvus": import "vector-store/milvus.jsonnet",
+   "vector-store-qdrant": import "vector-store/qdrant.jsonnet",
+   "vector-store-pinecone": import "vector-store/pinecone.jsonnet",
+
+   // Object store (S3-compatible) for the librarian. Import exactly one of
+   // these to select how the librarian gets its object store.
+   "garage": import "backends/garage.jsonnet",
+
+   // Distributed Garage override (include AFTER garage)
+   "garage-cluster": import "backends/garage-cluster.jsonnet",
+
+   // External S3-compatible store (AWS S3, R2, managed MinIO, ...). Deploys
+   // nothing; wires the librarian to read creds from env-var secrets.
+   "object-store-s3": import "backends/object-store-s3.jsonnet",
+
+   // Distributed Qdrant override (include AFTER vector-store-qdrant)
+   "qdrant-cluster": import "backends/qdrant-cluster.jsonnet",
+
+   // Triples stores
+   "triple-store-cassandra": import "triple-store/cassandra.jsonnet",
+   "triple-store-neo4j": import "triple-store/neo4j.jsonnet",
+   "triple-store-falkordb": import "triple-store/falkordb.jsonnet",
+   "triple-store-memgraph": import "triple-store/memgraph.jsonnet",
+
+   // Row stores
+   "row-store-cassandra": import "row-store/cassandra.jsonnet",
+
+   // Self-hosted Cassandra (single node). List this to deploy it; consumers
+   // talk to host "cassandra". Mutually exclusive with cassandra-external.
+   "cassandra": import "backends/cassandra.jsonnet",
+
+   // Distributed Cassandra override (include AFTER the cassandra store)
+   "cassandra-cluster": import "backends/cassandra-cluster.jsonnet",
+
+   // External (managed/secured) Cassandra: deploys nothing, supplies
+   // connection via env secrets. Mutually exclusive with cassandra-cluster.
+   "cassandra-external": import "backends/cassandra-external.jsonnet",
+
+   // Observability support
+   "grafana": import "monitoring/grafana.jsonnet",
+   "loki": import "monitoring/loki.jsonnet",
+
+   // Pulsar manager is a UI for Pulsar.  Uses a LOT of memory
+   "pulsar-manager": import "pulsar/pulsar-manager.jsonnet",
+
+   "override-recursive-chunker": import "core/chunker-recursive.jsonnet",
+
+   // The prompt manager
+   "prompt-overrides": import "core/prompt-overrides.jsonnet",
+
+   // Extra MCP services
+   "ddg-mcp-server": import "mcp/ddg-mcp-server.jsonnet",
+
+   // Optional MCP server
+   "mcp-server": import "core/mcp-server.jsonnet",
+
+   // RBAC IAM: switches control to enterprise image with RBAC processor
+   "rbac-iam": import "core/rbac-iam.jsonnet",
+
+   // Does nothing.  But, can be a hack to overwrite parameters
+   "null": {},
+
+   // Merges incoming parameters into the top-level 'parameters' object.
+   "override": {
+       with_params:: function(pars)
+           { parameters +:: pars },
+   },
+
+   // Memory profiles
+   "memory-profile-low": import "profiles/memory-profile-low.jsonnet",
+
+   // Model hosting
+
+   "hosting-intel-battlemage-vllm":
+       import "model-hosting/intel-battlemage-vllm.jsonnet",
+
+   "hosting-cpu-tgi":
+       import "model-hosting/cpu-tgi.jsonnet",
+
+   "hosting-intel-xpu-tgi":
+       import "model-hosting/intel-xpu-tgi.jsonnet",
+
+   "hosting-intel-gaudi-tgi":
+       import "model-hosting/intel-gaudi-tgi.jsonnet",
+
+   "hosting-intel-xpu-vllm":
+       import "model-hosting/intel-xpu-vllm.jsonnet",
+
+   "hosting-intel-gaudi-vllm":
+       import "model-hosting/intel-gaudi-vllm.jsonnet",
+
+   "hosting-nvidia-gpu-vllm":
+       import "model-hosting/nvidia-gpu-vllm.jsonnet",
+
+}

--- a/trustgraph_configurator/templates/2.7/core/api-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/api-gateway.jsonnet
@@ -1,0 +1,77 @@
+// External HTTP/WebSocket API gateway processor definition.
+
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "api-gateway-port": 8088,
+        "api-gateway-timeout": 600,
+        "api-gateway-cpu-limit": "0.5",
+        "api-gateway-cpu-reservation": "0.1",
+        "api-gateway-memory-limit": "512M",
+        "api-gateway-memory-reservation": "512M",
+        "api-gateway-replicas": 1,
+        "api-gateway-external": true,
+    },
+
+    "api-gateway" +: {
+
+        local pars = $.parameters,
+
+        local logLevel = pars["log-level"],
+        local port = pars["api-gateway-port"],
+        local timeout = pars["api-gateway-timeout"],
+        local cpuLimit = pars["api-gateway-cpu-limit"],
+        local cpuReservation = pars["api-gateway-cpu-reservation"],
+        local memoryLimit = pars["api-gateway-memory-limit"],
+        local memoryReservation = pars["api-gateway-memory-reservation"],
+        local replicas = pars["api-gateway-replicas"],
+        local external = pars["api-gateway-external"],
+
+        create:: function(engine)
+
+            local container =
+                engine.container("api-gateway")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "api-gateway",
+                    ] + $["pub-sub-args"] + [
+                        "--timeout",
+                        std.toString(timeout),
+                        "--port",
+                        std.toString(port),
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation)
+                    .with_port(port, port, "api");
+
+            local containerSet = engine.containers(
+                "api-gateway", [ container ]
+            ).with_replicas(replicas);
+
+            local svc =
+                if external then
+                    engine.service("api-gateway", containerSet)
+                else
+                    engine.internalService("api-gateway", containerSet);
+
+            local service = svc
+                .with_port(port, port, "api")
+                ;
+
+            local metrics =
+                engine.internalService("api-gateway-metrics", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+                metrics,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/core/control.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/control.jsonnet
@@ -1,0 +1,286 @@
+// Control-plane processors: flow orchestration and librarian service.
+
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// Reads the Cassandra hooks ($["cassandra-env-secrets"] / -replication-factor)
+// off the merged config; whichever Cassandra backend is listed supplies them.
+
+{
+
+    parameters +:: {
+        "control-cpu-limit": "0.5",
+        "control-cpu-reservation": "0.1",
+        "control-memory-limit": "256M",
+        "control-memory-reservation": "256M",
+        "control-replicas": 1,
+    },
+
+    // S3-compatible object store the librarian talks to. Fail-secure hooks,
+    // empty by default: no params and no secrets means the librarian gets no
+    // credentials and denies (fail-closed). An object-store backend component
+    // populates one. control does NOT know which backends exist or how they
+    // work - it just merges whatever was populated.
+    //
+    // Both use +:: (merge, not replace) so these empty defaults never clobber
+    // a backend's value regardless of component order in the config list.
+    //
+    //   object-store-params  - map merged into the librarian's launch.yaml
+    //                          params (an embedded store, e.g. garage, owns
+    //                          its creds).
+    //   object-store-secrets - map of ENV_VAR -> secret-key. control builds
+    //                          the deploy-time env-var secrets from it (an
+    //                          external store, e.g. object-store-s3). Empty
+    //                          means no env secrets.
+    "object-store-params" +:: {},
+    "object-store-secrets" +:: {},
+
+    "control" +: {
+
+        "control-image":: images.trustgraph_flow,
+        "iam-processor-class":: "trustgraph.iam.service.Processor",
+
+        local pars = $.parameters,
+
+        local logLevel = pars["log-level"],
+        local cpuLimit = pars["control-cpu-limit"],
+        local cpuReservation = pars["control-cpu-reservation"],
+        local memoryLimit = pars["control-memory-limit"],
+        local memoryReservation = pars["control-memory-reservation"],
+        local replicas = pars["control-replicas"],
+
+        local controlImage = self["control-image"],
+        local iamProcessorClass = self["iam-processor-class"],
+        local imagePullSecret =
+            if std.objectHasAll(self, "image-pull-secret")
+            then self["image-pull-secret"]
+            else null,
+
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("iam-bootstrap-token")
+                .with_env_var("IAM_BOOTSTRAP_TOKEN", "token");
+
+            // Object-store wiring comes entirely from the hooks above. A
+            // backend populates one; if neither is set the librarian gets no
+            // credentials and denies (fail-closed). control stays agnostic.
+            // Build env secrets from the ENV_VAR -> key map; empty map (the
+            // default, or an embedded backend) means no env secrets.
+            local objectStoreEnv = $["object-store-secrets"];
+            local objectStoreSecrets =
+                if std.length(objectStoreEnv) > 0 then
+                    std.foldl(
+                        function(s, envVar)
+                            s.with_env_var(envVar, objectStoreEnv[envVar]),
+                        std.objectFields(objectStoreEnv),
+                        engine.envSecrets("object-store")
+                    )
+                else null;
+
+            // External Cassandra (cassandra-external backend) supplies the
+            // librarian/iam/config/knowledge keyspaces' connection via env
+            // secrets; null when self-hosted (host "cassandra", no auth).
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+
+            // Replication factor for the keyspaces control's processors create.
+            // Set in self-hosted mode; omitted in external mode so the
+            // CASSANDRA_REPLICATION_FACTOR env secret takes effect. control
+            // never sets cassandra_host (processor defaults to "cassandra").
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else {
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
+
+            local librarianParams = {
+                 id: "librarian",
+            } + $["object-store-params"] + $["pub-sub-params"] + cassandraParams;
+
+            local init = "trustgraph.bootstrap.initialisers";
+
+            local pulsarInit =
+                if $["pub-sub-params"].pubsub_backend == "pulsar" then [
+                    {
+                        "class": "%s.PulsarTopology" % init,
+                        "name": "pulsar-topology",
+                        "flag": "v1",
+                        "params": {
+                            "admin_url": url.pulsar_admin,
+                        }
+                    }
+                ] else [];
+
+            local initialisers = pulsarInit + [
+                {
+                    "class": "%s.TemplateSeed" % init,
+                    "name": "template-seed",
+                    "flag": "v1",
+                    "params": {
+                        "config_file": "/etc/trustgraph/template/config.json",
+                        "overwrite": false,
+                    }
+                },
+                {
+                    "class": "%s.WorkspaceInit" % init,
+                    "name": "default-workspace",
+                    "flag": "v1",
+                    "params": {
+                        "workspace": "default",
+                        "source": "template",
+                        "overwrite": false,
+                    }
+                },
+                {
+                    "class": "%s.DefaultFlowStart" % init,
+                    "name": "default-flow",
+                    "flag": "v1",
+                    "params": {
+                        "workspace": "default",
+                        "flow_id": "default",
+                        "blueprint": "everything",
+                        "description": "Default",
+                    }
+                }
+            ];
+
+            local cfgVol = engine.configVolume(
+                "control-launch-cfg", "launch/control",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.librarian.Processor",
+                                params: librarianParams,
+                            },
+                            {
+                                class: "trustgraph.config.service.Processor",
+                                params:  {
+                                    id: "config-svc",
+                                } + $["pub-sub-params"] + cassandraParams,
+                            },
+                            {
+                                class: "trustgraph.flow.service.Processor",
+                                params:  {
+                                    id: "flow-svc",
+                                } + $["pub-sub-params"] + $["pub-sub-admin-params"],
+                            },
+                            {
+                                class: "trustgraph.cores.service.Processor",
+                                params: {
+                                    id: "knowledge",
+                                } + $["pub-sub-params"] + cassandraParams,
+                            },
+                            {
+                                class: "trustgraph.storage.knowledge.store.Processor",
+                                params: {
+                                    id: "kg-store",
+                                } + $["pub-sub-params"] + cassandraParams,
+                            },
+                            {
+                                class: "trustgraph.metering.Processor",
+                                params: {
+                                    id: "metering",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.metering.Processor",
+                                params: {
+                                    id: "metering-rag",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: iamProcessorClass,
+                                params: {
+                                    id: "iam-svc",
+                                    bootstrap_mode: "token",
+                                    // Bootstrap token is set by
+                                    // IAM_BOOTSTRAP_TOKEN
+                                } + $["pub-sub-params"] + cassandraParams,
+                            },
+                            {
+                                class: "trustgraph.bootstrap.bootstrapper.Processor",
+                                "params": {
+                                    "id": "bootstrap",
+                                    "initialisers": initialisers,
+                                } + $["pub-sub-params"]
+                            },
+
+                        ]
+                    })
+		}
+            );
+
+            local templateVol = engine.configVolume(
+                "template-cfg", "trustgraph",
+		{
+                    // This is a virtual import?  Will be caught by the
+                    // wrapper
+		    "config.json": importstr "trustgraph/config.json",
+		}
+            );
+
+            local baseContainerNoSecret =
+                engine.container("control")
+                    .with_image(controlImage)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch/launch.yaml"
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_volume_mount(
+                        cfgVol, "/etc/trustgraph/launch/"
+                    )
+                    .with_volume_mount(
+                        templateVol, "/etc/trustgraph/template/"
+                    )
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local baseContainer =
+                if imagePullSecret != null then
+                    baseContainerNoSecret
+                        .with_image_pull_secret(imagePullSecret)
+                else baseContainerNoSecret;
+
+            // Attach object-store and Cassandra env secrets only if a backend
+            // populated them.
+            local containerWithObjectStore =
+                if objectStoreSecrets != null then
+                    baseContainer.with_env_var_secrets(objectStoreSecrets)
+                else baseContainer;
+
+            local container =
+                if cassandraSecrets != null then
+                    containerWithObjectStore.with_env_var_secrets(cassandraSecrets)
+                else containerWithObjectStore;
+
+            local containerSet = engine.containers(
+                "control", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("control", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources(
+                [
+                    envSecrets,
+                    cfgVol,
+                    templateVol,
+                    containerSet,
+                    service,
+                ]
+                + (if objectStoreSecrets != null then [ objectStoreSecrets ]
+                   else [])
+                + (if cassandraSecrets != null then [ cassandraSecrets ]
+                   else [])
+            )
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/core/document-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/document-decoder.jsonnet
@@ -1,0 +1,57 @@
+// Document decoder processor — turns uploaded files (PDF, etc.)
+// into the text representation consumed by the ingest pipeline.
+
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "document-decoder-cpu-limit": "0.5",
+        "document-decoder-cpu-reservation": "0.1",
+        "document-decoder-memory-limit": "1400M",
+        "document-decoder-memory-reservation": "1400M",
+        "document-decoder-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "document-decoder" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["document-decoder-cpu-limit"],
+        local cpuReservation = pars["document-decoder-cpu-reservation"],
+        local memoryLimit = pars["document-decoder-memory-limit"],
+        local memoryReservation = pars["document-decoder-memory-reservation"],
+        local replicas = pars["document-decoder-replicas"],
+
+        create:: function(engine)
+
+            local container =
+                engine.container("document-decoder")
+                    .with_image(images.trustgraph_unstructured)
+                    .with_command([
+                        "universal-decoder",
+                    ] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "document-decoder", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("document-decoder", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/core/ingest.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/ingest.jsonnet
@@ -1,0 +1,133 @@
+// Document ingest pipeline: loaders and pre-processing that feed
+// the extraction and embedding stages.
+
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    parameters +:: {
+        "kg-extract-definitions-concurrency": 1,
+        "kg-extract-ontology-concurrency": 1,
+        "kg-extract-relationships-concurrency": 1,
+        "kg-extract-rows-concurrency": 1,
+        "prompt-concurrency": 1,
+        "ingest-cpu-limit": "0.5",
+        "ingest-cpu-reservation": "0.1",
+        "ingest-memory-limit": "256M",
+        "ingest-memory-reservation": "256M",
+        "ingest-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "ingest" +: {
+
+        "chunk-size":: 2000,
+        "chunk-overlap":: 100,
+
+        local pars = $.parameters,
+
+        local exDefinitionsConc =
+            pars["kg-extract-definitions-concurrency"],
+        local exOntologyConc =
+            pars["kg-extract-ontology-concurrency"],
+        local exRelationshipsConc =
+            pars["kg-extract-relationships-concurrency"],
+        local exRowsConc =
+            pars["kg-extract-rows-concurrency"],
+        local promptConcurrency =
+            pars["prompt-concurrency"],
+        local cpuLimit = pars["ingest-cpu-limit"],
+        local cpuReservation = pars["ingest-cpu-reservation"],
+        local memoryLimit = pars["ingest-memory-limit"],
+        local memoryReservation = pars["ingest-memory-reservation"],
+        local replicas = pars["ingest-replicas"],
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "ingest-launch-cfg", "launch/ingest",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.chunking.recursive.Processor",
+                                params: {
+                                    id: "chunker",
+                                    "chunk_size": $["ingest"]["chunk-size"],
+                                    "chunk_overlap": $["ingest"]["chunk-overlap"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.extract.kg.definitions.Processor",
+                                params:  {
+                                    id: "kg-extract-definitions",
+                                    concurrency: exDefinitionsConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.extract.kg.ontology.Processor",
+                                params: {
+                                    id: "kg-extract-ontology",
+                                    concurrency: exOntologyConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.extract.kg.relationships.Processor",
+                                params: {
+                                    id: "kg-extract-relationships",
+                                    concurrency: exRelationshipsConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.extract.kg.rows.Processor",
+                                params: {
+                                    id: "kg-extract-rows",
+                                    concurrency: exRowsConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.prompt.template.Processor",
+                                params: {
+                                    id: "prompt",
+                                    concurrency: promptConcurrency,
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local container =
+                engine.container("ingest")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "ingest", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("ingest", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/core/mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/mcp-server.jsonnet
@@ -1,0 +1,59 @@
+// MCP (Model Context Protocol) server processor — exposes
+// TrustGraph tools to MCP-capable clients.
+
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    parameters +:: {
+        "mcp-server-port": 8000,
+        "mcp-server-cpu-limit": "0.5",
+        "mcp-server-cpu-reservation": "0.1",
+        "mcp-server-memory-limit": "256M",
+        "mcp-server-memory-reservation": "256M",
+        "mcp-server-replicas": 1,
+    },
+
+    "mcp-server" +: {
+
+        local pars = $.parameters,
+
+        local port = pars["mcp-server-port"],
+        local cpuLimit = pars["mcp-server-cpu-limit"],
+        local cpuReservation = pars["mcp-server-cpu-reservation"],
+        local memoryLimit = pars["mcp-server-memory-limit"],
+        local memoryReservation = pars["mcp-server-memory-reservation"],
+        local replicas = pars["mcp-server-replicas"],
+
+        create:: function(engine)
+
+            local container =
+                engine.container("mcp-server")
+                    .with_image(images.trustgraph_mcp)
+                    .with_command([
+                        "mcp-server",
+                        "--port",
+                        std.toString(port),
+                    ])
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation)
+                    .with_port(port, port, "mcp");
+
+            local containerSet = engine.containers(
+                "mcp-server", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("mcp-server", containerSet)
+                .with_port(port, port, "mcp");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/core/prompt-overrides.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/prompt-overrides.jsonnet
@@ -1,0 +1,27 @@
+// Helpers for overriding individual prompt templates from the
+// default set without copying the full default-prompts.jsonnet.
+
+local default_prompts = import "prompts/default-prompts.jsonnet";
+
+{
+
+    with:: function(key, value)
+        if (key == "system-template") then
+            self + {
+                prompts +:: {
+                    "system-template": value,
+                }
+            }
+        else
+            self + {
+                prompts +:: {
+                    templates +:: {
+                        [key] +:: {
+                            prompt: value
+                        }
+                    }
+                }
+            },
+
+} + default_prompts
+

--- a/trustgraph_configurator/templates/2.7/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/rag.jsonnet
@@ -1,0 +1,163 @@
+// RAG query path: graph- and document-RAG processors plus their
+// supporting prompt / LLM interfaces.
+
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    parameters +:: {
+        "graph-rag-concurrency": 1,
+        "graph-rag-entity-limit": 50,
+        "graph-rag-triple-limit": 30,
+        "graph-rag-edge-limit": 30,
+        "graph-rag-edge-score-limit": 10,
+        "graph-rag-max-subgraph-size": 100,
+        "graph-rag-max-path-length": 2,
+        "document-rag-doc-limit": 20,
+        "prompt-rag-concurrency": 1,
+        "rag-cpu-limit": "0.5",
+        "rag-cpu-reservation": "0.1",
+        "rag-memory-limit": "640M",
+        "rag-memory-reservation": "640M",
+        "rag-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "rag" +: {
+
+        local pars = $.parameters,
+
+        local graphRagConc = pars["graph-rag-concurrency"],
+        local entityLimit = pars["graph-rag-entity-limit"],
+        local tripleLimit = pars["graph-rag-triple-limit"],
+        local edgeLimit = pars["graph-rag-edge-limit"],
+        local edgeScoreLimit = pars["graph-rag-edge-score-limit"],
+        local maxSubgraphSize = pars["graph-rag-max-subgraph-size"],
+        local maxPathLength = pars["graph-rag-max-path-length"],
+        local docLimit = pars["document-rag-doc-limit"],
+        local promptRagConc = pars["prompt-rag-concurrency"],
+        local cpuLimit = pars["rag-cpu-limit"],
+        local cpuReservation = pars["rag-cpu-reservation"],
+        local memoryLimit = pars["rag-memory-limit"],
+        local memoryReservation = pars["rag-memory-reservation"],
+        local replicas = pars["rag-replicas"],
+
+        local retrieval = "trustgraph.retrieval",
+        local agentOrchestrator = "trustgraph.agent.orchestrator.Processor",
+        local graphRag = "%s.graph_rag.Processor" % retrieval,
+        local documentRag = "%s.document_rag.Processor" % retrieval,
+        local nlpQuery = "%s.nlp_query.Processor" % retrieval,
+        local structuredQuery = "%s.structured_query.Processor" % retrieval,
+        local structuredDiag = "%s.structured_diag.Processor" % retrieval,
+        local sparql = "trustgraph.query.sparql.Processor",
+        local promptProc = "trustgraph.prompt.template.Processor",
+        local mcpTool = "trustgraph.agent.mcp_tool.Service",
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "rag-launch-cfg", "launch/rag",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: agentOrchestrator,
+                                params: {
+                                    id: "agent-manager",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: graphRag,
+                                params: {
+                                    id: "graph-rag",
+                                    concurrency: graphRagConc,
+                                    entity_limit: entityLimit,
+                                    triple_limit: tripleLimit,
+                                    edge_limit: edgeLimit,
+                                    edge_score_limit: edgeScoreLimit,
+                                    max_subgraph_size: maxSubgraphSize,
+                                    max_path_length: maxPathLength,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: documentRag,
+                                params: {
+                                    id: "document-rag",
+                                    doc_limit: docLimit,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: nlpQuery,
+                                params: {
+                                    id: "nlp-query",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: structuredQuery,
+                                params: {
+                                    id: "structured-query",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: structuredDiag,
+                                params: {
+                                    id: "structured-diag",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: sparql,
+                                params: {
+                                    id: "sparql-query",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: promptProc,
+                                params: {
+                                    id: "prompt-rag",
+                                    concurrency: promptRagConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: mcpTool,
+                                params: {
+                                    id: "mcp-tool",
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local container =
+                engine.container("rag")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "rag", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("rag", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}

--- a/trustgraph_configurator/templates/2.7/core/rbac-iam.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/rbac-iam.jsonnet
@@ -1,0 +1,11 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "control" +: {
+        "control-image":: images.trustgraph_enterprise,
+        "iam-processor-class":: "trustgraph.rbac.service.Processor",
+        "image-pull-secret":: "private-registry-credentials",
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/core/rev-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/rev-gateway.jsonnet
@@ -1,0 +1,69 @@
+// Reverse gateway processor — ingress front-end that terminates
+// external connections and forwards to internal services.
+
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    parameters +:: {
+        // Invalid default — rev-gateway won't connect to anything it
+        // shouldn't until the operator sets a real relay URI.
+        "rev-gateway-token": "INVALID_TOKEN",
+        "rev-gateway-uri":
+            "wss://127.0.0.1/api/v1/relay?token=INVALID_TOKEN",
+        "rev-gateway-cpu-limit": "0.5",
+        "rev-gateway-cpu-reservation": "0.1",
+        "rev-gateway-memory-limit": "256M",
+        "rev-gateway-memory-reservation": "256M",
+    },
+
+    "rev-gateway" +: {
+
+        local pars = $.parameters,
+
+        local logLevel = pars["log-level"],
+        local uri = pars["rev-gateway-uri"],
+        local cpuLimit = pars["rev-gateway-cpu-limit"],
+        local cpuReservation = pars["rev-gateway-cpu-reservation"],
+        local memoryLimit = pars["rev-gateway-memory-limit"],
+        local memoryReservation = pars["rev-gateway-memory-reservation"],
+
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("rev-gateway-secret")
+                .with_env_var("REV_GATEWAY_SECRET", "rev-gateway-secret");
+
+            local container =
+                engine.container("rev-gateway")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "rev-gateway",
+                    ] + $["pub-sub-args"] + [
+                        "--websocket-uri",
+                        std.toString(uri),
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "rev-gateway", [ container ]
+            );
+
+            local service =
+                engine.internalService("rev-gateway", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/core/trustgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/trustgraph.jsonnet
@@ -1,0 +1,31 @@
+// Core TrustGraph assembly.
+// Composes the always-on processor set (control plane, ingest, RAG,
+// API gateway, MCP server, workbench UI, runtime config) into a
+// single object that the platform renderers consume. Individual
+// processor definitions live in sibling files in this directory.
+
+local images = import "values/images.jsonnet";
+
+local config  = import "../runtime-config/trustgraph-config.jsonnet";
+local control = import "control.jsonnet";
+local ingest = import "ingest.jsonnet";
+local rag = import "rag.jsonnet";
+local api_gateway = import "api-gateway.jsonnet";
+local document_decoder = import "document-decoder.jsonnet";
+local ui = import "../ui/trustgraph-ui.jsonnet";
+local ddg = import "mcp/ddg-mcp-server.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["trustgraph-" + key]:: value,
+        },
+
+    parameters +:: {
+        "log-level":: "INFO",
+    },
+
+} + control + ingest + rag + api_gateway + document_decoder
+  + ui + config + ddg
+

--- a/trustgraph_configurator/templates/2.7/embeddings/embeddings-fastembed.jsonnet
+++ b/trustgraph_configurator/templates/2.7/embeddings/embeddings-fastembed.jsonnet
@@ -1,0 +1,118 @@
+local images = import "values/images.jsonnet";
+local embedModels = import "parameters/embeddings-fastembed.jsonnet";
+local rerankModels = import "parameters/reranker-flashrank.jsonnet";
+
+{
+
+    parameters +:: {
+        "embeddings-concurrency": 1,
+        "embeddings-cpu-limit": "4.0",
+        "embeddings-cpu-reservation": "0.5",
+        "embeddings-memory-limit": "1500M",
+        "embeddings-memory-reservation": "1500M",
+        "reranker-concurrency": 1,
+    },
+
+    "fastembed-models":: embedModels,
+    "embeddings-models" +:: $["fastembed-models"],
+
+    "flashrank-models":: rerankModels,
+    "reranker-models" +:: $["flashrank-models"],
+
+    local logLevel = $.parameters["log-level"],
+
+    "embeddings" +: {
+
+        local pars = $.parameters,
+
+        local embeddingsConc = pars["embeddings-concurrency"],
+        local cpuLimit = pars["embeddings-cpu-limit"],
+        local cpuReservation = pars["embeddings-cpu-reservation"],
+        local memoryLimit = pars["embeddings-memory-limit"],
+        local memoryReservation = pars["embeddings-memory-reservation"],
+        local rerankerConc = pars["reranker-concurrency"],
+
+        local embeds = "trustgraph.embeddings",
+        local fastEmbedProc = "%s.fastembed.Processor" % embeds,
+        local docEmbedProc = "%s.document_embeddings.Processor" % embeds,
+        local graphEmbedProc = "%s.graph_embeddings.Processor" % embeds,
+        local rowEmbedProc = "%s.row_embeddings.Processor" % embeds,
+        local flashRankProc = "trustgraph.reranker.flashrank.Processor",
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "embeddings-launch-cfg", "launch/embeddings",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: fastEmbedProc,
+                                params: {
+                                    id: "embeddings",
+                                    concurrency: embeddingsConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: docEmbedProc,
+                                params: {
+                                    id: "document-embeddings",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: graphEmbedProc,
+                                params: {
+                                    id: "graph-embeddings",
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: rowEmbedProc,
+                                params: {
+                                    id: "row-embeddings",
+                                } + $["pub-sub-params"],
+                            },
+
+                            // FlashRank re-ranker
+                            {
+                                class: flashRankProc,
+                                params: {
+                                    id: "reranker",
+                                    concurrency: rerankerConc,
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local container =
+                engine.container("embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "embeddings", [ container ]
+            );
+
+            local service =
+                engine.internalService("embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}

--- a/trustgraph_configurator/templates/2.7/embeddings/embeddings-hf.jsonnet
+++ b/trustgraph_configurator/templates/2.7/embeddings/embeddings-hf.jsonnet
@@ -1,0 +1,48 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/embeddings-huggingface.jsonnet";
+
+{
+
+    "huggingface-embeddings-models":: models,
+
+    "embeddings-models" +:: $["huggingface-embeddings-models"],
+
+    embeddings +: {
+
+        concurrency:: 1,
+
+        create:: function(engine)
+
+            local concurrency = self.concurrency;
+
+            local container =
+                engine.container("embeddings")
+                    .with_image(images.trustgraph_hf)
+                    .with_command([
+                        "embeddings-hf",
+                    ] + $["pub-sub-args"] + [
+                        "--concurrency",
+                        std.toString(concurrency),
+                    ])
+                    .with_limits("1.0", "400M")
+                    .with_reservations("0.5", "400M");
+
+            local containerSet = engine.containers(
+                "embeddings", [ container ]
+            );
+
+            local service =
+                engine.internalService("embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/embeddings/embeddings-ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.7/embeddings/embeddings-ollama.jsonnet
@@ -1,0 +1,55 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local models = import "parameters/embeddings-ollama.jsonnet";
+
+{
+
+    local logLevel = $.parameters["log-level"],
+
+    "ollama-url":: "${OLLAMA_HOST}",
+
+    "ollama-models":: models,
+
+    "embeddings-models" +:: $["ollama-models"],
+
+    embeddings +: {
+
+        concurrency:: 1,
+
+        create:: function(engine)
+
+            local concurrency = self.concurrency;
+
+            local container =
+                engine.container("embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "embeddings-ollama",
+                    ] + $["pub-sub-args"] + [
+                        "--concurrency",
+                        std.toString(concurrency),
+                        "-r",
+                        $["ollama-url"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "embeddings", [ container ]
+            );
+
+            local service =
+                engine.internalService("embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/aca.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/aca.jsonnet
@@ -1,0 +1,750 @@
+// ARM template engine targeting Azure Container Apps (ACA).
+
+// ACA Consumption plan only accepts a fixed grid of (cpu, memory)
+// pairs where memory == cpu * 2 Gi. Patterns request values like
+// "0.5"/"128M" that don't fit; we round up to the smallest valid
+// pair that satisfies both axes.
+local acaSizes = [
+    { cpu: 0.25, memGib: 0.5 },
+    { cpu: 0.5,  memGib: 1.0 },
+    { cpu: 0.75, memGib: 1.5 },
+    { cpu: 1.0,  memGib: 2.0 },
+    { cpu: 1.25, memGib: 2.5 },
+    { cpu: 1.5,  memGib: 3.0 },
+    { cpu: 1.75, memGib: 3.5 },
+    { cpu: 2.0,  memGib: 4.0 },
+];
+
+local parseCpu = function(c)
+    if std.isNumber(c) then c
+    else if std.endsWith(c, "m") then
+        std.parseJson(std.substr(c, 0, std.length(c) - 1)) / 1000.0
+    else std.parseJson(c);
+
+// M and Mi (and G/Gi) are treated as equivalent here - the rounding
+// step absorbs the small discrepancy.
+local parseMemGib = function(m)
+    if std.isNumber(m) then m
+    else if std.endsWith(m, "Gi") then
+        std.parseJson(std.substr(m, 0, std.length(m) - 2))
+    else if std.endsWith(m, "G") then
+        std.parseJson(std.substr(m, 0, std.length(m) - 1))
+    else if std.endsWith(m, "Mi") then
+        std.parseJson(std.substr(m, 0, std.length(m) - 2)) / 1024
+    else if std.endsWith(m, "M") then
+        std.parseJson(std.substr(m, 0, std.length(m) - 1)) / 1024
+    else 0;
+
+local pickAcaSize = function(cpu, memGib)
+    local fits = std.filter(
+        function(s) s.cpu >= cpu && s.memGib >= memGib,
+        acaSizes
+    );
+    if std.length(fits) > 0 then fits[0]
+    else acaSizes[std.length(acaSizes) - 1];
+
+// ARM parameter names allow letters/digits/underscores but not
+// hyphens, so we underscore-encode the ACA secret name.
+local toArmParam = function(s) std.strReplace(s, "-", "_");
+
+{
+
+    container:: function(name)
+    {
+
+        local container = self,
+
+        name: name,
+        ports: [],
+        volumes: [],
+        bindMounts: [],
+        environment: [],
+        secretRefs: [],
+
+        with_image:: function(x) self + { image: x },
+
+        with_image_pull_secret:: function(name) self,
+
+        with_user:: function(x) self + { uid: x },
+
+        with_group:: function(x) self + { gid: x },
+
+        with_supplemental_group:: function(x) self,
+
+        with_privileged:: function(x) self,
+
+        with_command:: function(x) self + { command: x },
+
+        with_entrypoint:: function(x) self + { entrypoint: x },
+
+        with_membership:: function(group) self,
+
+        with_hostname:: function(h) self,
+
+        with_subdomain:: function(s) self,
+
+        with_environment:: function(x) self + {
+            environment: super.environment + [
+                { name: v.key, value: v.value }
+                for v in std.objectKeysValues(x)
+            ],
+        },
+
+        with_limits:: function(c, m) self + {
+            cpuLimit: c, memLimit: m,
+        },
+
+        with_reservations:: function(c, m) self + {
+            cpuReservation: c, memReservation: m,
+        },
+
+        with_volume_mount::
+            function(vol, mnt) self + {
+                volumes: super.volumes + [
+                    { volume: vol, mount: mnt }
+                ],
+            },
+
+        with_bind_mount::
+            function(src, dest) self + {
+                bindMounts: super.bindMounts + [
+                    { src: src, dest: dest }
+                ],
+            },
+
+        with_port::
+            function(src, dest, name) self + {
+                ports: super.ports + [
+                    { src: src, dest: dest, name: name }
+                ],
+            },
+
+        with_env_var_secrets:: function(vars) self + {
+            secretRefs: super.secretRefs + [
+                {
+                    envVar: v,
+                    secretRef: vars.name + "-" + vars.keyMap[v],
+                }
+                for v in vars.variables
+            ],
+        },
+
+        add:: function(replicas=1)
+            local cpuRaw =
+                if std.objectHas(container, "cpuLimit") then container.cpuLimit
+                else if std.objectHas(container, "cpuReservation") then container.cpuReservation
+                else "0.5";
+            local memRaw =
+                if std.objectHas(container, "memLimit") then container.memLimit
+                else if std.objectHas(container, "memReservation") then container.memReservation
+                else "1Gi";
+            local size = pickAcaSize(parseCpu(cpuRaw), parseMemGib(memRaw));
+            local secretEnv = [
+                { name: r.envVar, secretRef: r.secretRef }
+                for r in container.secretRefs
+            ];
+            local allEnv = container.environment + secretEnv;
+            local azureFileVolumes = [
+                {
+                    name: v.volume.name,
+                    storageType: "NfsAzureFile",
+                    storageName: v.volume.name,
+                }
+                for v in container.volumes
+                if std.objectHasAll(v.volume, "kind")
+                   && v.volume.kind == "azureFile"
+            ];
+            local azureFileDeps = [
+                "[resourceId('Microsoft.App/managedEnvironments/storages', parameters('environmentName'), '" + v.volume.name + "')]"
+                for v in container.volumes
+                if std.objectHasAll(v.volume, "kind")
+                   && v.volume.kind == "azureFile"
+            ];
+            [
+            {
+                type: "Microsoft.App/containerApps",
+                apiVersion: "2026-01-01",
+                name: container.name,
+                location: "[parameters('location')]",
+                dependsOn: [
+                    "[resourceId('Microsoft.App/managedEnvironments', parameters('environmentName'))]",
+                ] + azureFileDeps,
+                properties: {
+                    managedEnvironmentId:
+                        "[resourceId('Microsoft.App/managedEnvironments', parameters('environmentName'))]",
+                    configuration: {
+                        activeRevisionsMode: "Single",
+                    },
+                    template: {
+                        containers: [
+                            {
+                                name: container.name,
+                                image: container.image,
+                                resources: {
+                                    cpu: size.cpu,
+                                    memory: "" + size.memGib + "Gi",
+                                },
+                            } + (
+                                if std.objectHas(container, "entrypoint") then
+                                    (if std.isString(container.entrypoint) && container.entrypoint == "" then
+                                        { command: [] }
+                                    else if std.isArray(container.entrypoint) then
+                                        { command: container.entrypoint }
+                                    else
+                                        { command: [container.entrypoint] }
+                                    ) + (if std.objectHas(container, "command") then
+                                        { args:
+                                            if std.isArray(container.command)
+                                            then container.command
+                                            else [container.command]
+                                        }
+                                    else {})
+                                else if std.objectHas(container, "command") then
+                                    { command:
+                                        if std.isArray(container.command)
+                                        then container.command
+                                        else [container.command]
+                                    }
+                                else {}
+                            ) + (
+                                if std.length(allEnv) > 0 then
+                                    { env: allEnv }
+                                else {}
+                            ) + (
+                                local mounts = [
+                                    {
+                                        volumeName: v.volume.name,
+                                        mountPath: v.mount,
+                                    }
+                                    for v in container.volumes
+                                    if std.objectHasAll(v.volume, "kind")
+                                       && (v.volume.kind == "configVolume"
+                                           || v.volume.kind == "secretVolume"
+                                           || v.volume.kind == "azureFile")
+                                ];
+                                if std.length(mounts) > 0
+                                then { volumeMounts: mounts }
+                                else {}
+                            ),
+                        ],
+                        scale: {
+                            minReplicas: replicas,
+                            maxReplicas: replicas,
+                        },
+                    } + (
+                        if std.length(azureFileVolumes) > 0 then
+                            { volumes: azureFileVolumes }
+                        else {}
+                    ),
+                },
+            },
+        ],
+
+    },
+
+    // service/internalService emit sentinel markers rather than
+    // free-standing ARM resources; ACA ingress is a property of the
+    // containerApp, not a separate resource. `package()` recognises
+    // the marker and folds it into the matching containerApp before
+    // output.
+    internalService:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        ports: [],
+
+        with_port::
+            function(src, dest, name) self + {
+                ports: super.ports + [
+                    { src: src, dest: dest, name: name }
+                ],
+            },
+
+        add:: function()
+            if std.length(service.ports) == 0 then []
+            else [{
+                _aca_kind: "ingress",
+                targetApp: service.name,
+                ports: service.ports,
+                external: false,
+            }],
+
+    },
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        with_port:: function(src, dest, name) self,
+
+        with_publish_not_ready_addresses:: function() self,
+
+        add:: function() [],
+
+    },
+
+    service:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        ports: [],
+
+        with_port::
+            function(src, dest, name) self + {
+                ports: super.ports + [
+                    { src: src, dest: dest, name: name }
+                ],
+            },
+
+        add:: function()
+            if std.length(service.ports) == 0 then []
+            else [{
+                _aca_kind: "ingress",
+                targetApp: service.name,
+                ports: service.ports,
+                external: true,
+            }],
+
+    },
+
+    volume:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+        kind:: "azureFile",
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [{
+            _aca_kind: "azureFileVolume",
+            name: volume.name,
+            size: if std.objectHas(volume, "size") then volume.size else "1Gi",
+        }],
+
+        volRef:: function() { name: volume.name },
+
+    },
+
+    configVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: name,
+        kind:: "configVolume",
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [{
+            _aca_kind: "configVolume",
+            name: volume.name,
+            parts: parts,
+        }],
+
+        volRef:: function() { name: volume.name },
+
+    },
+
+    secretVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: name,
+        kind:: "secretVolume",
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [{
+            _aca_kind: "secretVolume",
+            name: volume.name,
+            parts: parts,
+        }],
+
+        volRef:: function() { name: volume.name },
+
+    },
+
+    envSecrets:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+        variables: [],
+        keyMap: {},
+
+        with_size:: function(size) self,
+
+        with_env_var::
+            function(name, key) self + {
+                variables: super.variables + [name],
+                keyMap: super.keyMap + { [name]: key },
+            },
+
+        add:: function() [],
+
+        volRef:: function() { name: volume.name },
+
+    },
+
+    containers:: function(name, containers)
+    {
+
+        local cont = self,
+
+        name: name,
+        containers: containers,
+        replicas: 1,
+
+        with_replicas:: function(n) self + { replicas: n },
+
+        add:: function() std.flattenArrays(
+            [ c.add(cont.replicas) for c in cont.containers ]
+        ),
+
+    },
+
+    resources:: function(res)
+        std.flattenArrays([ c.add() for c in res ]),
+
+    package:: function(patterns)
+        local rawList = std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local isMarker = function(r) std.objectHas(r, "_aca_kind");
+        local markers = std.filter(isMarker, rawList);
+        local arms = std.filter(function(r) !isMarker(r), rawList);
+        local ingressByApp = {
+            [m.targetApp]: m
+            for m in markers
+            if m._aca_kind == "ingress"
+        };
+        // ACA TCP ingress requires a unique exposedPort per env when
+        // exposedPort is set; we leave it unset so it defaults to
+        // targetPort. Apps with overlapping targetPorts (e.g. multiple
+        // services exposing :8000 metrics) will conflict at deploy
+        // time - that's a step-3 concern.
+        local applyIngress = function(arm)
+            if std.objectHas(arm, "type")
+               && arm.type == "Microsoft.App/containerApps"
+               && std.objectHas(ingressByApp, arm.name) then
+                local m = ingressByApp[arm.name];
+                local first = m.ports[0];
+                local rest = m.ports[1:];
+                // Extra (non-primary) ports become internal additional port
+                // mappings. The primary port is served by the ingress itself
+                // (HTTP 80/443 when external, TCP targetPort when internal) and
+                // must NOT be repeated here: ACA requires every
+                // additionalPortMappings targetPort to be distinct from the
+                // ingress targetPort. (exposedPort is left unset so it defaults
+                // to targetPort.)
+                local additionalPorts = rest;
+                arm + {
+                    properties+: {
+                        configuration+: {
+                            ingress: {
+                                external: m.external,
+                                transport: if m.external then "http" else "tcp",
+                                targetPort: first.dest,
+                            } + (
+                                if std.length(additionalPorts) > 0 then {
+                                    additionalPortMappings: [
+                                        {
+                                            external: false,
+                                            targetPort: p.dest,
+                                        }
+                                        for p in additionalPorts
+                                    ],
+                                } else {}
+                            ),
+                        },
+                    },
+                }
+            else arm;
+        // configVolume parts are mounted via ACA Secret-type volumes:
+        // each file becomes an entry in `configuration.secrets`, and a
+        // `template.volumes[]` entry of storageType=Secret references
+        // them with the original filenames as paths. Read-only mount.
+        local cfgVolByName = {
+            [m.name]: m
+            for m in markers
+            if m._aca_kind == "configVolume"
+               || m._aca_kind == "secretVolume"
+        };
+        local sanitize = function(s)
+            std.strReplace(std.strReplace(s, ".", "-"), "_", "-");
+        local applyConfigVolumes = function(arm)
+            if std.objectHas(arm, "type")
+               && arm.type == "Microsoft.App/containerApps"
+               && std.length(arm.properties.template.containers) > 0
+               && std.objectHas(
+                    arm.properties.template.containers[0], "volumeMounts"
+               ) then
+                local mounts =
+                    arm.properties.template.containers[0].volumeMounts;
+                local cfgs = [
+                    cfgVolByName[m.volumeName]
+                    for m in mounts
+                    if std.objectHas(cfgVolByName, m.volumeName)
+                ];
+                if std.length(cfgs) == 0 then arm
+                else
+                    // configVolume content stays inline; secretVolume
+                    // content is lifted into a per-file secureString
+                    // ARM parameter so the credential never sits in the
+                    // template itself.
+                    local secrets = std.flattenArrays([
+                        [
+                            {
+                                name: cfg.name + "-" + sanitize(filename),
+                                value:
+                                    if cfg._aca_kind == "secretVolume" then
+                                        "[parameters('"
+                                        + toArmParam(
+                                            cfg.name + "-" + sanitize(filename)
+                                          )
+                                        + "')]"
+                                    else cfg.parts[filename],
+                            }
+                            for filename in std.objectFields(cfg.parts)
+                        ]
+                        for cfg in cfgs
+                    ]);
+                    local volumes = [
+                        {
+                            name: cfg.name,
+                            storageType: "Secret",
+                            secrets: [
+                                {
+                                    secretRef:
+                                        cfg.name + "-" + sanitize(filename),
+                                    path: filename,
+                                }
+                                for filename in std.objectFields(cfg.parts)
+                            ],
+                        }
+                        for cfg in cfgs
+                    ];
+                    arm + {
+                        properties+: {
+                            configuration+: {
+                                secrets+: secrets,
+                            },
+                            template+: {
+                                volumes+: volumes,
+                            },
+                        },
+                    }
+            else arm;
+        // envSecrets: each container's env entry with `secretRef` is
+        // backed by a per-app entry in `configuration.secrets` whose
+        // value is an ARM-parameter reference, plus a template-level
+        // `parameters` declaration of type `secureString`. Operators
+        // supply real values at deploy time.
+        local appSecretRefs = function(arm)
+            if std.objectHas(arm, "type")
+               && arm.type == "Microsoft.App/containerApps"
+               && std.length(arm.properties.template.containers) > 0
+               && std.objectHas(
+                    arm.properties.template.containers[0], "env"
+               ) then
+                std.filter(
+                    function(e) std.objectHas(e, "secretRef"),
+                    arm.properties.template.containers[0].env
+                )
+            else [];
+        local applyEnvSecrets = function(arm)
+            local refs = appSecretRefs(arm);
+            if std.length(refs) == 0 then arm
+            else
+                local newSecrets = [
+                    {
+                        name: e.secretRef,
+                        value: "[parameters('" + toArmParam(e.secretRef) + "')]",
+                    }
+                    for e in refs
+                ];
+                arm + {
+                    properties+: {
+                        configuration+: {
+                            secrets+: newSecrets,
+                        },
+                    },
+                };
+        // AzureFile volumes are emitted directly by container.add()
+        // (template.volumes + dependsOn), so package() only needs to
+        // declare the template-scope storage account, file shares, and
+        // env-storage registrations - that happens further below.
+        local azureFileMarkers = [
+            m for m in markers
+            if m._aca_kind == "azureFileVolume"
+        ];
+        local appResources = std.map(
+            applyEnvSecrets,
+            std.map(applyConfigVolumes, std.map(applyIngress, arms))
+        );
+        local allSecretRefNames = std.set(std.flattenArrays([
+            [e.secretRef for e in appSecretRefs(arm)]
+            for arm in std.map(applyIngress, arms)
+        ]));
+        local secretParams = {
+            [toArmParam(ref)]: { type: "secureString" }
+            for ref in allSecretRefNames
+        };
+        local secretVolumeParts = std.set(std.flattenArrays([
+            [
+                m.name + "-" + sanitize(filename)
+                for filename in std.objectFields(m.parts)
+            ]
+            for m in markers
+            if m._aca_kind == "secretVolume"
+        ]));
+        local secretVolumeParams = {
+            [toArmParam(p)]: { type: "secureString" }
+            for p in secretVolumeParts
+        };
+        local externalApps = std.set([
+            m.targetApp
+            for m in markers
+            if m._aca_kind == "ingress" && m.external
+        ]);
+        local outputs = {
+            [toArmParam(app) + "_url"]: {
+                type: "string",
+                value:
+                    "[concat('https://', reference(resourceId("
+                    + "'Microsoft.App/containerApps', '"
+                    + app
+                    + "'), '2026-01-01').configuration.ingress.fqdn)]",
+            }
+            for app in externalApps
+        };
+        local quotaGib = function(s)
+            local g = parseMemGib(s);
+            if g < 100 then 100 else std.ceil(g);
+        local storageAccount =
+            if std.length(azureFileMarkers) > 0 then [{
+                type: "Microsoft.Storage/storageAccounts",
+                apiVersion: "2023-01-01",
+                name: "[parameters('storageAccountName')]",
+                location: "[parameters('location')]",
+                kind: "FileStorage",
+                sku: { name: "Premium_LRS" },
+                properties: {
+                    minimumTlsVersion: "TLS1_2",
+                    allowBlobPublicAccess: false,
+                    supportsHttpsTrafficOnly: false,
+                    networkAcls: {
+                        defaultAction: "Deny",
+                        virtualNetworkRules: [
+                            {
+                                id: "[parameters('infrastructureSubnetId')]",
+                                action: "Allow",
+                            },
+                        ],
+                    },
+                },
+            }] else [];
+        local fileShares = [
+            {
+                type: "Microsoft.Storage/storageAccounts/fileServices/shares",
+                apiVersion: "2023-01-01",
+                name: "[concat(parameters('storageAccountName'), '/default/" + m.name + "')]",
+                dependsOn: [
+                    "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                ],
+                properties: {
+                    shareQuota: quotaGib(m.size),
+                    enabledProtocols: "NFS",
+                },
+            }
+            for m in azureFileMarkers
+        ];
+        local envStorages = [
+            {
+                type: "Microsoft.App/managedEnvironments/storages",
+                apiVersion: "2026-01-01",
+                name: "[concat(parameters('environmentName'), '/" + m.name + "')]",
+                dependsOn: [
+                    "[resourceId('Microsoft.App/managedEnvironments', parameters('environmentName'))]",
+                    "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', parameters('storageAccountName'), 'default', '" + m.name + "')]",
+                ],
+                properties: {
+                    nfsAzureFile: {
+                        server: "[concat(parameters('storageAccountName'), '.file.core.windows.net')]",
+                        shareName: "[concat('/', parameters('storageAccountName'), '/" + m.name + "')]",
+                        accessMode: "ReadWrite",
+                    },
+                },
+            }
+            for m in azureFileMarkers
+        ];
+        local logAnalyticsWorkspace = {
+            type: "Microsoft.OperationalInsights/workspaces",
+            apiVersion: "2022-10-01",
+            name: "[variables('logAnalyticsWorkspaceName')]",
+            location: "[parameters('location')]",
+            properties: {
+                sku: { name: "PerGB2018" },
+                retentionInDays: 30,
+            },
+        };
+        local managedEnvironment = {
+            type: "Microsoft.App/managedEnvironments",
+            apiVersion: "2026-01-01",
+            name: "[parameters('environmentName')]",
+            location: "[parameters('location')]",
+            dependsOn: [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]",
+            ],
+            properties: {
+                vnetConfiguration: {
+                    infrastructureSubnetId: "[parameters('infrastructureSubnetId')]",
+                    internal: false,
+                },
+                appLogsConfiguration: {
+                    destination: "log-analytics",
+                    logAnalyticsConfiguration: {
+                        customerId: "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').customerId]",
+                        sharedKey: "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2022-10-01').primarySharedKey]",
+                    },
+                },
+            },
+        };
+        {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            contentVersion: "1.0.0.0",
+            parameters: {
+                location: {
+                    type: "string",
+                    defaultValue: "[resourceGroup().location]",
+                },
+                environmentName: {
+                    type: "string",
+                    defaultValue: "trustgraph-env",
+                },
+                storageAccountName: {
+                    type: "string",
+                    defaultValue: "[concat('tg', uniqueString(resourceGroup().id))]",
+                },
+                infrastructureSubnetId: {
+                    type: "string",
+                },
+            } + secretParams + secretVolumeParams,
+            variables: {
+                logAnalyticsWorkspaceName: "[concat(parameters('environmentName'), '-logs')]",
+            },
+            resources:
+                [logAnalyticsWorkspace, managedEnvironment]
+                + storageAccount + fileShares + envStorages
+                + appResources,
+            outputs: outputs,
+        },
+
+}

--- a/trustgraph_configurator/templates/2.7/engine/ack-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/ack-k8s.jsonnet
@@ -1,0 +1,73 @@
+
+local k8s = import "k8s.jsonnet";
+
+// Alibaba Cloud ACK cloud disks have a 20 GiB minimum size. The CSI driver
+// measures the floor in binary GiB, so a decimal "20G" request (~18.6 GiB) is
+// rejected. parseGib converts every unit to GiB - decimal G/M via the 1000 vs
+// 1024 ratio - so floorSize lifts anything short of 20 GiB up to "20Gi".
+local minGib = 20;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) * 1000000000 / 1073741824
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) * 1000000 / 1073741824
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "diskplugin.csi.alibabacloud.com",
+    parameters: {
+        type: "cloud_essd",
+        "csi.storage.k8s.io/fstype": "ext4",
+    },
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+};
+
+k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: resources,
+        };
+        resourceList
+
+}

--- a/trustgraph_configurator/templates/2.7/engine/aks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/aks-k8s.jsonnet
@@ -1,0 +1,45 @@
+
+local k8s = import "k8s.jsonnet";
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "disk.csi.azure.com",
+    parameters: {
+        // Standard disks (spinning magnetic), Locally Redundant Storage
+        // Cheapest, basically
+        skuName: "Standard_LRS",
+    },
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+};
+
+k8s + {
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: resources,
+        };
+        resourceList
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/compose.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/compose.jsonnet
@@ -1,0 +1,331 @@
+{
+
+    // Extract resources using the engine
+    package:: function(patterns)
+        std.foldl(
+            function(state, p) state + p.create(self),
+            std.objectValues(patterns),
+            {}
+        ),
+
+    container:: function(name)
+    {
+
+        local container = self,
+
+        name:: name,
+
+        with_image:: function(x) self + { image: x },
+
+        with_image_pull_secret:: function(name) self,
+
+        // user/group combine into compose's "uid[:gid]" string field;
+        // call order is user-then-group (a later with_user would
+        // overwrite the combined value, but patterns conventionally
+        // declare user before group).
+        with_user:: function(x) self,
+
+        with_group:: function(x) self,
+
+        with_supplemental_group:: function(x) self +
+            if std.objectHas(container, "group_add") then
+              { group_add: container.group_add + [x] }
+            else
+              { group_add: [x] },
+
+        with_command:: function(x) self + {
+            command:
+                if std.isString(x) then
+                    std.strReplace(x, "$", "$$")
+                else if std.isArray(x) then
+                    std.map(function(s) std.strReplace(s, "$", "$$"), x)
+                else
+                    x
+        },
+
+        with_entrypoint:: function(x) self + { entrypoint: x },
+
+        with_runtime:: function(x) self + { runtime: x },
+
+        with_privileged:: function(x) self + { privileged: x },
+
+        with_ipc:: function(x) self + { ipc: x },
+
+        with_capability:: function(x) self +
+            if std.objectHas(container, "capability") then
+              { cap_add: container.capability + x }
+            else
+              { cap_add: [x], },
+
+        with_membership:: function(group) self,
+
+        with_hostname:: function(h) self,
+
+        with_subdomain:: function(s) self,
+
+        with_environment:: function(x) self +
+            if std.objectHas(container, "environment") then
+              { environment: container.environment + x }
+            else
+              { environment: x, },
+
+        with_device:: function(hdev, cdev) self +
+            if std.objectHas(container, "devices") then
+              { devices: container.devices + [ "%s:%s" % [hdev, cdev] ] }
+            else
+              { devices: [ "%s:%s" % [hdev, cdev] ], },
+
+        with_limits:: function(c, m) self + {
+           deploy +: { resources +: {
+               limits: { cpus: c, memory: m }
+           } },
+        },
+
+        with_reservations:: function(c, m) self + {
+            deploy +: { resources +: {
+                reservations: { cpus: c, memory: m }
+            } },
+        },
+
+        with_volume_mount::
+            function(vol, mnt)
+                self + {
+                    volumes:
+                        if std.objectHas(container, "volumes") then
+                            container.volumes + [
+                                "%s:%s" % [vol.volid, mnt]
+                            ]
+                        else
+                            [
+                                "%s:%s" % [vol.volid, mnt]
+                            ]
+                },
+
+        with_bind_mount::
+            function(src, dest)
+                self + {
+                    volumes:
+                        if std.objectHas(container, "volumes") then
+                            container.volumes + [
+                                "%s:%s" % [src, dest]
+                            ]
+                        else
+                            [
+                                "%s:%s" % [src, dest]
+                            ]
+                },
+
+        with_port::
+            function(src, dest, name) self,
+
+        with_env_var_secrets::
+            function(vars)
+                std.foldl(
+                    function(obj, x) obj.with_environment(
+                        { [x]: "${" + x  + "}" }
+                    ),
+                    vars.variables,
+                    self
+                ),
+
+        restart: "on-failure:100",
+
+        add:: function(replicas=1) {
+            services +: {
+                [container.name]: container + (
+                    if replicas > 1 then
+                        { scale: replicas }
+                    else {}
+                ),
+            }
+        }
+
+    },
+
+    internalService:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        ports: [],
+
+        with_port:: function(src, dest, name)
+            self + {
+                ports: super.ports + [dest],
+            },
+
+        add:: function()
+            if std.length(service.ports) == 0 then {}
+            else {
+                services +: {
+                    [containers.name] +: {
+                        expose: [
+                            "%d" % [port]
+                            for port in service.ports
+                        ],
+                    },
+                },
+            },
+
+    },
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        local service = self,
+
+        ports: [],
+
+        with_port:: function(src, dest, name)
+            self + {
+                ports: super.ports + [dest],
+            },
+
+        with_publish_not_ready_addresses:: function() self,
+
+        add:: function()
+            if std.length(service.ports) == 0
+               || std.length(members) == 0 then {}
+            else {
+                services +: {
+                    [m] +: {
+                        expose: [
+                            "%d" % [port]
+                            for port in service.ports
+                        ],
+                    }
+                    for m in members
+                },
+            },
+
+    },
+
+    service:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        ports: [],
+
+        with_port:: function(src, dest, name)
+            self + {
+                ports: super.ports + [{ src: src, dest: dest }],
+            },
+
+        add:: function()
+            if std.length(service.ports) == 0 then {}
+            else {
+                services +: {
+                    [containers.name] +: {
+                        ports: [
+                            "%d:%d" % [port.src, port.dest]
+                            for port in service.ports
+                        ],
+                    },
+                },
+            },
+
+    },
+
+    volume:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        volid:: name,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() {
+            volumes +: {
+                [volume.name]: {}
+            }
+        }
+
+    },
+
+    configVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: dir,
+
+        volid:: "./" + dir,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() {
+        }
+
+    },
+
+    secretVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: dir,
+
+        volid:: dir,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() {
+        }
+
+    },
+
+    envSecrets:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        volid:: name,
+
+        variables:: [],
+
+        with_env_var::
+            function(name, key) self + {
+                variables: super.variables + [name],
+            },
+
+        add:: function() {
+        }
+
+    },
+
+    containers:: function(name, containers)
+    {
+
+        local cont = self,
+
+        name: name,
+        containers: containers,
+        replicas: 1,
+
+        with_replicas:: function(n) self + { replicas: n },
+
+        add:: function() std.foldl(
+            function(state, c) state + c.add(cont.replicas),
+            cont.containers,
+            {}
+        ),
+
+    },
+
+    resources:: function(res)
+        std.foldl(
+            function(state, c) state + c.add(),
+            res,
+            {}
+        ),
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/eks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/eks-k8s.jsonnet
@@ -1,0 +1,74 @@
+
+local k8s = import "k8s.jsonnet";
+
+// gp3 with 6000 IOPS / 400 MiB/s requires minimum 16 GiB
+// (500 IOPS-per-GiB ratio needs 12 GiB; throughput floor needs 16 GiB).
+local minGib = 16;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "ebs.csi.aws.com",
+    parameters: {
+        type: "gp3",
+        encrypted: "true",
+        iops: "6000",
+        throughput: "400",
+    },
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+};
+
+k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: resources,
+        };
+        resourceList
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/gcp-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/gcp-k8s.jsonnet
@@ -1,0 +1,71 @@
+
+local k8s = import "k8s.jsonnet";
+
+// GCP persistent disks have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "pd.csi.storage.gke.io",
+    parameters: {
+        type: "pd-balanced",
+        "csi.storage.k8s.io/fstype": "ext4",
+    },
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+};
+
+k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: resources,
+        };
+        resourceList
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/k8s.jsonnet
@@ -1,0 +1,493 @@
+{
+
+    container:: function(name)
+    {
+
+        local container = self,
+
+        name: name,
+        limits: {},
+        reservations: {},
+        ports: [],
+        volumes: [],
+        bindMounts: [],
+        supplementalGroups: [],
+        environment: [],
+        imagePullSecrets: [],
+
+        with_image:: function(x) self + { image: x },
+
+        with_image_pull_secret:: function(name) self + {
+            imagePullSecrets: super.imagePullSecrets + [name],
+        },
+
+        // k8s deliberately ignores `with_user`: the running UID is
+        // determined by the image's USER directive. `with_group(gid)`
+        // is wired to fsGroup so the kubelet chowns mounted PVCs to
+        // a GID the container can access.
+        with_user:: function(x) self,
+
+        with_group:: function(x) self + { gid: x },
+
+        with_supplemental_group:: function(x) self + {
+            supplementalGroups: super.supplementalGroups + [x],
+        },
+
+        with_privileged:: function(x) self + { privileged: x },
+
+        with_command:: function(x) self + { command: x },
+
+        with_entrypoint:: function(x) self + { entrypoint: x },
+
+        with_membership:: function(group) self + { membership: group },
+
+        with_hostname:: function(h) self + { podHostname: h },
+
+        with_subdomain:: function(s) self + { podSubdomain: s },
+
+        with_environment:: function(x) self + {
+            environment: super.environment + [
+                {
+                    name: v.key, value: v.value
+                }
+                for v in std.objectKeysValues(x)
+            ],
+        },
+
+        with_limits:: function(c, m) self + { limits: { cpu: c, memory: m } },
+
+        with_reservations::
+            function(c, m) self + { reservations: { cpu: c, memory: m } },
+
+        with_volume_mount::
+            function(vol, mnt)
+                self + {
+                    volumes: super.volumes + [{
+                        volume: vol, mount: mnt
+                    }]
+                },
+
+        with_bind_mount::
+            function(src, dest)
+                local name = "bind-" + std.strReplace(std.strReplace(src, "/", "-"), ".", "-");
+                self + {
+                    bindMounts: super.bindMounts + [{
+                        name: name, src: src, dest: dest
+                    }]
+                },
+
+        with_port::
+            function(src, dest, name) self + {
+                ports: super.ports + [
+                    { src: src, dest: dest, name : name }
+                ]
+            },
+
+        with_env_var_secrets::
+            function(vars)
+                std.foldl(
+                    function(obj, x) obj + {
+                        environment: super.environment + [{
+                            name: x,
+                            valueFrom: {
+                                secretKeyRef: {
+                                    name: vars.name,
+                                    key: vars.keyMap[x],
+                                }
+                            }
+                        }]
+                    },
+                    vars.variables,
+                    self
+                ),
+
+        add:: function(replicas=1) [
+
+                {
+                    apiVersion: "apps/v1",
+                    kind: "Deployment",
+                    metadata: {
+                        name: container.name,
+                        namespace: "trustgraph",
+                        labels: {
+                            app: container.name
+                        }
+                    },
+                    spec: {
+                        replicas: replicas,
+                        selector: {
+                            matchLabels: {
+                                app: container.name,
+                            }
+                        },
+                        template: {
+                            metadata: {
+                                labels: {
+                                    app: container.name,
+                                } + (
+                                    if std.objectHas(container, "membership")
+                                    then { membership: container.membership }
+                                    else {}
+                                ),
+                            },
+                            spec: {
+                                enableServiceLinks: false,
+                                containers: [
+                                    {
+                                        name: container.name,
+                                        image: container.image,
+
+                                        resources: {
+                                            requests: container.reservations,
+                                            limits: container.limits
+                                        },
+                                    } + (
+                                        if std.objectHas(container, "privileged") && container.privileged then
+                                        { securityContext: { privileged: true } }
+                                        else {}
+                                    ) + (
+                                    if std.length(container.ports) > 0 then
+                                    {
+                                        ports:  [
+                                            {
+                                                hostPort: port.src,
+                                                containerPort: port.dest,
+                                            }
+                                            for port in container.ports
+                                        ]
+                                    } else
+                                    {}) + 
+
+                                    (if std.objectHas(container, "entrypoint") then
+                                        // Entrypoint is set - use command for entrypoint, args for command
+                                        (if std.isString(container.entrypoint) && container.entrypoint == "" then
+                                            { command: [] }
+                                        else if std.isArray(container.entrypoint) then
+                                            { command: container.entrypoint }
+                                        else
+                                            { command: [container.entrypoint] }
+                                        ) + (if std.objectHas(container, "command") then
+                                            { args: container.command }
+                                        else {})
+                                    else if std.objectHas(container, "command") then
+                                        { command: container.command }
+                                    else {}) +
+
+                                    (if std.length(container.environment) > 0 then
+                                    {
+                                        env: container.environment,
+                                    }
+                                    else {}) + 
+
+                (if std.length(container.volumes) > 0 || std.length(container.bindMounts) > 0 then
+                {
+                    volumeMounts: [
+                        {
+                            mountPath: vol.mount,
+                            name: vol.volume.name,
+                        }
+                        for vol in container.volumes
+                    ] + [
+                        {
+                            mountPath: bm.dest,
+                            name: bm.name,
+                        }
+                        for bm in container.bindMounts
+                    ]
+                }
+
+                else
+                {}
+                )
+                            ],
+                            volumes: [
+                        vol.volume.volRef()
+                        for vol in container.volumes
+                    ] + [
+                        {
+                            name: bm.name,
+                            hostPath: { path: bm.src }
+                        }
+                        for bm in container.bindMounts
+                            ]
+                        } + (
+                            local hasFsGroup = std.objectHas(container, "gid");
+                            local hasSuppGroups =
+                                std.length(container.supplementalGroups) > 0;
+                            if hasFsGroup || hasSuppGroups then
+                            {
+                                securityContext:
+                                    (if hasFsGroup
+                                     then { fsGroup: container.gid }
+                                     else {}) +
+                                    (if hasSuppGroups then {
+                                        supplementalGroups:
+                                            container.supplementalGroups,
+                                    } else {}),
+                            }
+                            else {}
+                        ) + (
+                            if std.objectHas(container, "podHostname")
+                            then { hostname: container.podHostname }
+                            else {}
+                        ) + (
+                            if std.objectHas(container, "podSubdomain")
+                            then { subdomain: container.podSubdomain }
+                            else {}
+                        ) + (
+                            if std.length(container.imagePullSecrets) > 0
+                            then { imagePullSecrets: [
+                                { name: s }
+                                for s in container.imagePullSecrets
+                            ] }
+                            else {}
+                        )
+                    },
+                } + {}
+
+                }
+
+            ]
+
+    },
+
+    internalService:: function(name, containers)
+    {
+
+        local service = self,
+
+        name: name,
+        appName: containers.name,
+
+        ports: [],
+
+        with_port::
+            function(src, dest, name)
+                self + {
+                    ports: super.ports + [
+                        { src: src, dest: dest, name: name  }
+                    ]
+                },
+
+        add:: function() [
+
+                {
+
+                    apiVersion: "v1",
+                    kind: "Service",
+                    metadata: {
+                        name: service.name,
+                        namespace: "trustgraph",
+                    },
+                    spec: {
+                        selector: {
+                            app: service.appName,
+                        },
+                        ports: [
+                            {
+                                port: port.src,
+                                targetPort: port.dest,
+                                name: port.name,
+                            }
+                            for port in service.ports
+                        ],
+                    }
+                }
+            ],
+
+    },
+
+    service:: self.internalService,
+
+    headlessService:: function(name, membership, members=[])
+    {
+
+        local service = self,
+
+        name: name,
+        membership: membership,
+        publishNotReady: false,
+
+        ports: [],
+
+        with_port::
+            function(src, dest, name)
+                self + {
+                    ports: super.ports + [
+                        { src: src, dest: dest, name: name }
+                    ]
+                },
+
+        with_publish_not_ready_addresses:: function()
+            self + { publishNotReady: true },
+
+        add:: function() [
+
+                {
+
+                    apiVersion: "v1",
+                    kind: "Service",
+                    metadata: {
+                        name: service.name,
+                        namespace: "trustgraph",
+                    },
+                    spec: {
+                        clusterIP: "None",
+                        selector: {
+                            membership: service.membership,
+                        },
+                        ports: [
+                            {
+                                port: port.src,
+                                targetPort: port.dest,
+                                name: port.name,
+                            }
+                            for port in service.ports
+                        ],
+                    } + (
+                        if service.publishNotReady
+                        then { publishNotReadyAddresses: true }
+                        else {}
+                    )
+                }
+            ],
+
+    },
+
+    volume:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [
+                {
+                    apiVersion: "v1",
+                    kind: "PersistentVolumeClaim",
+                    metadata: {
+                        name: volume.name,
+                        namespace: "trustgraph",
+                    },
+                    spec: {
+                        storageClassName: "tg",
+                        accessModes: [ "ReadWriteOnce" ],
+                        resources: {
+                            requests: {
+                                storage: volume.size,
+                            }
+                        },
+                    }
+                }
+            ],
+
+        volRef:: function() {
+            name: volume.name,
+            persistentVolumeClaim: { claimName: volume.name },
+        }
+
+    },
+
+    configVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [
+                {
+                    apiVersion: "v1",
+                    kind: "ConfigMap",
+                    metadata: {
+                        name: volume.name,
+                        namespace: "trustgraph",
+                    },
+                    data: parts
+                },
+            ],
+
+
+        volRef:: function() {
+            name: volume.name,
+            configMap: { name: volume.name },
+        }
+
+    },
+
+    secretVolume:: function(name, dir, parts)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [
+        ],
+
+        volRef:: function() {
+            name: volume.name,
+            secret: { secretName: volume.name },
+        }
+
+    },
+
+    envSecrets:: function(name)
+    {
+
+        local volume = self,
+
+        name: name,
+
+        variables: [],
+        keyMap: {},
+
+        with_size:: function(size) self + { size: size },
+
+        add:: function() [
+        ],
+
+        volRef:: function() {
+            name: volume.name,
+            secret: { secretName: volume.name },
+        },
+
+        with_env_var::
+            function(name, key) self + {
+                variables: super.variables + [name],
+                keyMap: super.keyMap + { [name]: key },
+            },
+
+    },
+
+    containers:: function(name, containers)
+    {
+
+        local cont = self,
+
+        name: name,
+        containers: containers,
+        replicas: 1,
+
+        with_replicas:: function(n) self + { replicas: n },
+
+        add:: function() std.flattenArrays(
+            [ c.add(cont.replicas) for c in cont.containers ]
+        ),
+
+    },
+
+    resources:: function(res)
+
+        std.flattenArrays(
+            [ c.add() for c in res ]
+        ),
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/minikube-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/minikube-k8s.jsonnet
@@ -1,0 +1,116 @@
+
+local k8s = import "k8s.jsonnet";
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+k8s + {
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: resources,
+        };
+        resourceList,
+
+    volume:: function(name)
+    {
+        local volume = self,
+        name: name,
+        with_size:: function(size) self + { size: size },
+        add:: function() [
+            {
+                apiVersion: "v1",
+                kind: "PersistentVolume",
+                metadata: {
+                    name: volume.name,
+                },
+                spec: {
+                    accessModes: [ "ReadWriteOnce" ],
+                    capacity: {
+                        storage: volume.size,
+                    },
+                    persistentVolumeReclaimPolicy: "Delete",
+                    hostPath: {
+                        path: "/data/pv-" + volume.name,
+                    },
+                }
+            },
+            {
+                apiVersion: "v1",
+                kind: "PersistentVolumeClaim",
+                metadata: {
+                    name: volume.name,
+                    namespace: "trustgraph",
+                },
+                spec: {
+                    accessModes: [ "ReadWriteOnce" ],
+                    resources: {
+                        requests: {
+                            storage: volume.size,
+                        }
+                    },
+                }
+            }
+        ],
+
+        volRef:: function() {
+            name: volume.name,
+            persistentVolumeClaim: { claimName: volume.name },
+        }
+
+    },
+
+    service:: function(name, containers)
+    {
+        local service = self,
+        name: name,
+        appName: containers.name,
+        ports: [],
+        with_port::
+            function(src, dest, name)
+                self + {
+                    ports: super.ports + [
+                        { src: src, dest: dest, name: name  }
+                    ]
+                },
+        add:: function() [
+            {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: service.name,
+                    namespace: "trustgraph",
+                },
+                spec: {
+                    selector: {
+                        app: service.appName,
+                    },
+                    type: "LoadBalancer",
+                    ports: [
+                        {
+                            port: port.src,
+                            targetPort: port.dest,
+                            name: port.name,
+                        }
+                        for port in service.ports
+                    ],
+                }
+            }
+        ],
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/noop.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/noop.jsonnet
@@ -1,0 +1,98 @@
+{
+
+    // Extract resources usnig the engine
+    package:: function(patterns) {},
+
+    container:: function(name) {
+
+        with_image:: function(x) self + {},
+
+        with_image_pull_secret:: function(name) self + {},
+
+        with_user:: function(x) self + {},
+
+        with_group:: function(x) self + {},
+
+        with_supplemental_group:: function(x) self + {},
+
+        with_command:: function(x) self + {},
+
+        with_runtime:: function(x) self + {},
+
+        with_privileged:: function(x) self + {},
+
+        with_ipc:: function(x) self + {},
+
+        with_capability:: function(x) self + {},
+
+        with_membership:: function(group) self + {},
+
+        with_hostname:: function(h) self + {},
+
+        with_subdomain:: function(s) self + {},
+
+        with_environment:: function(x) self + {},
+
+        with_device:: function(hdev, cdev) self + {},
+
+        with_limits:: function(c, m) self + {},
+
+        with_reservations:: function(c, m) self + {},
+
+        with_volume_mount:: self + {},
+
+        with_port:: function(src, dest, name) self + {},
+
+        with_env_var_secrets:: function(vars) self + {},
+
+        add:: function() {},
+    },
+
+    internalService:: function(name, containers) {
+        with_port:: function(src, dest, name) self + {},
+        add:: function() {},
+    },
+
+    headlessService:: function(name, membership, members=[]) {
+        with_port:: function(src, dest, name) self + {},
+        with_publish_not_ready_addresses:: function() self + {},
+        add:: function() {},
+    },
+
+    service:: function(name, containers) {
+        with_port:: function(src, dest, name) self + {},
+        add:: function() {},
+    },
+
+    volume:: function(name) {
+        with_size:: function(size) self + {},
+        add:: function() {},
+    },
+
+    configVolume:: function(name, dir, parts) {
+        add:: function() {},
+    },
+
+    secretVolume:: function(name, dir, parts) {
+        add:: function() {},
+    },
+
+    envSecrets:: function(name) {
+        with_env_var:: function(name, key) self + {},
+        add:: function() {},
+    },
+
+    containers:: function(name, containers) {
+        with_replicas:: function(n) self,
+        add:: function() {},
+    },
+
+    resources:: function(res)
+        std.foldl(
+            function(state, c) state + c.add(),
+            res,
+            {}
+        ),
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/ovh-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/ovh-k8s.jsonnet
@@ -1,0 +1,72 @@
+
+local k8s = import "k8s.jsonnet";
+
+// OVHcloud high-speed volumes have a 10 GiB minimum size.
+local minGib = 10;
+
+local parseGib = function(s)
+    if std.endsWith(s, "Gi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2))
+    else if std.endsWith(s, "G") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1))
+    else if std.endsWith(s, "Mi") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 2)) / 1024
+    else if std.endsWith(s, "M") then
+        std.parseJson(std.substr(s, 0, std.length(s) - 1)) / 1024
+    else 0;
+
+local floorSize = function(s)
+    local g = parseGib(s);
+    if g < minGib then "" + minGib + "Gi" else s;
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "cinder.csi.openstack.org",
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+    parameters: {
+        availability: "nova",
+        fsType: "ext4",
+        type: "high-speed",
+    },
+};
+
+k8s + {
+
+    volume:: function(name)
+        local base = k8s.volume(name);
+        base + {
+            add:: function()
+                local vol = self;
+                local patched = base { size: floorSize(vol.size) };
+                patched.add(),
+        },
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: [ns, sc] + resources,
+        };
+        resourceList
+
+}
+

--- a/trustgraph_configurator/templates/2.7/engine/scw-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/engine/scw-k8s.jsonnet
@@ -1,0 +1,40 @@
+
+local k8s = import "k8s.jsonnet";
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+local sc = {
+    apiVersion: "storage.k8s.io/v1",
+    kind: "StorageClass",
+    metadata: {
+        name: "tg",
+    },
+    provisioner: "csi.scaleway.com",
+    reclaimPolicy: "Delete",
+    volumeBindingMode: "WaitForFirstConsumer",
+};
+
+k8s + {
+
+    // Extract resources usnig the engine
+    package:: function(patterns)
+        local resources = [sc, ns] + std.flattenArrays([
+            p.create(self) for p in std.objectValues(patterns)
+        ]);
+        local resourceList = {
+            apiVersion: "v1",
+            kind: "List",
+            items: [ns, sc] + resources,
+        };
+        resourceList
+
+}
+

--- a/trustgraph_configurator/templates/2.7/flows/agent-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/agent-extract.jsonnet
@@ -1,0 +1,35 @@
+// Agent-based extraction module
+// Uses AI agents for more sophisticated knowledge extraction from text
+// Leverages agent tools and reasoning for complex extraction tasks
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+
+{
+    // No external interfaces - internal agent extraction service
+    "interfaces" +: {
+    },
+
+    // No configurable parameters for agent extraction
+    "parameters" +: {
+    },
+
+    // Flow-level processors for agent-based extraction
+    "flow" +: {
+        // Agent-based knowledge extraction processor
+        // Uses AI agents with tools to extract structured knowledge
+        "kg-extract-agent:{id}": {
+            input: flow("chunk-load:{workspace}:{id}"),                       // Input text chunks
+            triples: flow("triples-store:{workspace}:{id}"),                  // Output knowledge triples
+            "entity-contexts": flow("entity-contexts-load:{workspace}:{id}"), // Entity context information
+            "agent-request": request("agent:{workspace}:{id}"),               // Agent service requests
+            "agent-response": response("agent:{workspace}:{id}"),             // Agent service responses
+        },
+    },
+
+    // No blueprint-level processors needed
+    "blueprint" +: {
+    }
+}

--- a/trustgraph_configurator/templates/2.7/flows/agent.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/agent.jsonnet
@@ -1,0 +1,58 @@
+// Agent management module
+// Provides AI agent orchestration and tool integration
+// Manages agent conversations, tool calls, and response coordination
+// Supports MCP tools, GraphRAG, and structured queries
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
+
+// Import shared services (agent requires LLM for reasoning, MCP for tools)
+local llm_services = import "llm-services.jsonnet";
+local mcp_service = import "mcp-service.jsonnet";
+
+// Merge shared services with agent-specific configuration
+llm_services + mcp_service + {
+
+    // External interfaces for agent operations
+    "interfaces" +: {
+        "agent": request_response_if("agent:{workspace}:{id}"),
+    },
+
+    // Flow-level processors for agent management
+    "flow" +: {
+        // Agent manager orchestrates agent conversations and tool usage
+        "agent-manager:{id}": {
+            topics: {
+                request: request("agent:{workspace}:{id}"),
+                next: request("agent:{workspace}:{id}"),
+                response: response("agent:{workspace}:{id}"),
+                "text-completion-request": request("text-completion:{workspace}:{id}"),
+                "text-completion-response": response("text-completion:{workspace}:{id}"),
+                "prompt-request": request("prompt-rag:{workspace}:{id}"),
+                "prompt-response": response("prompt-rag:{workspace}:{id}"),
+                "mcp-tool-request": request("mcp-tool:{workspace}:{id}"),
+                "mcp-tool-response": response("mcp-tool:{workspace}:{id}"),
+                "graph-rag-request": request("graph-rag:{workspace}:{id}"),
+                "graph-rag-response": response("graph-rag:{workspace}:{id}"),
+                "structured-query-request": request("structured-query:{workspace}:{id}"),
+                "structured-query-response": response("structured-query:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+                "row-embeddings-query-request": request("row-embeddings:{workspace}:{id}"),
+                "row-embeddings-query-response": response("row-embeddings:{workspace}:{id}"),
+                explainability: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+        },
+    },
+
+    // Blueprint-level processors for agent-related services
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
@@ -1,0 +1,73 @@
+// Document store module
+// Infrastructure for document-based RAG using chunk embeddings
+// Handles document embedding storage, retrieval, and question answering
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local flow_if = helpers.flow_if;
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
+
+// Import shared services
+local llm_services = import "llm-services.jsonnet";
+local embeddings_service = import "embeddings-service.jsonnet";
+local reranker_service = import "reranker-service.jsonnet";
+
+// Merge shared services with document store configuration
+llm_services + embeddings_service + reranker_service + {
+
+    // External interfaces for document store
+    "interfaces" +: {
+        // Document embedding storage and retrieval
+        "document-embeddings-store": flow_if("document-embeddings-store:{workspace}:{id}"),
+        "document-rag": request_response_if("document-rag:{workspace}:{id}"),
+        "document-embeddings": request_response_if("document-embeddings:{workspace}:{id}"),
+    },
+
+    // Flow-level processors for document embedding and storage
+    "flow" +: {
+        "document-embeddings:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                output: flow("document-embeddings-store:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+            },
+        },
+        "doc-embeddings-write:{id}": {
+            topics: {
+                input: flow("document-embeddings-store:{workspace}:{id}"),
+            },
+        },
+        "document-rag:{id}": {
+            topics: {
+                request: request("document-rag:{workspace}:{id}"),
+                response: response("document-rag:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+                "prompt-request": request("prompt-rag:{workspace}:{id}"),
+                "prompt-response": response("prompt-rag:{workspace}:{id}"),
+                "document-embeddings-request": request("document-embeddings:{workspace}:{id}"),
+                "document-embeddings-response": response("document-embeddings:{workspace}:{id}"),
+                "reranker-request": request("reranker:{workspace}:{id}"),
+                "reranker-response": response("reranker:{workspace}:{id}"),
+                explainability: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+        },
+        "doc-embeddings-query:{id}": {
+            topics: {
+                request: request("document-embeddings:{workspace}:{id}"),
+                response: response("document-embeddings:{workspace}:{id}"),
+            },
+        },
+    },
+
+    // Blueprint-level processors for document RAG operations
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/embeddings-service.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/embeddings-service.jsonnet
@@ -1,0 +1,34 @@
+// Shared embeddings service module
+// Provides vector embedding generation for text
+// Import this module in any flow that requires embeddings
+
+local helpers = import "helpers.jsonnet";
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+{
+    // Interfaces exposed by embeddings service
+    "interfaces" +: {
+        "embeddings": request_response_if("embeddings:{workspace}:{id}"),
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for embeddings
+    "flow" +: {
+        "embeddings:{id}": {
+            topics: {
+                request: request("embeddings:{workspace}:{id}"),
+                response: response("embeddings:{workspace}:{id}"),
+            },
+            parameters: {
+                model: "{embeddings-model}",
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/flow-blueprints.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/flow-blueprints.jsonnet
@@ -1,0 +1,48 @@
+// TrustGraph Flow Blueprints Configuration
+//
+// RAG Modes (4 types):
+// - Document RAG: Uses document chunk embeddings
+// - Graph RAG: Extracts definitions + relationships to graph
+// - Ontology RAG: Extracts using ontology definitions to graph (mutually exclusive with Graph RAG)
+// - Structured RAG: Extracts objects to object store
+//
+// Module structure:
+// - *-store: Storage and query infrastructure
+// - *-extract: Extraction methods
+
+// Import all the modular flow components
+local graph_store = import "graph-store.jsonnet";
+local document_store = import "document-store.jsonnet";
+local structured_store = import "structured-store.jsonnet";
+local graphrag_extract = import "graphrag-extract.jsonnet";
+local ontorag_extract = import "ontorag-extract.jsonnet";
+local structured_extract = import "structured-extract.jsonnet";
+local agent = import "agent.jsonnet";
+local load = import "load.jsonnet";
+local kgcore = import "kgcore.jsonnet";
+
+{
+
+    // Full system: Graph RAG + Document RAG + knowledge cores
+    "everything": {
+        description: "Graph RAG + Document RAG + knowledge cores",
+        tags: ["document-rag", "graph-rag", "kgcore"],
+    } +
+      graph_store + document_store + agent + load +
+      graphrag_extract + kgcore + structured_store,
+
+    // Structured RAG only
+    "structured": {
+        description: "Structured data extraction and querying",
+        tags: ["structured"],
+    } +
+      structured_store + structured_extract + agent + load,
+
+    // Ontology RAG + knowledge cores
+    "ontology": {
+        description: "Ontology RAG + knowledge cores",
+        tags: ["onto-rag", "kgcore"],
+    } +
+      graph_store + ontorag_extract + agent + load + kgcore,
+
+}

--- a/trustgraph_configurator/templates/2.7/flows/graph-store.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/graph-store.jsonnet
@@ -1,0 +1,100 @@
+// Graph store module
+// Shared infrastructure for graph-based RAG (used by both GraphRAG and OntologyRAG)
+// Handles knowledge graph storage, embeddings, and graph-based question answering
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local flow_if = helpers.flow_if;
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
+
+// Import shared services
+local llm_services = import "llm-services.jsonnet";
+local embeddings_service = import "embeddings-service.jsonnet";
+local reranker_service = import "reranker-service.jsonnet";
+
+// Merge shared services with graph store configuration
+llm_services + embeddings_service + reranker_service + {
+
+    // External interfaces exposed by the graph store
+    "interfaces" +: {
+        // Data ingestion interfaces for graph construction
+        "entity-contexts-load": flow_if("entity-contexts-load:{workspace}:{id}"),
+        "triples-store": flow_if("triples-store:{workspace}:{id}"),
+        "graph-embeddings-store": flow_if("graph-embeddings-store:{workspace}:{id}"),
+
+        // Query interfaces for graph-based operations
+        "graph-rag": request_response_if("graph-rag:{workspace}:{id}"),
+        "triples": request_response_if("triples:{workspace}:{id}"),
+        "graph-embeddings": request_response_if("graph-embeddings:{workspace}:{id}"),
+        "sparql": request_response_if("sparql:{workspace}:{id}"),
+    },
+
+    // Flow-level processors - handle data streams for a specific flow instance
+    "flow" +: {
+        "graph-embeddings:{id}": {
+            topics: {
+                input: flow("entity-contexts-load:{workspace}:{id}"),
+                output: flow("graph-embeddings-store:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+            },
+        },
+        "triples-write:{id}": {
+            topics: {
+                input: flow("triples-store:{workspace}:{id}"),
+            },
+        },
+        "graph-embeddings-write:{id}": {
+            topics: {
+                input: flow("graph-embeddings-store:{workspace}:{id}"),
+            },
+        },
+        "graph-rag:{id}": {
+            topics: {
+                request: request("graph-rag:{workspace}:{id}"),
+                response: response("graph-rag:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+                "reranker-request": request("reranker:{workspace}:{id}"),
+                "reranker-response": response("reranker:{workspace}:{id}"),
+                "prompt-request": request("prompt-rag:{workspace}:{id}"),
+                "prompt-response": response("prompt-rag:{workspace}:{id}"),
+                "graph-embeddings-request": request("graph-embeddings:{workspace}:{id}"),
+                "graph-embeddings-response": response("graph-embeddings:{workspace}:{id}"),
+                "triples-request": request("triples:{workspace}:{id}"),
+                "triples-response": response("triples:{workspace}:{id}"),
+                explainability: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+        },
+        "sparql-query:{id}": {
+            topics: {
+                request: request("sparql:{workspace}:{id}"),
+                response: response("sparql:{workspace}:{id}"),
+                "triples-request": request("triples:{workspace}:{id}"),
+                "triples-response": response("triples:{workspace}:{id}"),
+            },
+        },
+        "triples-query:{id}": {
+            topics: {
+                request: request("triples:{workspace}:{id}"),
+                response: response("triples:{workspace}:{id}"),
+            },
+        },
+        "graph-embeddings-query:{id}": {
+            topics: {
+                request: request("graph-embeddings:{workspace}:{id}"),
+                response: response("graph-embeddings:{workspace}:{id}"),
+            },
+        },
+    },
+
+    // Blueprint-level processors - shared across all flow instances of this blueprint
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/graphrag-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/graphrag-extract.jsonnet
@@ -1,0 +1,46 @@
+// GraphRAG extraction module
+// Extraction method for GraphRAG - extracts definitions and relationships
+// Mutually exclusive with OntologyRAG extraction (both write to graph store)
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+
+{
+    // No external interfaces - this module provides internal extraction services
+    "interfaces" +: {
+    },
+
+    // No configurable parameters for basic KG extraction
+    "parameters" +: {
+    },
+
+    // Flow-level processors for knowledge extraction
+    "flow" +: {
+        // Extracts entity definitions from text chunks
+        "kg-extract-definitions:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                triples: flow("triples-store:{workspace}:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{workspace}:{id}"),
+                "prompt-request": request("prompt:{workspace}:{id}"),
+                "prompt-response": response("prompt:{workspace}:{id}"),
+            },
+        },
+
+        // Extracts relationships between entities
+        "kg-extract-relationships:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                triples: flow("triples-store:{workspace}:{id}"),
+                "prompt-request": request("prompt:{workspace}:{id}"),
+                "prompt-response": response("prompt:{workspace}:{id}"),
+            },
+        },
+    },
+
+    // No blueprint-level processors needed
+    "blueprint" +: {
+    }
+}

--- a/trustgraph_configurator/templates/2.7/flows/helpers.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/helpers.jsonnet
@@ -1,0 +1,44 @@
+// Helper functions for flow configuration
+// Provides utility functions for constructing flow, request, and response URIs
+// used throughout the TrustGraph flow configuration system
+
+// Creates a persistent flow URI for data streams
+// Persistent flows retain messages until consumed
+local flow(x) = "flow:tg:" + x;
+
+// Creates a non-persistent request URI for request-response patterns
+// Non-persistent means messages are not retained if no consumer is present
+local request(x) = "request:tg:" + x;
+
+// Creates a non-persistent response URI for request-response patterns
+local response(x) = "response:tg:" + x;
+
+local librarian_request = request("librarian:{workspace}");
+local librarian_response = response("librarian:{workspace}");
+
+// Creates a request-response pair for bidirectional communication
+// Returns an object with both request and response URIs
+local flow_if(x) = {
+  flow: flow(x),
+};
+
+local request_response_if(x) = {
+  request: request(x),
+  response: response(x),
+};
+
+// Export all helper functions for use in other modules
+{
+
+    flow: flow,
+    request: request,
+    response: response,
+
+    flow_if: flow_if,
+    request_response_if: request_response_if,
+
+    librarian_request: librarian_request,
+    librarian_response: librarian_response,
+
+}
+

--- a/trustgraph_configurator/templates/2.7/flows/kgcore.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/kgcore.jsonnet
@@ -1,0 +1,31 @@
+// Knowledge Graph Core storage module
+// Handles persistent storage of knowledge graph data
+// Consolidates triples and graph embeddings into permanent storage
+// Creates the core knowledge base for long-term use
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+
+{
+    // No external interfaces - internal storage service
+    "interfaces" +: {
+    },
+
+    // No configurable parameters for core storage
+    "parameters" +: {
+    },
+
+    // Flow-level processors for knowledge graph storage
+    "flow" +: {
+        "kg-store:{id}": {
+            topics: {
+                "triples-input": flow("triples-store:{workspace}:{id}"),
+                "graph-embeddings-input": flow("graph-embeddings-store:{workspace}:{id}"),
+            },
+        },
+    },
+
+    // No blueprint-level processors needed
+    "blueprint" +: {
+    }
+}

--- a/trustgraph_configurator/templates/2.7/flows/llm-parameters.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/llm-parameters.jsonnet
@@ -1,0 +1,66 @@
+{
+
+    // LLM model selection for normal LLM
+    "llm-model": {
+        "type": "llm-model",
+        "description": "LLM model",
+        "order": 1,
+        "advanced": false,
+    },
+
+    // LLM model for RAG operations
+    "llm-rag-model": {
+        "type": "llm-model",
+        "description": "LLM model for RAG",
+        "order": 2,
+        "advanced": true,
+        "controlled-by": "llm-model",
+    },
+
+    // LLM model selection for normal LLM
+    "llm-temperature": {
+        "type": "llm-temperature",
+        "description": "LLM temperature",
+        "order": 3,
+        "advanced": true,
+    },
+
+    // LLM model selection for normal LLM
+    "llm-rag-temperature": {
+        "type": "llm-temperature",
+        "description": "LLM temperature for RAG",
+        "order": 4,
+        "advanced": true,
+    },
+
+    "embeddings-model": {
+        "type": "embeddings-model",
+        "description": "Embeddings model",
+        "order": 5,
+        "advanced": true,
+    },
+
+    "reranker-model": {
+        "type": "reranker-model",
+        "description": "Re-ranker model",
+        "order": 6,
+        "advanced": true,
+    },
+
+    // LLM model selection for normal LLM
+    "chunk-size": {
+        "type": "chunk-size",
+        "description": "Chunk size",
+        "order": 7,
+        "advanced": true,
+    },
+
+    // LLM model selection for normal LLM
+    "chunk-overlap": {
+        "type": "chunk-overlap",
+        "description": "Chunk overlap",
+        "order": 8,
+        "advanced": true,
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/flows/llm-services.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/llm-services.jsonnet
@@ -1,0 +1,82 @@
+// Shared LLM services module
+// Provides text completion, prompt processing, and metering services
+// Import this module in any flow that requires LLM functionality
+
+local helpers = import "helpers.jsonnet";
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+local llm_parameters = import "llm-parameters.jsonnet";
+
+{
+    // Interfaces exposed by LLM services
+    "interfaces" +: {
+        "prompt": request_response_if("prompt:{workspace}:{id}"),
+        "text-completion": request_response_if("text-completion:{workspace}:{id}"),
+    },
+
+    // LLM configuration parameters
+    "parameters" +: llm_parameters,
+
+    // Flow-level processors for LLM services
+    "flow" +: {
+        // Primary text completion service
+        "text-completion:{id}": {
+            topics: {
+                request: request("text-completion:{workspace}:{id}"),
+                response: response("text-completion:{workspace}:{id}"),
+            },
+            parameters: {
+                model: "{llm-model}",
+            },
+        },
+
+        // RAG-specific text completion (may use different model)
+        "text-completion-rag:{id}": {
+            topics: {
+                request: request("text-completion-rag:{workspace}:{id}"),
+                response: response("text-completion-rag:{workspace}:{id}"),
+            },
+            parameters: {
+                model: "{llm-rag-model}",
+            },
+        },
+
+        // Prompt processing service
+        "prompt:{id}": {
+            topics: {
+                request: request("prompt:{workspace}:{id}"),
+                response: response("prompt:{workspace}:{id}"),
+                "text-completion-request": request("text-completion:{workspace}:{id}"),
+                "text-completion-response": response("text-completion:{workspace}:{id}"),
+            },
+        },
+
+        // RAG-specific prompt processing
+        "prompt-rag:{id}": {
+            topics: {
+                request: request("prompt-rag:{workspace}:{id}"),
+                response: response("prompt-rag:{workspace}:{id}"),
+                "text-completion-request": request("text-completion-rag:{workspace}:{id}"),
+                "text-completion-response": response("text-completion-rag:{workspace}:{id}"),
+            },
+        },
+
+        // Usage metering for primary completion
+        "metering:{id}": {
+            topics: {
+                input: response("text-completion:{workspace}:{id}"),
+            },
+        },
+
+        // Usage metering for RAG completion
+        "metering-rag:{id}": {
+            topics: {
+                input: response("text-completion-rag:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/load.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/load.jsonnet
@@ -1,0 +1,59 @@
+// Document loading and preprocessing module
+// Handles document ingestion, format conversion, and chunking
+// Converts PDFs to text and splits documents into processable chunks
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local flow_if = helpers.flow_if;
+local request = helpers.request;
+local response = helpers.response;
+local librarian_request = helpers.librarian_request;
+local librarian_response = helpers.librarian_response;
+
+// Import shared services (load requires embeddings for chunk processing)
+local embeddings_service = import "embeddings-service.jsonnet";
+
+// Merge shared services with load-specific configuration
+embeddings_service + {
+
+    // External interfaces for document loading
+    "interfaces" +: {
+        "document-load": flow_if("document-load:{workspace}:{id}"),
+        "text-load": flow_if("text-document-load:{workspace}:{id}"),
+    },
+
+    // Flow-level processors for document preprocessing
+    "flow" +: {
+        // PDF decoder converts PDF documents to text
+        // Also emits page provenance triples and saves pages via librarian
+        "document-decoder:{id}": {
+            topics: {
+                input: flow("document-load:{workspace}:{id}"),
+                output: flow("text-document-load:{workspace}:{id}"),
+                triples: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+        },
+
+        // Chunker splits documents into smaller, processable pieces
+        // Also emits chunk provenance triples and saves chunks via librarian
+        "chunker:{id}": {
+            topics: {
+                input: flow("text-document-load:{workspace}:{id}"),
+                output: flow("chunk-load:{workspace}:{id}"),
+                triples: flow("triples-store:{workspace}:{id}"),
+                "librarian-request": librarian_request,
+                "librarian-response": librarian_response,
+            },
+            parameters: {
+                "chunk-size": "{chunk-size}",
+                "chunk-overlap": "{chunk-overlap}",
+            },
+        },
+    },
+
+    // Blueprint-level processors for document loading services
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/mcp-service.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/mcp-service.jsonnet
@@ -1,0 +1,33 @@
+// Shared MCP (Model Context Protocol) tool service module
+// Provides MCP tool execution capabilities for agents
+// Import this module in any flow that requires MCP tool integration
+
+local helpers = import "helpers.jsonnet";
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+{
+    // Interfaces exposed by MCP service
+    "interfaces" +: {
+        "mcp-tool": request_response_if("mcp-tool:{workspace}:{id}"),
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for MCP tool execution
+    "flow" +: {
+        "mcp-tool:{id}": {
+            topics: {
+                request: request("mcp-tool:{workspace}:{id}"),
+                response: response("mcp-tool:{workspace}:{id}"),
+                "text-completion-request": request("text-completion:{workspace}:{id}"),
+                "text-completion-response": response("text-completion:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/ontorag-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/ontorag-extract.jsonnet
@@ -1,0 +1,39 @@
+// OntologyRAG extraction module
+// Extraction method for OntologyRAG - extracts using ontology definitions
+// Mutually exclusive with GraphRAG extraction (both write to graph store)
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+
+{
+    // No external interfaces - this module provides internal extraction
+    // services
+    "interfaces" +: {
+    },
+
+    // No configurable parameters for basic KG extraction
+    "parameters" +: {
+    },
+
+    // Flow-level processors for knowledge extraction
+    "flow" +: {
+        "kg-extract-ontology:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                triples: flow("triples-store:{workspace}:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{workspace}:{id}"),
+                "prompt-request": request("prompt:{workspace}:{id}"),
+                "prompt-response": response("prompt:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+            },
+        },
+    },
+
+    // No blueprint-level processors needed
+    "blueprint" +: {
+    }
+}
+

--- a/trustgraph_configurator/templates/2.7/flows/reranker-service.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/reranker-service.jsonnet
@@ -1,0 +1,34 @@
+// Shared reranker service module
+// Provides vector reranker generation for text
+// Import this module in any flow that requires reranker
+
+local helpers = import "helpers.jsonnet";
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+{
+    // Interfaces exposed by reranker service
+    "interfaces" +: {
+        "reranker": request_response_if("reranker:{workspace}:{id}"),
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for reranker
+    "flow" +: {
+        "reranker:{id}": {
+            topics: {
+                request: request("reranker:{workspace}:{id}"),
+                response: response("reranker:{workspace}:{id}"),
+            },
+            parameters: {
+                model: "{reranker-model}",
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/structured-extract.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/structured-extract.jsonnet
@@ -1,0 +1,32 @@
+// Structured RAG extraction module
+// Extracts structured rows from text chunks
+// Outputs to rows-store for structured data querying
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+
+{
+    "interfaces" +: {
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for structured row extraction
+    "flow" +: {
+        "kg-extract-rows:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                output: flow("rows-store:{workspace}:{id}"),
+                "entity-contexts": flow("entity-contexts-load:{workspace}:{id}"),
+                "prompt-request": request("prompt:{workspace}:{id}"),
+                "prompt-response": response("prompt:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/flows/structured-store.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/structured-store.jsonnet
@@ -1,0 +1,95 @@
+// Structured store module
+// Shared infrastructure for structured data RAG
+// Handles row storage, retrieval, and NLP query capabilities
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local flow_if = helpers.flow_if;
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+// Import shared services
+local llm_services = import "llm-services.jsonnet";
+local embeddings_service = import "embeddings-service.jsonnet";
+
+// Merge shared services with structured store configuration
+llm_services + embeddings_service + {
+
+    // External interfaces for structured store
+    "interfaces" +: {
+        // Row storage and querying
+        "rows-store": flow_if("rows-store:{workspace}:{id}"),
+        "row-embeddings-store": flow_if("row-embeddings-store:{workspace}:{id}"),
+        "rows": request_response_if("rows:{workspace}:{id}"),
+        "row-embeddings": request_response_if("row-embeddings:{workspace}:{id}"),
+
+        // Query interfaces
+        "nlp-query": request_response_if("nlp-query:{workspace}:{id}"),
+        "structured-query": request_response_if("structured-query:{workspace}:{id}"),
+        "structured-diag": request_response_if("structured-diag:{workspace}:{id}"),
+    },
+
+    // Flow-level processors for structured storage and query
+    "flow" +: {
+        "row-embeddings:{id}": {
+            topics: {
+                input: flow("rows-store:{workspace}:{id}"),
+                output: flow("row-embeddings-store:{workspace}:{id}"),
+                "embeddings-request": request("embeddings:{workspace}:{id}"),
+                "embeddings-response": response("embeddings:{workspace}:{id}"),
+            },
+        },
+        "rows-write:{id}": {
+            topics: {
+                input: flow("rows-store:{workspace}:{id}"),
+            },
+        },
+        "row-embeddings-write:{id}": {
+            topics: {
+                input: flow("row-embeddings-store:{workspace}:{id}"),
+            },
+        },
+        "rows-query:{id}": {
+            topics: {
+                request: request("rows:{workspace}:{id}"),
+                response: response("rows:{workspace}:{id}"),
+            },
+        },
+        "row-embeddings-query:{id}": {
+            topics: {
+                request: request("row-embeddings:{workspace}:{id}"),
+                response: response("row-embeddings:{workspace}:{id}"),
+            },
+        },
+        "nlp-query:{id}": {
+            topics: {
+                request: request("nlp-query:{workspace}:{id}"),
+                response: response("nlp-query:{workspace}:{id}"),
+                "prompt-request": request("prompt-rag:{workspace}:{id}"),
+                "prompt-response": response("prompt-rag:{workspace}:{id}"),
+            },
+        },
+        "structured-query:{id}": {
+            topics: {
+                request: request("structured-query:{workspace}:{id}"),
+                response: response("structured-query:{workspace}:{id}"),
+                "nlp-query-request": request("nlp-query:{workspace}:{id}"),
+                "nlp-query-response": response("nlp-query:{workspace}:{id}"),
+                "rows-query-request": request("rows:{workspace}:{id}"),
+                "rows-query-response": response("rows:{workspace}:{id}"),
+            },
+        },
+        "structured-diag:{id}": {
+            topics: {
+                request: request("structured-diag:{workspace}:{id}"),
+                response: response("structured-diag:{workspace}:{id}"),
+                "prompt-request": request("prompt:{workspace}:{id}"),
+                "prompt-response": response("prompt:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/llm/azure-openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/azure-openai.jsonnet
@@ -1,0 +1,113 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/azure-openai.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["azure-openai-" + key]:: value,
+        },
+
+    "azure-openai-max-output-tokens":: 4192,
+    "azure-openai-temperature":: 0.0,
+    "azure-openai-models":: models,
+
+    "llm-models" +:: $["azure-openai-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.azure_openai.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["azure-openai-max-output-tokens"],
+                                    temperature: $["azure-openai-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.azure_openai.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["azure-openai-max-output-tokens"],
+                                    temperature: $["azure-openai-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("azure-openai-credentials")
+                .with_env_var("AZURE_TOKEN", "azure-token")
+                .with_env_var("AZURE_MODEL", "azure-model")
+                .with_env_var("AZURE_ENDPOINT", "azure-endpoint");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/azure.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/azure.jsonnet
@@ -1,0 +1,112 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/azure.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["azure-" + key]:: value,
+        },
+
+    "azure-max-output-tokens":: 4096,
+    "azure-temperature":: 0.0,
+    "azure-models":: models,
+
+    "llm-models" +:: $["azure-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.azure.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["azure-max-output-tokens"],
+                                    temperature: $["azure-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.azure.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["azure-max-output-tokens"],
+                                    temperature: $["azure-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("azure-ai-credentials")
+                .with_env_var("AZURE_TOKEN", "azure-token")
+                .with_env_var("AZURE_ENDPOINT", "azure-endpoint");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/bedrock.jsonnet
@@ -1,0 +1,113 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/bedrock.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["bedrock-" + key]:: value,
+        },
+
+    "bedrock-max-output-tokens":: 4096,
+    "bedrock-temperature":: 0.0,
+    "bedrock-models":: models,
+
+    "llm-models" +:: $["bedrock-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.bedrock.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["bedrock-max-output-tokens"],
+                                    temperature: $["bedrock-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.bedrock.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["bedrock-max-output-tokens"],
+                                    temperature: $["bedrock-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("bedrock-credentials")
+                .with_env_var("AWS_ACCESS_KEY_ID", "aws-id-key")
+                .with_env_var("AWS_SECRET_ACCESS_KEY", "aws-secret")
+                .with_env_var("AWS_DEFAULT_REGION", "aws-region");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_bedrock)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/claude.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/claude.jsonnet
@@ -1,0 +1,111 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/claude.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["claude-" + key]:: value,
+        },
+
+    "claude-max-output-tokens":: 4096,
+    "claude-temperature":: 0.0,
+    "claude-models":: models,
+
+    "llm-models" +:: $["claude-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.claude.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["claude-max-output-tokens"],
+                                    temperature: $["claude-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.claude.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["claude-max-output-tokens"],
+                                    temperature: $["claude-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("claude-credentials")
+                .with_env_var("CLAUDE_KEY", "claude-key");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/cohere.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/cohere.jsonnet
@@ -1,0 +1,108 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/cohere.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["cohere-" + key]:: value,
+        },
+
+    "cohere-temperature":: 0.0,
+    "cohere-models":: models,
+
+    "llm-models" +:: $["cohere-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.cohere.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    temperature: $["cohere-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.cohere.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    temperature: $["cohere-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("cohere-credentials")
+                .with_env_var("COHERE_KEY", "cohere-key");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/googleaistudio.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/googleaistudio.jsonnet
@@ -1,0 +1,111 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/googleaistudio.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["googleaistudio-" + key]:: value,
+        },
+
+    "googleaistudio-max-output-tokens":: 4096,
+    "googleaistudio-temperature":: 0.0,
+    "googleaistudio-models":: models,
+
+    "llm-models" +:: $["googleaistudio-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.googleaistudio.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["googleaistudio-max-output-tokens"],
+                                    temperature: $["googleaistudio-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.googleaistudio.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["googleaistudio-max-output-tokens"],
+                                    temperature: $["googleaistudio-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("googleaistudio-credentials")
+                .with_env_var("GOOGLE_AI_STUDIO_KEY", "googleaistudio-key");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/llamafile.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/llamafile.jsonnet
@@ -1,0 +1,105 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/slm.jsonnet";
+local models = import "parameters/llamafile.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["llamafile-" + key]:: value,
+        },
+
+    "llamafile-models":: models,
+
+    "llm-models" +:: $["llamafile-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.llamafile.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.llamafile.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("llamafile-credentials")
+                .with_env_var("LLAMAFILE_URL", "llamafile-url");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/lmstudio.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/lmstudio.jsonnet
@@ -1,0 +1,111 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/lmstudio.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["lmstudio-" + key]:: value,
+        },
+
+    "lmstudio-max-output-tokens":: 4096,
+    "lmstudio-temperature":: 0.0,
+    "lmstudio-models":: models,
+
+    "llm-models" +:: $["lmstudio-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.lmstudio.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["lmstudio-max-output-tokens"],
+                                    temperature: $["lmstudio-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.lmstudio.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["lmstudio-max-output-tokens"],
+                                    temperature: $["lmstudio-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("lmstudio-credentials")
+                .with_env_var("LMSTUDIO_URL", "lmstudio-url");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/mistral.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/mistral.jsonnet
@@ -1,0 +1,111 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/mistral.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["mistral-" + key]:: value,
+        },
+
+    "mistral-max-output-tokens":: 4096,
+    "mistral-temperature":: 0.0,
+    "mistral-models":: models,
+
+    "llm-models" +:: $["mistral-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.mistral.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["mistral-max-output-tokens"],
+                                    temperature: $["mistral-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.mistral.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["mistral-max-output-tokens"],
+                                    temperature: $["mistral-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("mistral-credentials")
+                .with_env_var("MISTRAL_TOKEN", "mistral-token");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/ollama.jsonnet
@@ -1,0 +1,105 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/ollama.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["ollama-" + key]:: value,
+        },
+
+    "ollama-models":: models,
+
+    "llm-models" +:: $["ollama-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.ollama.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.ollama.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("ollama-credentials")
+                .with_env_var("OLLAMA_HOST", "ollama-host");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/openai.jsonnet
@@ -1,0 +1,118 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/openai.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["openai-" + key]:: value,
+        },
+
+    "openai-max-output-tokens":: 4096,
+    "openai-temperature":: 0.0,
+    "openai-variant":: "openai",
+    "openai-thinking":: "off",
+    "openai-models":: models,
+
+    "llm-models" +:: $["openai-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.openai.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["openai-max-output-tokens"],
+                                    temperature: $["openai-temperature"],
+                                    variant: $["openai-variant"],
+                                    thinking: $["openai-thinking"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.openai.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["openai-max-output-tokens"],
+                                    temperature: $["openai-temperature"],
+                                    variant: $["openai-variant"],
+                                    thinking: $["openai-thinking"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("openai-credentials")
+                .with_env_var("OPENAI_TOKEN", "openai-token")
+                .with_env_var("OPENAI_BASE_URL", "openai-url");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/tgi.jsonnet
@@ -1,0 +1,107 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["tgi-" + key]:: value,
+        },
+
+    "tgi-max-output-tokens":: 1024,
+    "tgi-temperature":: 0.0,
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.tgi.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["tgi-max-output-tokens"],
+                                    temperature: $["tgi-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.tgi.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["tgi-max-output-tokens"],
+                                    temperature: $["tgi-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("tgi-credentials")
+                .with_env_var("TGI_BASE_URL", "tgi-url");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/vertexai.jsonnet
@@ -1,0 +1,122 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/vertexai.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vertexai-" + key]:: value,
+        },
+
+    "vertexai-private-key":: "/vertexai/private.json",
+    "vertexai-region":: "us-central1",
+    "vertexai-max-output-tokens":: 4096,
+    "vertexai-temperature":: 0.0,
+    "vertexai-models":: models,
+
+    "llm-models" +:: $["vertexai-models"],
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "256M",
+        "text-completion-memory-reservation": "256M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.vertexai.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    private_key: $["vertexai-private-key"],
+                                    region: $["vertexai-region"],
+                                    max_output_tokens: $["vertexai-max-output-tokens"],
+                                    temperature: $["vertexai-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.vertexai.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    private_key: $["vertexai-private-key"],
+                                    region: $["vertexai-region"],
+                                    max_output_tokens: $["vertexai-max-output-tokens"],
+                                    temperature: $["vertexai-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local credsVol = engine.secretVolume(
+	        "vertexai-creds",
+	        "./vertexai",
+		{
+		    "private.json": importstr "vertexai/private.json",
+		}
+            );
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_vertexai)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_volume_mount(credsVol, "/vertexai")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                credsVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/llm/vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/llm/vllm.jsonnet
@@ -1,0 +1,112 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local prompts = import "prompts/mixtral.jsonnet";
+local models = import "parameters/vllm.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vllm-" + key]:: value,
+        },
+
+    "vllm-models":: models,
+
+    "llm-models" +:: $["vllm-models"],
+
+    "vllm-max-output-tokens":: 1024,
+    "vllm-temperature":: 0.0,
+
+    parameters +:: {
+        "text-completion-cpu-limit": "0.5",
+        "text-completion-cpu-reservation": "0.1",
+        "text-completion-memory-limit": "128M",
+        "text-completion-memory-reservation": "128M",
+        "text-completion-replicas": 1,
+        "text-completion-concurrency": 1,
+        "text-completion-rag-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "text-completion" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["text-completion-cpu-limit"],
+        local cpuReservation = pars["text-completion-cpu-reservation"],
+        local memoryLimit = pars["text-completion-memory-limit"],
+        local memoryReservation = pars["text-completion-memory-reservation"],
+        local replicas = pars["text-completion-replicas"],
+        local textCompletionConc = pars["text-completion-concurrency"],
+        local textCompletionRagConc = pars["text-completion-rag-concurrency"],
+
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "text-completion-launch-cfg", "launch/text-completion",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.text_completion.vllm.Processor",
+                                params: {
+                                    id: "text-completion",
+                                    concurrency: textCompletionConc,
+                                    max_output_tokens: $["vllm-max-output-tokens"],
+                                    temperature: $["vllm-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.model.text_completion.vllm.Processor",
+                                params: {
+                                    id: "text-completion-rag",
+                                    concurrency: textCompletionRagConc,
+                                    max_output_tokens: $["vllm-max-output-tokens"],
+                                    temperature: $["vllm-temperature"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local envSecrets = engine.envSecrets("vllm-credentials")
+                .with_env_var("VLLM_BASE_URL", "vllm-url");
+
+            local container =
+                engine.container("text-completion")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(
+                        cpuReservation,
+                        memoryReservation
+                    );
+
+            local containerSet = engine.containers(
+                "text-completion", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("text-completion", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + prompts

--- a/trustgraph_configurator/templates/2.7/mcp/ddg-mcp-server.jsonnet
+++ b/trustgraph_configurator/templates/2.7/mcp/ddg-mcp-server.jsonnet
@@ -1,0 +1,47 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    "ddg-mcp-server-port":: 9870,
+
+    "ddg-mcp-server" +: {
+
+        create:: function(engine)
+
+            local port = $["ddg-mcp-server-port"];
+
+            local container =
+                engine.container("ddg-mcp-server")
+                    .with_image(images["ddg-mcp-server"])
+                    .with_limits("0.5", "256M")
+                    .with_reservations("0.1", "256M")
+                    .with_port(port, port, "mcp");
+
+            local containerSet = engine.containers(
+                "ddg-mcp-server", [ container ]
+            );
+
+            local service =
+                engine.internalService("ddg-mcp-server", containerSet)
+                .with_port(port, port, "mcp");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    mcp +:: {
+        "duckduckgo": {
+            "remote-name": "search",
+            local port = $["ddg-mcp-server-port"],
+            local url = "http://ddg-mcp-server:%s/mcp" % port,
+            "url": url,
+        }
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/model-hosting/cpu-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/cpu-tgi.jsonnet
@@ -1,0 +1,68 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["tgi-service-" + key]:: value,
+        },
+
+    "tgi-service-model":: "teknium/OpenHermes-2.5-Mistral-7B",
+    "tgi-service-cpus":: "8.0",
+    "tgi-service-memory":: "16G",
+    "tgi-service-storage":: "20G",
+    "tgi-service-hf-token":: null,
+
+    "tgi-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("tgi-storage")
+                .with_size($["tgi-service-storage"]);
+
+            local container =
+                engine.container("tgi-service")
+                    .with_image(images["tgi-service-cpu"])
+                    .with_command([
+                        "--model-id",
+                        $["tgi-service-model"],
+                        "--hostname",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--cuda-graphs",
+                        "0",
+                    ])
+                    .with_environment({
+                    } + (
+                        if $["tgi-service-hf-token"] != null
+                            then { HF_TOKEN: $["tgi-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_limits(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_reservations(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_port(7000, 7000, "tgi")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "tgi-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("tgi-service", containerSet)
+                .with_port(7000, 7000, "tgi");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/model-hosting/intel-battlemage-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/intel-battlemage-vllm.jsonnet
@@ -1,0 +1,98 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vllm-service-" + key]:: value,
+        },
+
+    "vllm-service-model":: "mistralai/Mistral-Nemo-Instruct-2407",
+    "vllm-service-cpus":: "32.0",
+    "vllm-service-memory":: "48G",
+    "vllm-service-storage":: "48G",
+    "vllm-service-tokenizer-mode":: "mistral",
+    "vllm-service-datatype":: "float16",
+    "vllm-service-quantization":: "woq_int4",
+    "vllm-service-hf-token":: null,
+    "vllm-service-max-model-len":: 8192,
+    "vllm-service-max-num-seqs":: 16,
+
+    "vllm-service" +: {
+    
+        create:: function(engine)
+
+            local vol = engine.volume("vllm-storage")
+                .with_size($["vllm-service-storage"]);
+
+            local container =
+                engine.container("vllm-service")
+                    .with_image(images["vllm-service-intel-battlemage"])
+                    .with_entrypoint("")  // Clear default entrypoint
+                    .with_command([
+                        "python",
+                        "-m",
+                        "ipex_llm.vllm.xpu.entrypoints.openai.api_server",
+                        "--model",
+                        $["vllm-service-model"],
+                        "--served-model-name",
+                        "model",
+                        "--host",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--device",
+                        "xpu",
+                        "--dtype",
+                        $["vllm-service-datatype"],
+                        "--enforce-eager",
+                        "--max-model-len",
+                        std.toString($["vllm-service-max-model-len"]),
+                        "--max-num-seqs",
+                        std.toString($["vllm-service-max-num-seqs"]),
+                        "--load-in-low-bit",
+                        $["vllm-service-quantization"],
+                        "--trust-remote-code",
+                        "--tokenizer-mode",
+                        $["vllm-service-tokenizer-mode"],
+                        "--disable-sliding-window",
+                    ])
+                    .with_environment({
+                        VLLM_WORKER_MULTIPROC_METHOD: "spawn",
+                        SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS: "1",
+                    } + (
+                        if $["vllm-service-hf-token"] != null
+                            then { HF_TOKEN: $["vllm-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_privileged(true)
+                    .with_device("/dev/dri", "/dev/dri")
+                    .with_ipc("host")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_reservations(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_port(7000, 7000, "vllm")
+                    .with_bind_mount("/dev/dri/by-path", "/dev/dri/by-path")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "vllm-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("vllm-service", containerSet)
+                .with_port(7000, 7000, "vllm");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/model-hosting/intel-gaudi-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/intel-gaudi-tgi.jsonnet
@@ -1,0 +1,96 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["tgi-service-" + key]:: value,
+        },
+
+    "tgi-service-model":: "meta-llama/Llama-3.3-70B-Instruct",
+    "tgi-service-cpus":: "64.0",
+    "tgi-service-memory":: "64G",
+    "tgi-service-storage":: "50G",
+    "tgi-service-num-shard":: 8,
+    "tgi-service-max-input-tokens":: 4096,
+    "tgi-service-max-total-tokens":: 4096,
+    "tgi-service-max-batch-size":: 128,
+    "tgi-service-max-concurrent-requests":: 512,
+    "tgi-service-hf-token":: null,
+
+    "tgi-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("tgi-storage")
+                .with_size($["tgi-service-storage"]);
+
+            local container =
+                engine.container("tgi-service")
+                    .with_image(images["tgi-service-gaudi"])
+                    .with_command([
+                        "--model-id",
+                        $["tgi-service-model"],
+                        "--hostname",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--sharded",
+                        "true",
+                        "--num-shard",
+                        std.toString($["tgi-service-num-shard"]),
+                        "--max-input-tokens",
+                        std.toString($["tgi-service-max-input-tokens"]),
+                        "--max-total-tokens",
+                        std.toString($["tgi-service-max-total-tokens"]),
+                        "--max-batch-size",
+                        std.toString($["tgi-service-max-batch-size"]),
+                        "--max-waiting-tokens",
+                        "7",
+                        "--max-concurrent-requests",
+                        std.toString($["tgi-service-max-concurrent-requests"]),
+                        "--cuda-graphs",
+                        "0",
+                    ])
+                    .with_runtime("habana")
+                    .with_environment({
+                        HABANA_VISIBLE_DEVICES: "all",
+                        OMPI_MCA_btl_vader_single_copy_mechanism: "none",
+                        ENABLE_HPU_GRAPH: "true",
+                        LIMIT_HPU_GRAPH: "true",
+                        USE_FLASH_ATTENTION: "true",
+                        FLASH_ATTENTION_RECOMPUTE: "true",
+                    } + (
+                        if $["tgi-service-hf-token"] != null
+                            then { HF_TOKEN: $["tgi-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_ipc("host")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_reservations(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_port(7000, 7000, "tgi")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "tgi-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("tgi-service", containerSet)
+                .with_port(7000, 7000, "tgi");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/model-hosting/intel-gaudi-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/intel-gaudi-vllm.jsonnet
@@ -1,0 +1,76 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vllm-service-" + key]:: value,
+        },
+
+    "vllm-service-model":: "teknium/OpenHermes-2.5-Mistral-7B",
+    "vllm-service-cpus":: "64.0",
+    "vllm-service-memory":: "64G",
+    "vllm-service-storage":: "50G",
+    "vllm-service-tensor-parallel-size":: 8,
+    "vllm-service-hf-token":: null,
+
+    "vllm-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("vllm-storage")
+                .with_size($["vllm-service-storage"]);
+
+            local container =
+                engine.container("vllm-service")
+                    .with_image(images["vllm-service-gaudi"])
+                    .with_command([
+                        "--model",
+                        $["vllm-service-model"],
+                        "--served-model-name",
+                        "model",
+                        "--host",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--tensor-parallel-size",
+                        std.toString($["vllm-service-tensor-parallel-size"]),
+                    ])
+                    .with_runtime("habana")
+                    .with_environment({
+                        VLLM_SKIP_WARMUP: "true",
+                        HABANA_VISIBLE_DEVICES: "all",
+                    } + (
+                        if $["vllm-service-hf-token"] != null
+                            then { HF_TOKEN: $["vllm-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_privileged(true)
+                    .with_ipc("host")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_reservations(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_port(7000, 7000, "vllm")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "vllm-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("vllm-service", containerSet)
+                .with_port(7000, 7000, "vllm");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/model-hosting/intel-xpu-tgi.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/intel-xpu-tgi.jsonnet
@@ -1,0 +1,75 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["tgi-service-" + key]:: value,
+        },
+
+    "tgi-service-model":: "teknium/OpenHermes-2.5-Mistral-7B",
+    "tgi-service-cpus":: "8.0",
+    "tgi-service-memory":: "16G",
+    "tgi-service-storage":: "20G",
+    "tgi-service-hf-token":: null,
+
+    "tgi-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("tgi-storage")
+                .with_size($["tgi-service-storage"]);
+
+            local container =
+                engine.container("tgi-service")
+                    .with_image(images["tgi-service-intel-xpu"])
+                    .with_command([
+                        "--model-id",
+                        $["tgi-service-model"],
+                        "--hostname",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--cuda-graphs",
+                        "0",
+                    ])
+                    .with_environment({
+                    } + (
+                        if $["tgi-service-hf-token"] != null
+                            then { HF_TOKEN: $["tgi-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_privileged(true)
+                    .with_device("/dev/dri", "/dev/dri")
+                    .with_ipc("host")
+                    .with_supplemental_group("video")
+                    .with_supplemental_group("render")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_reservations(
+                        $["tgi-service-cpus"], $["tgi-service-memory"]
+                    )
+                    .with_port(7000, 7000, "tgi")
+                    .with_bind_mount("/dev/dri/by-path", "/dev/dri/by-path")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "tgi-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("tgi-service", containerSet)
+                .with_port(7000, 7000, "tgi");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/model-hosting/intel-xpu-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/intel-xpu-vllm.jsonnet
@@ -1,0 +1,97 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vllm-service-" + key]:: value,
+        },
+
+    "vllm-service-model":: "teknium/OpenHermes-2.5-Mistral-7B",
+    "vllm-service-cpus":: "8.0",
+    "vllm-service-memory":: "16G",
+    "vllm-service-storage":: "20G",
+    "vllm-service-datatype":: "float16",
+    "vllm-service-max-model-len":: 4096,
+    "vllm-service-max-num-seqs":: 16,
+    "vllm-service-hf-token":: null,
+
+    "vllm-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("vllm-storage")
+                .with_size($["vllm-service-storage"]);
+
+            local container =
+                engine.container("vllm-service")
+                    .with_image(images["vllm-service-intel-xpu"])
+                    .with_command([
+                        "python",
+                        "-m",
+                        "vllm.entrypoints.openai.api_server",
+                        "--model",
+                        $["vllm-service-model"],
+                        "--served-model-name",
+                        "model",
+                        "--host",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                        "--device",
+                        "xpu",
+                        "--dtype",
+                        $["vllm-service-datatype"],
+                        "--enforce-eager",
+                        "--max-model-len",
+                        std.toString($["vllm-service-max-model-len"]),
+                        "--max-num-seqs",
+                        std.toString($["vllm-service-max-num-seqs"]),
+                        "--block-size",
+                        "64",
+                        "--gpu-memory-util",
+                        "0.85",
+                        "--trust-remote-code",
+                        "--disable-sliding-window",
+                    ])
+                    .with_environment({
+                        VLLM_USE_V1: "1",
+                        VLLM_WORKER_MULTIPROC_METHOD: "spawn",
+                    } + (
+                        if $["vllm-service-hf-token"] != null
+                            then { HF_TOKEN: $["vllm-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_privileged(true)
+                    .with_device("/dev/dri", "/dev/dri")
+                    .with_ipc("host")
+                    .with_supplemental_group("video")
+                    .with_supplemental_group("render")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_reservations(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_port(7000, 7000, "vllm")
+                    .with_bind_mount("/dev/dri/by-path", "/dev/dri/by-path")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "vllm-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("vllm-service", containerSet)
+                .with_port(7000, 7000, "vllm");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/model-hosting/nvidia-gpu-vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/model-hosting/nvidia-gpu-vllm.jsonnet
@@ -1,0 +1,72 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["vllm-service-" + key]:: value,
+        },
+
+    "vllm-service-model":: "mistralai/Mistral-7B-Instruct-v0.3",
+    "vllm-service-cpus":: "0.5",
+    "vllm-service-memory":: "1G",
+    "vllm-service-storage":: "50G",
+    "vllm-service-hf-token":: null,
+
+    "vllm-service" +: {
+
+        create:: function(engine)
+
+            local vol = engine.volume("vllm-storage")
+                .with_size($["vllm-service-storage"]);
+
+            local container =
+                engine.container("vllm-service")
+                    .with_image(images["vllm-service-nvidia"])
+                    .with_command([
+                        "--model",
+                        $["vllm-service-model"],
+                        "--served-model-name",
+                        "model",
+                        "--host",
+                        "0.0.0.0",
+                        "--port",
+                        "7000",
+                    ])
+                    .with_runtime("nvidia")
+                    .with_environment({
+                        VLLM_SKIP_WARMUP: "true",
+                    } + (
+                        if $["vllm-service-hf-token"] != null
+                            then { HF_TOKEN: $["vllm-service-hf-token"] }
+                            else {}
+                    ))
+                    .with_privileged(true)
+                    .with_ipc("host")
+                    .with_capability("SYS_NICE")
+                    .with_limits(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_reservations(
+                        $["vllm-service-cpus"], $["vllm-service-memory"]
+                    )
+                    .with_port(7000, 7000, "vllm")
+                    .with_volume_mount(vol, "/root/.cache/huggingface");
+
+            local containerSet = engine.containers(
+                "vllm-service", [ container ]
+            );
+
+            local service =
+                engine.internalService("vllm-service", containerSet)
+                .with_port(7000, 7000, "vllm");
+
+            engine.resources([
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/monitoring/grafana.jsonnet
+++ b/trustgraph_configurator/templates/2.7/monitoring/grafana.jsonnet
@@ -1,0 +1,160 @@
+local images = import "values/images.jsonnet";
+local loki = import "loki.jsonnet";
+
+{
+
+    parameters +:: {
+        "grafana-admin-user":: "admin",
+        "prometheus-cpu-limit": "0.5",
+        "prometheus-cpu-reservation": "0.1",
+        "prometheus-memory-limit": "256M",
+        "prometheus-memory-reservation": "256M",
+        "grafana-cpu-limit": "1.0",
+        "grafana-cpu-reservation": "0.5",
+        "grafana-memory-limit": "256M",
+        "grafana-memory-reservation": "256M",
+    },
+
+    "prometheus" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["prometheus-cpu-limit"],
+        local cpuReservation = pars["prometheus-cpu-reservation"],
+        local memoryLimit = pars["prometheus-memory-limit"],
+        local memoryReservation = pars["prometheus-memory-reservation"],
+
+        create:: function(engine)
+
+            local vol = engine.volume("prometheus-data").with_size("20G");
+
+            local cfgVol = engine.configVolume(
+                "prometheus-cfg", "prometheus",
+		{
+		    "prometheus.yml": $["prometheus-config"],
+		}
+            );
+
+            local container =
+                engine.container("prometheus")
+                    .with_image(images.prometheus)
+                    .with_user(65534)
+                    .with_group(65534)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation)
+                    .with_port(9090, 9090, "http")
+                    .with_volume_mount(cfgVol, "/etc/prometheus/")
+                    .with_volume_mount(vol, "/prometheus");
+
+            local containerSet = engine.containers(
+                "prometheus", [ container ]
+            );
+
+            local service =
+                engine.internalService("prometheus", containerSet)
+                .with_port(9090, 9090, "http");
+
+            engine.resources([
+                cfgVol,
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "grafana" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["grafana-cpu-limit"],
+        local cpuReservation = pars["grafana-cpu-reservation"],
+        local memoryLimit = pars["grafana-memory-limit"],
+        local memoryReservation = pars["grafana-memory-reservation"],
+
+        create:: function(engine)
+
+            local vol = engine.volume("grafana-storage").with_size("20G");
+
+            local envSecrets = engine.envSecrets("grafana-secret")
+                .with_env_var("GF_SECURITY_ADMIN_PASSWORD", "password");
+
+            local provDashVol = engine.configVolume(
+                "prov-dash", "grafana/provisioning/",
+		{
+		    "dashboard.yml":
+                        importstr "grafana/provisioning/dashboard.yml",
+		}
+		
+            );
+
+            local provDataVol = engine.configVolume(
+                "prov-data", "grafana/provisioning/",
+		{
+		    "datasource.yml":
+                        importstr "grafana/provisioning/datasource.yml",
+		}
+		
+            );
+
+            local dashVol = engine.configVolume(
+                "dashboards", "grafana/dashboards/",
+		{
+		    "overview-dashboard.json":
+                        $["overview-dashboard"],
+		    "log-dashboard.json":
+                        importstr "grafana/dashboards/log-dashboard.json",
+		}
+		
+            );
+
+            local container =
+                engine.container("grafana")
+                    .with_image(images.grafana)
+                    .with_user(472)
+                    .with_group(472)
+                    .with_env_var_secrets(envSecrets)
+                    .with_environment({
+                        GF_ORG_NAME: "trustgraph.ai",
+                        GF_SECURITY_ADMIN_USER: pars["grafana-admin-user"],
+                        GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: "/var/lib/grafana/dashboards/overview-dashboard.json",
+                        GF_ANALYTICS_REPORT_WHATS_NEW: "false",
+                        GF_PANELS_DISABLE_NEWS_FEED: "true",
+                        GF_NEWS_NEWS_FEED_ENABLED: "false",
+                        GF_PLUGINS_EXCLUDE_APPS: "grafana-assistant-app",
+                        GF_FEATURE_TOGGLES_ASSISTANT: "false",
+                    })
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation)
+                    .with_port(3000, 3000, "grafana")
+                    .with_volume_mount(vol, "/var/lib/grafana")
+                    .with_volume_mount(
+                        provDashVol, "/etc/grafana/provisioning/dashboards/"
+                    )
+                    .with_volume_mount(
+                        provDataVol, "/etc/grafana/provisioning/datasources/"
+                    )
+                    .with_volume_mount(
+                        dashVol, "/var/lib/grafana/dashboards/"
+                    );
+
+            local containerSet = engine.containers(
+                "grafana", [ container ]
+            );
+
+            local service =
+                engine.service("grafana", containerSet)
+                .with_port(3000, 3000, "http")
+                ;
+
+            engine.resources([
+                vol,
+	        provDashVol,
+	        provDataVol,
+		dashVol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+} + loki
+

--- a/trustgraph_configurator/templates/2.7/monitoring/loki.jsonnet
+++ b/trustgraph_configurator/templates/2.7/monitoring/loki.jsonnet
@@ -1,0 +1,60 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "loki-cpu-limit": "1.0",
+        "loki-cpu-reservation": "0.5",
+        "loki-memory-limit": "350M",
+        "loki-memory-reservation": "350M",
+    },
+
+    "loki" +: {
+
+        local pars = $.parameters,
+        local cpuLimit = pars["loki-cpu-limit"],
+        local cpuReservation = pars["loki-cpu-reservation"],
+        local memoryLimit = pars["loki-memory-limit"],
+        local memoryReservation = pars["loki-memory-reservation"],
+
+        create:: function(engine)
+
+            local vol = engine.volume("loki-data").with_size("20G");
+
+            local cfgVol = engine.configVolume(
+                "loki-cfg", "loki",
+		{
+		    "local-config.yaml": importstr "loki/local-config.yaml",
+		}
+            );
+
+            local container =
+                engine.container("loki")
+                    .with_image(images.loki)
+                    .with_user(10001)
+                    .with_group(10001)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation)
+                    .with_port(3100, 3100, "http")
+                    .with_volume_mount(cfgVol, "/etc/loki/")
+                    .with_volume_mount(vol, "/loki");
+
+            local containerSet = engine.containers(
+                "loki", [ container ]
+            );
+
+            local service =
+                engine.internalService("loki", containerSet)
+                .with_port(3100, 3100, "http");
+
+            engine.resources([
+                cfgVol,
+                vol,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/ocr/mistral-ocr.jsonnet
+++ b/trustgraph_configurator/templates/2.7/ocr/mistral-ocr.jsonnet
@@ -1,0 +1,50 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    local logLevel = $.parameters["log-level"],
+
+    with:: function(key, value)
+        self + {
+            ["mistral-" + key]:: value,
+        },
+
+    "document-decoder" +: {
+    
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("mistral-credentials")
+                .with_env_var("MISTRAL_TOKEN", "mistral-token");
+
+            local container =
+                engine.container("mistral-ocr")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "pdf-ocr-mistral",
+                    ] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "mistral-ocr", [ container ]
+            );
+
+            local service =
+                engine.internalService("mistral-ocr", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/ocr/ocr.jsonnet
+++ b/trustgraph_configurator/templates/2.7/ocr/ocr.jsonnet
@@ -1,0 +1,36 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+{
+
+    "document-decoder" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("pdf-ocr")
+                    .with_image(images.trustgraph_ocr)
+                    .with_command([
+                        "pdf-ocr",
+                    ] + $["pub-sub-args"] + [
+                    ])
+                    .with_limits("1.0", "512M")
+                    .with_reservations("0.1", "512M");
+
+            local containerSet = engine.containers(
+                "pdf-ocr", [ container ]
+            );
+
+            local service =
+                engine.internalService("pdf-ocr", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/parameters/azure-openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/azure-openai.jsonnet
@@ -1,0 +1,9 @@
+// Azure OpenAI LLM Model Definitions
+// Model input is just text
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "gpt-5.2",
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/azure.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/azure.jsonnet
@@ -1,0 +1,9 @@
+// Azure LLM Model Definitions
+// Model input is just text
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "phi4:14b",
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/bedrock.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/bedrock.jsonnet
@@ -1,0 +1,84 @@
+// AWS Bedrock LLM Model Definitions
+// Defines available models and their configurations for AWS Bedrock
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "enum": [
+        // ── Anthropic Claude ──────────────────────────────────────
+        {
+            id: "global.anthropic.claude-opus-4-6-v1",
+            description: "Claude Opus 4.6 (maximum intelligence)"
+        },
+        {
+            id: "global.anthropic.claude-opus-4-5-20251101-v1:0",
+            description: "Claude Opus 4.5 (frontier coding + agents)"
+        },
+        {
+            id: "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            description: "Claude Sonnet 4.5 (complex agents + coding)"
+        },
+        {
+            id: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+            description: "Claude Haiku 4.5 (fastest with near-frontier intelligence)"
+        },
+        {
+            id: "global.anthropic.claude-opus-4-1-20250805-v1:0",
+            description: "Claude Opus 4.1 (agentic search + reasoning)"
+        },
+        {
+            id: "global.anthropic.claude-sonnet-4-20250514-v1:0",
+            description: "Claude Sonnet 4.0"
+        },
+        {
+            id: "anthropic.claude-3-5-haiku-20241022-v1:0",
+            description: "Claude 3.5 Haiku (legacy)"
+        },
+
+        // ── Meta Llama ────────────────────────────────────────────
+        {
+            id: "us.meta.llama4-maverick-17b-instruct-v1:0",
+            description: "Llama 4 Maverick 17B (128 experts, 400B params, multimodal)"
+        },
+        {
+            id: "us.meta.llama4-scout-17b-instruct-v1:0",
+            description: "Llama 4 Scout 17B (16 experts, 3.5M context)"
+        },
+        {
+            id: "us.meta.llama3-3-70b-instruct-v1:0",
+            description: "Llama 3.3 70B Instruct"
+        },
+
+        // ── Mistral AI ────────────────────────────────────────────
+        {
+            id: "us.mistral.mistral-large-2511-v1:0",
+            description: "Mistral Large 3 (flagship text, 128K context)"
+        },
+        {
+            id: "us.mistral.magistral-small-2506-v1:0",
+            description: "Magistral Small 1.2 (reasoning, cost-effective)"
+        },
+
+        // ── DeepSeek ──────────────────────────────────────────────
+        {
+            id: "us.deepseek.r1-v1:0",
+            description: "DeepSeek-R1 (reasoning)"
+        },
+
+        // ── Amazon Nova ───────────────────────────────────────────
+        {
+            id: "us.amazon.nova-pro-v1:0",
+            description: "Amazon Nova Pro (multimodal, balanced)"
+        },
+        {
+            id: "us.amazon.nova-lite-v1:0",
+            description: "Amazon Nova Lite (fast, multimodal)"
+        },
+        {
+            id: "us.amazon.nova-micro-v1:0",
+            description: "Amazon Nova Micro (text-only, cheapest)"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/chunking-param-types.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/chunking-param-types.jsonnet
@@ -1,0 +1,25 @@
+// Chunk parameter type definitions
+
+{
+    "chunk-size": {
+        "type": "integer",
+        "description": "Chunk size",
+        "placeholder": 2000,
+        "helper": "An integer, usually 2000 .. 8000",
+        "default": 2000,
+        "min": 0,
+        "max": 32768,
+        "required": true
+    },
+    "chunk-overlap": {
+        "type": "integer",
+        "description": "Chunk overlap",
+        "placeholder": 50,
+        "helper": "An integer, usually 50 .. 100",
+        "default": 50,
+        "min": 0,
+        "max": 8000,
+        "required": true
+    },
+}
+

--- a/trustgraph_configurator/templates/2.7/parameters/claude.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/claude.jsonnet
@@ -1,0 +1,39 @@
+// Claude LLM Model Definitions
+// Defines available models and their configurations for Anthropic's Claude
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "claude-sonnet-4-5-20250929",
+    "enum": [
+        {
+            id: "claude-opus-4-6",
+            description: "Claude Opus 4.6 (maximum intelligence)"
+        },
+        {
+            id: "claude-opus-4-5-20251101",
+            description: "Claude Opus 4.5 (frontier coding + agents)"
+        },
+        {
+            id: "claude-sonnet-4-5-20250929",
+            description: "Claude Sonnet 4.5 (complex agents + coding)"
+        },
+        {
+            id: "claude-haiku-4-5-20251001",
+            description: "Claude Haiku 4.5 (fast)"
+        },
+        {
+            id: "claude-opus-4-1-20250805",
+            description: "Claude Opus 4.1 (agentic search + reasoning)"
+        },
+        {
+            id: "claude-sonnet-4-20250514",
+            description: "Claude Sonnet 4.0"
+        },
+        {
+            id: "claude-3-5-haiku-20241022",
+            description: "Claude 3.5 Haiku"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/cohere.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/cohere.jsonnet
@@ -1,0 +1,35 @@
+// Cohere LLM Model Definitions
+// Defines available models and their configurations for Cohere
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "command-r-plus-08-2024",
+    "enum": [
+        {
+            id: "command-r-plus-08-2024",
+            description: "Command R+ (August 2024)"
+        },
+        {
+            id: "command-r-08-2024",
+            description: "Command R (August 2024)"
+        },
+        {
+            id: "command-r-plus",
+            description: "Command R+ (legacy)"
+        },
+        {
+            id: "command-r",
+            description: "Command R (legacy)"
+        },
+        {
+            id: "command",
+            description: "Command"
+        },
+        {
+            id: "command-light",
+            description: "Command Light"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/embeddings-fastembed.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/embeddings-fastembed.jsonnet
@@ -1,0 +1,127 @@
+// Embeddings model definitions for fastembed
+// Defines available models and their configurations for Fastembed
+
+{
+    "type": "string",
+    "description": "Embeddings model to use",
+    "default": "sentence-transformers/all-MiniLM-L6-v2",
+    "enum": [
+	{
+	    "id": "sentence-transformers/all-MiniLM-L6-v2",
+	    "description": "all-MiniLM-L6-v2"
+	},
+	{
+	    "id": "BAAI/bge-small-en-v1.5",
+	    "description": "bge-small-en-v1.5"
+	},
+	{
+	    "id": "BAAI/bge-small-zh-v1.5",
+	    "description": "bge-small-zh-v1.5"
+	},
+	{
+	    "id": "snowflake/snowflake-arctic-embed-xs",
+	    "description": "snowflake-arctic-embed-xs"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-small-en",
+	    "description": "jina-embeddings-v2-small-en"
+	},
+	{
+	    "id": "nomic-ai/nomic-embed-text-v1.5-Q",
+	    "description": "nomic-embed-text-v1.5-Q"
+	},
+	{
+	    "id": "snowflake/snowflake-arctic-embed-s",
+	    "description": "snowflake-arctic-embed-s"
+	},
+	{
+	    "id": "BAAI/bge-small-en",
+	    "description": "bge-small-en"
+	},
+	{
+	    "id": "BAAI/bge-base-en-v1.5",
+	    "description": "bge-base-en-v1.5"
+	},
+	{
+	    "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+	    "description": "paraphrase-multilingual-MiniLM-L12-v2"
+	},
+	{
+	    "id": "Qdrant/clip-ViT-B-32-text",
+	    "description": "clip-ViT-B-32-text"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-base-de",
+	    "description": "jina-embeddings-v2-base-de"
+	},
+	{
+	    "id": "BAAI/bge-base-en",
+	    "description": "bge-base-en"
+	},
+	{
+	    "id": "snowflake/snowflake-arctic-embed-m",
+	    "description": "snowflake-arctic-embed-m"
+	},
+	{
+	    "id": "thenlper/gte-base",
+	    "description": "gte-base"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-base-en",
+	    "description": "jina-embeddings-v2-base-en"
+	},
+	{
+	    "id": "nomic-ai/nomic-embed-text-v1",
+	    "description": "nomic-embed-text-v1"
+	},
+	{
+	    "id": "nomic-ai/nomic-embed-text-v1.5",
+	    "description": "nomic-embed-text-v1.5"
+	},
+	{
+	    "id": "snowflake/snowflake-arctic-embed-m-long",
+	    "description": "snowflake-arctic-embed-m-long"
+	},
+	{
+	    "id": "jinaai/jina-clip-v1",
+	    "description": "jina-clip-v1"
+	},
+	{
+	    "id": "mixedbread-ai/mxbai-embed-large-v1",
+	    "description": "mxbai-embed-large-v1"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-base-es",
+	    "description": "jina-embeddings-v2-base-es"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-base-code",
+	    "description": "jina-embeddings-v2-base-code"
+	},
+	{
+	    "id": "jinaai/jina-embeddings-v2-base-zh",
+	    "description": "jina-embeddings-v2-base-zh"
+	},
+	{
+	    "id": "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
+	    "description": "paraphrase-multilingual-mpnet-base-v2"
+	},
+	{
+	    "id": "snowflake/snowflake-arctic-embed-l",
+	    "description": "snowflake-arctic-embed-l"
+	},
+	{
+	    "id": "BAAI/bge-large-en-v1.5",
+	    "description": "bge-large-en-v1.5"
+	},
+	{
+	    "id": "thenlper/gte-large",
+	    "description": "gte-large"
+	},
+	{
+	    "id": "intfloat/multilingual-e5-large",
+	    "description": "multilingual-e5-large"
+	}
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/embeddings-huggingface.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/embeddings-huggingface.jsonnet
@@ -1,0 +1,31 @@
+// Embeddings model definitions for fastembed
+// Defines available models and their configurations for Fastembed
+
+{
+    "type": "string",
+    "description": "Embeddings model to use",
+    "default": "sentence-transformers/all-MiniLM-L6-v2",
+    "enum": [
+	{
+	    "id": "all-MiniLM-L6-v2",
+	    "description": "all-MiniLM-L6-v2"
+	},
+	{
+	    "id": "all-mpnet-base-v2",
+	    "description": "all-mpnet-base-v2"
+	},
+	{
+	    "id": "all-distilroberta-v1",
+	    "description": "all-distilroberta-v1"
+	},
+	{
+	    "id": "stsb-bert-large",
+	    "description": "stsb-bert-large"
+	},
+	{
+	    "id": "sentence-camembert-large",
+	    "description": "sentence-camembert-large"
+	}
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/embeddings-ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/embeddings-ollama.jsonnet
@@ -1,0 +1,23 @@
+// Embeddings model definitions for Ollama
+// Defines available models and their configurations for Ollama
+
+{
+    "type": "string",
+    "description": "Embeddings model to use",
+    "default": "all-minilm:latest",
+    "enum": [
+	{
+	    "id": "all-minilm:latest",
+	    "description": "all-MiniLM-L6-v2"
+	},
+	{
+	    "id": "nomic-ai/nomic-embed-text-v1.5-Q",
+	    "description": "nomic-embed-text-v1.5-Q"
+	},
+	{
+	    "id": "mixedbread-ai/mxbai-embed-large-v1",
+	    "description": "mxbai-embed-large-v1"
+	},
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/googleaistudio.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/googleaistudio.jsonnet
@@ -1,0 +1,54 @@
+// Google AI Studio LLM Model Definitions
+// Defines available models and their configurations for Google AI Studio
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "gemini-2.5-flash-lite",
+    "enum": [
+        // Gemini 3 models (preview)
+        {
+            id: "gemini-3-pro-preview",
+            description: "Gemini 3 Pro (preview)"
+        },
+        {
+            id: "gemini-3-flash-preview",
+            description: "Gemini 3 Flash (preview)"
+        },
+
+        // Gemini 2.5 models
+        {
+            id: "gemini-2.5-pro",
+            description: "Gemini 2.5 Pro"
+        },
+        {
+            id: "gemini-2.5-flash",
+            description: "Gemini 2.5 Flash"
+        },
+        {
+            id: "gemini-2.5-flash-lite",
+            description: "Gemini 2.5 Flash Lite"
+        },
+
+        // Gemini 2.0 models
+        {
+            id: "gemini-2.0-flash-001",
+            description: "Gemini 2.0 Flash"
+        },
+        {
+            id: "gemini-2.0-flash-lite-001",
+            description: "Gemini 2.0 Flash Lite"
+        },
+
+        // Gemma models
+        {
+            id: "gemma-3-27b",
+            description: "Gemma 3 27B"
+        },
+        {
+            id: "gemma-3n-e4b",
+            description: "Gemma 3n E4B"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/llamafile.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/llamafile.jsonnet
@@ -1,0 +1,9 @@
+// LlamaFile LLM Model Definitions
+// Model input is just text
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "phi4:14b",
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/lmstudio.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/lmstudio.jsonnet
@@ -1,0 +1,150 @@
+// LMStudio LLM Model Definitions
+// Defines available models and their configurations for LMStudio
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "llama3.1:70b",
+    "enum": [
+        // Gemma3 models
+        {
+            id: "gemma3:1b",
+            description: "Gemma3 1B"
+        },
+        {
+            id: "gemma3:4b",
+            description: "Gemma3 4B"
+        },
+        {
+            id: "gemma3:12b",
+            description: "Gemma3 12B"
+        },
+        {
+            id: "gemma3:27b",
+            description: "Gemma3 27B"
+        },
+
+        // Phi4 models
+        {
+            id: "phi4:mini:3.8b",
+            description: "Phi4 Mini 3.8B"
+        },
+        {
+            id: "phi4:14b",
+            description: "Phi4 14B"
+        },
+
+        // DeepSeek-R1 models
+        {
+            id: "deepseek-r1:671b",
+            description: "DeepSeek-R1 671B"
+        },
+        {
+            id: "deepseek-r1:70b",
+            description: "DeepSeek-R1 70B"
+        },
+        {
+            id: "deepseek-r1:32b",
+            description: "DeepSeek-R1 32B"
+        },
+        {
+            id: "deepseek-r1:14b",
+            description: "DeepSeek-R1 14B"
+        },
+        {
+            id: "deepseek-r1:8b",
+            description: "DeepSeek-R1 8B"
+        },
+        {
+            id: "deepseek-r1:7b",
+            description: "DeepSeek-R1 7B"
+        },
+        {
+            id: "deepseek-r1:1.5b",
+            description: "DeepSeek-R1 1.5B"
+        },
+
+        // Llama3.1 models
+        {
+            id: "llama3.1:405b",
+            description: "Llama 3.1 405B"
+        },
+        {
+            id: "llama3.1:70b",
+            description: "Llama 3.1 70B"
+        },
+        {
+            id: "llama3.1:8b",
+            description: "Llama 3.1 8B"
+        },
+
+        // Gemma2 models
+        {
+            id: "gemma2:2b",
+            description: "Gemma2 2B"
+        },
+        {
+            id: "gemma2:9b",
+            description: "Gemma2 9B"
+        },
+        {
+            id: "gemma2:27b",
+            description: "Gemma2 27B"
+        },
+
+        // Qwen2.5 models
+        {
+            id: "qwen2.5:0.5b",
+            description: "Qwen2.5 0.5B"
+        },
+        {
+            id: "qwen2.5:1.5b",
+            description: "Qwen2.5 1.5B"
+        },
+        {
+            id: "qwen2.5:3b",
+            description: "Qwen2.5 3B"
+        },
+        {
+            id: "qwen2.5:7b",
+            description: "Qwen2.5 7B"
+        },
+        {
+            id: "qwen2.5:14b",
+            description: "Qwen2.5 14B"
+        },
+        {
+            id: "qwen2.5:32b",
+            description: "Qwen2.5 32B"
+        },
+        {
+            id: "qwen2.5:72b",
+            description: "Qwen2.5 72B"
+        },
+
+        // Mistral models
+        {
+            id: "mistral:7b",
+            description: "Mistral 7B"
+        },
+        {
+            id: "mistral-nemo:12b",
+            description: "Mistral Nemo 12B"
+        },
+        {
+            id: "mistral-large:123b",
+            description: "Mistral Large 123B"
+        },
+
+        // Command-R models
+        {
+            id: "command-r:35b",
+            description: "Command-R 35B"
+        },
+        {
+            id: "command-r-plus:104b",
+            description: "Command-R Plus 104B"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/mistral.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/mistral.jsonnet
@@ -1,0 +1,61 @@
+// Mistral LLM Model Definitions
+// Defines available models and their configurations for Mistral AI
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "mistral-medium-2508",
+    "enum": [
+        // Featured models
+        {
+            id: "mistral-medium-2508",
+            description: "Mistral Medium 3.1"
+        },
+        {
+            id: "mistral-large-2512",
+            description: "Mistral Large 3"
+        },
+        {
+            id: "mistral-small-2506",
+            description: "Mistral Small 3.2"
+        },
+        {
+            id: "ministral-14b-2512",
+            description: "Ministral 3 14B"
+        },
+        {
+            id: "ministral-8b-2512",
+            description: "Ministral 3 8B"
+        },
+        {
+            id: "ministral-3b-2512",
+            description: "Ministral 3 3B"
+        },
+        {
+            id: "magistral-medium-2509",
+            description: "Magistral Medium 1.2 (reasoning)"
+        },
+        {
+            id: "magistral-small-2509",
+            description: "Magistral Small 1.2 (reasoning)"
+        },
+        {
+            id: "devstral-2512",
+            description: "Devstral 2 (code)"
+        },
+        // Other models
+        {
+            id: "codestral-2508",
+            description: "Codestral (code)"
+        },
+        {
+            id: "pixtral-large-2411",
+            description: "Pixtral Large (vision)"
+        },
+        {
+            id: "open-mistral-nemo",
+            description: "Open Mistral Nemo"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/ollama.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/ollama.jsonnet
@@ -1,0 +1,150 @@
+// Ollama LLM Model Definitions
+// Defines available models and their configurations for Ollama
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "gemma3:12b",
+    "enum": [
+        // Gemma3 models
+        {
+            id: "gemma3:1b",
+            description: "Gemma3 1B"
+        },
+        {
+            id: "gemma3:4b",
+            description: "Gemma3 4B"
+        },
+        {
+            id: "gemma3:12b",
+            description: "Gemma3 12B"
+        },
+        {
+            id: "gemma3:27b",
+            description: "Gemma3 27B"
+        },
+
+        // Phi4 models
+        {
+            id: "phi4:mini:3.8b",
+            description: "Phi4 Mini 3.8B"
+        },
+        {
+            id: "phi4:14b",
+            description: "Phi4 14B"
+        },
+
+        // DeepSeek-R1 models
+        {
+            id: "deepseek-r1:671b",
+            description: "DeepSeek-R1 671B"
+        },
+        {
+            id: "deepseek-r1:70b",
+            description: "DeepSeek-R1 70B"
+        },
+        {
+            id: "deepseek-r1:32b",
+            description: "DeepSeek-R1 32B"
+        },
+        {
+            id: "deepseek-r1:14b",
+            description: "DeepSeek-R1 14B"
+        },
+        {
+            id: "deepseek-r1:8b",
+            description: "DeepSeek-R1 8B"
+        },
+        {
+            id: "deepseek-r1:7b",
+            description: "DeepSeek-R1 7B"
+        },
+        {
+            id: "deepseek-r1:1.5b",
+            description: "DeepSeek-R1 1.5B"
+        },
+
+        // Llama3.1 models
+        {
+            id: "llama3.1:405b",
+            description: "Llama 3.1 405B"
+        },
+        {
+            id: "llama3.1:70b",
+            description: "Llama 3.1 70B"
+        },
+        {
+            id: "llama3.1:8b",
+            description: "Llama 3.1 8B"
+        },
+
+        // Gemma2 models
+        {
+            id: "gemma2:2b",
+            description: "Gemma2 2B"
+        },
+        {
+            id: "gemma2:9b",
+            description: "Gemma2 9B"
+        },
+        {
+            id: "gemma2:27b",
+            description: "Gemma2 27B"
+        },
+
+        // Qwen2.5 models
+        {
+            id: "qwen2.5:0.5b",
+            description: "Qwen2.5 0.5B"
+        },
+        {
+            id: "qwen2.5:1.5b",
+            description: "Qwen2.5 1.5B"
+        },
+        {
+            id: "qwen2.5:3b",
+            description: "Qwen2.5 3B"
+        },
+        {
+            id: "qwen2.5:7b",
+            description: "Qwen2.5 7B"
+        },
+        {
+            id: "qwen2.5:14b",
+            description: "Qwen2.5 14B"
+        },
+        {
+            id: "qwen2.5:32b",
+            description: "Qwen2.5 32B"
+        },
+        {
+            id: "qwen2.5:72b",
+            description: "Qwen2.5 72B"
+        },
+
+        // Mistral models
+        {
+            id: "mistral:7b",
+            description: "Mistral 7B"
+        },
+        {
+            id: "mistral-nemo:12b",
+            description: "Mistral Nemo 12B"
+        },
+        {
+            id: "mistral-large:123b",
+            description: "Mistral Large 123B"
+        },
+
+        // Command-R models
+        {
+            id: "command-r:35b",
+            description: "Command-R 35B"
+        },
+        {
+            id: "command-r-plus:104b",
+            description: "Command-R Plus 104B"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/openai.jsonnet
@@ -1,0 +1,51 @@
+// OpenAI LLM Model Definitions
+// Defines available models and their configurations for OpenAI's platform
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "gpt-5.2",
+    "enum": [
+        {
+            id: "gpt-5.2-pro",
+            description: "GPT-5.2 Pro (maximum intelligence, slow)"
+        },
+        {
+            id: "gpt-5.2",
+            description: "GPT-5.2 (flagship, best general-purpose)"
+        },
+        {
+            id: "gpt-5.2-codex",
+            description: "GPT-5.2 Codex (optimized for agentic coding)"
+        },
+        {
+            id: "gpt-5.1",
+            description: "GPT-5.1 (previous flagship)"
+        },
+        {
+            id: "gpt-5",
+            description: "GPT-5 (previous gen reasoning)"
+        },
+        {
+            id: "gpt-4.1",
+            description: "GPT-4.1 (coding + long context, 1M tokens)"
+        },
+        {
+            id: "gpt-4.1-mini",
+            description: "GPT-4.1 Mini (fast + affordable)"
+        },
+        {
+            id: "gpt-4.1-nano",
+            description: "GPT-4.1 Nano (ultra-fast, cheapest)"
+        },
+        {
+            id: "gpt-4o",
+            description: "GPT-4o (legacy multimodal)"
+        },
+        {
+            id: "gpt-4o-mini",
+            description: "GPT-4o Mini (legacy, budget)"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/reranker-flashrank.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/reranker-flashrank.jsonnet
@@ -1,0 +1,27 @@
+// Re-ranking model definitions for FlashRank
+// Defines available models and their configurations for FlashRank
+
+{
+    "type": "string",
+    "description": "Re-ranking model to use",
+    "default": "ms-marco-MiniLM-L-12-v2",
+    "enum": [
+	{
+	    "id": "ms-marco-MiniLM-L-12-v2",
+	    "description": "ms-marco-MiniLM-L-12-v2 - good quality/speed balance"
+	},
+	{
+	    "id": "ms-marco-TinyBERT-L-2-v2",
+	    "description": "ms-marco-TinyBERT-L-2-v2 - small / fast"
+	},
+	{
+	    "id": "ms-marco-MultiBERT-L-12",
+	    "description": "ms-marco-MultiBERT-L-12 - multilingual"
+	},
+	{
+	    "id": "ce-esci-MiniLM-L12-v2",
+	    "description": "ce-esci-MiniLM-L12-v2 - e-commerce tuned"
+	}
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/parameters/temperature-param-types.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/temperature-param-types.jsonnet
@@ -1,0 +1,15 @@
+// LLM temperature definitions
+
+{
+    "llm-temperature": {
+        "type": "float",
+        "description": "LLM temperature",
+        "placeholder": 0.3,
+        "helper": "A floating point number between 0 and 1",
+        "default": 0.3,
+        "min": 0.0,
+        "max": 10.0,
+        "required": true
+    }
+}
+

--- a/trustgraph_configurator/templates/2.7/parameters/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/vertexai.jsonnet
@@ -1,0 +1,81 @@
+// VertexAI LLM Model Definitions
+// Defines available models and their configurations for Google's VertexAI platform
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "gemini-2.5-flash-lite",
+    "enum": [
+        // Gemini 3 models (preview)
+        {
+            id: "gemini-3-pro-preview",
+            description: "Gemini 3 Pro (preview)"
+        },
+        {
+            id: "gemini-3-flash-preview",
+            description: "Gemini 3 Flash (preview)"
+        },
+
+        // Gemini 2.5 models
+        {
+            id: "gemini-2.5-pro",
+            description: "Gemini 2.5 Pro"
+        },
+        {
+            id: "gemini-2.5-flash",
+            description: "Gemini 2.5 Flash"
+        },
+        {
+            id: "gemini-2.5-flash-lite",
+            description: "Gemini 2.5 Flash Lite"
+        },
+
+        // Gemini 2.0 models
+        {
+            id: "gemini-2.0-flash-001",
+            description: "Gemini 2.0 Flash"
+        },
+        {
+            id: "gemini-2.0-flash-lite-001",
+            description: "Gemini 2.0 Flash Lite"
+        },
+
+        // Gemma models
+        {
+            id: "gemma-3-27b",
+            description: "Gemma 3 27B"
+        },
+        {
+            id: "gemma-3n-e4b",
+            description: "Gemma 3n E4B"
+        },
+
+        // Claude models on VertexAI
+        {
+            id: "claude-opus-4-6",
+            description: "Claude Opus 4.6"
+        },
+        {
+            id: "claude-opus-4-5",
+            description: "Claude Opus 4.5"
+        },
+        {
+            id: "claude-sonnet-4-5",
+            description: "Claude Sonnet 4.5"
+        },
+        {
+            id: "claude-haiku-4-5",
+            description: "Claude Haiku 4.5"
+        },
+        {
+            id: "claude-opus-4-1",
+            description: "Claude Opus 4.1"
+        },
+        {
+            id: "claude-sonnet-4",
+            description: "Claude Sonnet 4"
+        },
+    ],
+    "required": true
+}
+

--- a/trustgraph_configurator/templates/2.7/parameters/vllm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/parameters/vllm.jsonnet
@@ -1,0 +1,18 @@
+// vLLM Model Definitions
+// Defines available models and their configurations for vLLM
+// vLLM works with any HuggingFace model.  We have to use the model
+// vLLM was initialised with
+
+{
+    "type": "string",
+    "description": "LLM model to use",
+    "default": "model",
+    "enum": [
+        // Llama 3.1 models
+        {
+            id: "model",
+            description: "Pre-defined model"
+        },
+    ],
+    "required": true
+}

--- a/trustgraph_configurator/templates/2.7/profiles/memory-profile-low.jsonnet
+++ b/trustgraph_configurator/templates/2.7/profiles/memory-profile-low.jsonnet
@@ -1,0 +1,169 @@
+// Low memory profile - reduces memory allocation across components.
+// Include this at the END of your configuration to override default memory
+// settings with lower values suitable for memory-constrained environments.
+//
+// Usage: {"name": "memory-profile-low", "parameters": {}}
+//
+// Note: This trades some performance headroom for reduced memory usage.
+// Monitor for OOM errors under heavy load.
+
+{
+
+    // Override Pulsar stack memory settings
+    "pulsar" +: {
+
+        // Zookeeper: 512M -> 300M
+        "zk-memory-limit":: "300M",
+        "zk-memory-reservation":: "200M",
+        "zk-heap":: "128m",
+        "zk-direct-memory":: "64m",
+
+        // Bookie: 1024M -> 600M
+        "bookie-memory-limit":: "600M",
+        "bookie-memory-reservation":: "400M",
+        "bookie-heap":: "128m",
+        "bookie-direct-memory":: "128m",
+
+        // Broker: 800M -> 512M
+        "broker-memory-limit":: "512M",
+        "broker-memory-reservation":: "400M",
+        "broker-heap":: "192m",
+        "broker-direct-memory":: "192m",
+
+        // Pulsar-init: 256M -> 128M
+        "init-memory-limit":: "128M",
+        "init-memory-reservation":: "128M",
+        "init-heap":: "64m",
+        "init-direct-memory":: "64m",
+
+    },
+
+    // Override Cassandra memory settings: 1000M -> 600M
+    "cassandra" +: {
+        "memory-limit":: "600M",
+        "memory-reservation":: "500M",
+        "heap":: "200M",
+    },
+
+    // Override Qdrant memory settings: 1024M -> 600M
+    // Also enables mmap for vectors/payloads (trades latency for memory)
+    "qdrant" +: {
+        "memory-limit":: "600M",
+        "memory-reservation":: "500M",
+        "memmap-threshold-kb":: "1",
+        "on-disk-payload":: "true",
+    },
+
+    // TrustGraph core services - 50% memory reservations
+    "api-gateway" +: {
+        "memory-reservation":: "256M",  // 512M -> 256M
+    },
+
+    "chunker" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "config-svc" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "document-decoder" +: {
+        "memory-reservation":: "256M",  // 512M -> 256M
+    },
+
+    "mcp-tool" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "mcp-server" +: {
+        "memory-reservation":: "128M",  // 256M -> 128M
+    },
+
+    "metering" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "metering-rag" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "kg-store" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "kg-manager" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "prompt" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "prompt-rag" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "document-rag" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "document-embeddings" +: {
+        "memory-reservation":: "256M",  // 512M -> 256M
+    },
+
+    "librarian" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "agent-manager" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    // Graph RAG services
+    "kg-extract-definitions" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "kg-extract-relationships" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "kg-extract-agent" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "kg-extract-ontology" +: {
+        "memory-reservation":: "150M",  // 300M -> 150M
+    },
+
+    "kg-extract-objects" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "graph-rag" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "graph-embeddings" +: {
+        "memory-reservation":: "256M",  // 512M -> 256M
+    },
+
+    // Structured data services
+    "nlp-query" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "structured-query" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+    "structured-diag" +: {
+        "memory-reservation":: "48M",   // 96M -> 48M
+    },
+
+    // Init service
+    "init-trustgraph" +: {
+        "memory-reservation":: "64M",   // 128M -> 64M
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/prompts/agent-kg-extract.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/agent-kg-extract.txt
@@ -1,0 +1,28 @@
+Analyze the following text and extract both entity definitions and relationships.
+
+For definitions, extract entities and their explanations or descriptions.
+For relationships, extract subject-predicate-object triples where subjects and objects are entities, and predicates are relationship types.
+
+Text: {{text}}
+
+Output format: JSONL (one JSON object per line, no array wrapper)
+Each line must include a "type" field to distinguish between definitions and relationships.
+
+For definitions, output:
+{"type": "definition", "entity": "entity_name", "definition": "definition_text"}
+
+For relationships, output:
+{"type": "relationship", "subject": "subject_entity", "predicate": "relationship_type", "object": "object_entity_or_literal", "object-entity": true}
+
+Requirements:
+- Each line must be a complete, valid JSON object
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting or prefixes
+- Do not provide explanations, only output JSONL
+
+Example output:
+{"type": "definition", "entity": "DNA", "definition": "Deoxyribonucleic acid, a molecule carrying genetic instructions"}
+{"type": "definition", "entity": "RNA", "definition": "Ribonucleic acid, essential for coding and gene expression"}
+{"type": "relationship", "subject": "DNA", "predicate": "transcribes_to", "object": "RNA", "object-entity": true}
+{"type": "relationship", "subject": "DNA", "predicate": "located_in", "object": "cell nucleus", "object-entity": true}

--- a/trustgraph_configurator/templates/2.7/prompts/agent-prompt.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/agent-prompt.txt
@@ -1,0 +1,104 @@
+# ReAct Agent System Prompt
+
+You are an AI assistant that uses the ReAct (Reasoning + Acting) framework to solve problems through systematic reasoning and tool use.
+
+## Core Instructions
+
+For each user query, work through the problem step-by-step using this cycle:
+1. **Thought**: Reason about the current situation and determine what you need to do next
+2. **Action**: Take ONE specific action using an available tool
+3. Wait for **Observation**: The system will provide the result of your action
+4. Continue with the next **Thought** based on the observation
+
+**CRITICAL**: Generate exactly ONE Thought followed by ONE Action, then STOP. Do not generate multiple Thought/Action pairs in a single response. Do not generate Observations yourself - the system will provide them.
+
+## Response Format
+
+Use this exact format for each step:
+
+```
+Thought: [Your reasoning about what to do next - be specific about why this action is needed]
+Action: [tool_name]
+Args: {
+  "parameter_name": "value",
+  "another_parameter": 123,
+  "list_parameter": ["item1", "item2"]
+}
+```
+
+When you have finished provide the final answer:
+
+```
+Thought: [Your reasoning about why the process is complete]
+Final Answer: [The final answer]
+```
+
+When providing a final answer, do not provide an Action or Args.
+
+## Action Format Rules
+
+1. **Tool Name**: Write "Action: " followed by the exact tool name on its own line
+2. **Arguments**: Write "Args: " followed by a valid JSON object containing all parameters
+3. **JSON Requirements**:
+   - Use double quotes for all string keys and values
+   - Numbers don't need quotes: `"count": 5`
+   - Booleans: `"enabled": true` or `"enabled": false`
+   - Arrays: `"items": ["a", "b", "c"]`
+   - Nested objects: `"config": {"setting": "value"}`
+   - Null values: `"optional_field": null`
+4. **Required Parameters**: Include all required parameters for the tool
+5. **No Extra Text**: Don't add explanations or comments within the Action block
+1. **Final answer**: Write "Final Answer: " followed by the final answer
+
+## Available Tools
+
+{% for tool in tools %}- **{{ tool.name }}**: {{ tool.description }}
+{% for arg in tool.arguments %}  - Required: `"{{ arg.name }}"` ({{ arg.type }}): {{ arg.description }}
+{% endfor %}
+{% endfor %}
+
+## Behavior Rules
+
+1. **One Step at a Time**: Generate exactly one Thought and one Action, then wait for the system to provide an Observation
+2. **Be Specific**: Your Thought should clearly explain why you're taking the specific action
+3. **Use Context**: Build on previous Observations to inform your next steps
+4. **Error Handling**: If an action fails, reason about the error and try a different approach
+5. **Completion**: When you have enough information to fully answer the user's query, generate a final Thought explaining your conclusion, but do not take further actions
+
+## Error Responses
+
+If an action fails, you'll see:
+```
+Observation: Error: [specific error message]
+```
+
+When this happens:
+- Generate a Thought analyzing what went wrong
+- Take a corrective Action with different parameters or a different tool
+- If a tool is completely unavailable, explain this limitation in your next Thought
+
+## Termination
+
+The conversation ends when:
+- You determine you have sufficient information to answer the user's query completely and provide a final answer.
+- You encounter an unrecoverable error that prevents task completion
+- The system reaches the maximum iteration limit
+
+## Important Notes
+
+- **Never generate Observations yourself** - only the system provides these
+- **Always validate your JSON** - malformed JSON will cause action failures  
+- **Stay focused** - each Thought should directly relate to solving the user's query
+- **Be efficient** - choose actions that gather the most relevant information for the task
+
+# Proceed
+
+Question: {{question}}
+    
+{% for h in history %}
+Action: "{{h.action}}"
+Args: {
+{% for k, v in h.arguments.items() %}  "{{k}}": "{{v}}"
+{% endfor %}}
+Observation: "{{h.observation}}"
+{% endfor %}

--- a/trustgraph_configurator/templates/2.7/prompts/cohere.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/cohere.jsonnet
@@ -1,0 +1,42 @@
+// For Cohere.  Not currently overriding prompts
+
+local prompts = import "default-prompts.jsonnet";
+
+prompts + {
+
+    // "system-template":: "PROMPT GOES HERE.",
+
+    "templates" +:: {
+
+        "question" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-definitions" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-relationships" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-topics" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-rows" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "kg-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "document-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/prompts/default-prompts.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/default-prompts.jsonnet
@@ -1,0 +1,301 @@
+
+// Prompt templates.  For tidy JSONNET use, don't change these templates
+// here, but use over-rides in the prompt directory
+
+{
+
+    "system-template":: "You are a helpful assistant.",
+
+    "templates":: {
+
+        "question":: {
+            "prompt": "{{question}}",
+        },
+
+        "extract-concepts":: {
+            "prompt": importstr "extract-concepts.txt",
+            "response-type": "text",
+        },
+
+        "extract-definitions":: {
+            "prompt": importstr "extract-definitions.txt",
+            "response-type": "jsonl",
+            "object-schema": {
+                "type": "object",
+                "properties": {
+                    "entity": {
+                        "type": "string"
+                    },
+                    "definition": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "entity",
+                    "definition"
+                ]
+            }
+        },
+
+        "extract-relationships":: {
+            "prompt": importstr "extract-relationships.txt",
+            "response-type": "jsonl",
+            "object-schema": {
+                "type": "object",
+                "properties": {
+                    "subject": {
+                        "type": "string"
+                    },
+                    "predicate": {
+                        "type": "string"
+                    },
+                    "object": {
+                        "type": "string"
+                    },
+                    "object-entity": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "subject",
+                    "predicate",
+                    "object",
+                    "object-entity"
+                ]
+            }
+        },
+
+        "extract-topics":: {
+            "prompt": importstr "extract-topics.txt",
+            "response-type": "jsonl",
+            "object-schema": {
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string"
+                    },
+                    "definition": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "topic",
+                    "definition"
+                ]
+            }
+        },
+
+        "extract-rows":: {
+            "prompt": importstr "extract-rows.txt",
+            "response-type": "jsonl",
+        },
+
+        "kg-synthesis":: {
+            "prompt": importstr "kg-synthesis.txt",
+            "response-type": "text",
+        },
+
+        "document-prompt":: {
+            "prompt": importstr "document-prompt.txt",
+            "response-type": "text",
+        },
+
+        "agent-react":: {
+            "prompt": importstr "agent-prompt.txt",
+            "response-type": "text"
+        },
+
+        "agent-kg-extract":: {
+            "prompt": importstr "agent-kg-extract.txt",
+            "response-type": "jsonl",
+            "object-schema": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": { "const": "definition" },
+                            "entity": { "type": "string" },
+                            "definition": { "type": "string" }
+                        },
+                        "required": ["type", "entity", "definition"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": { "const": "relationship" },
+                            "subject": { "type": "string" },
+                            "predicate": { "type": "string" },
+                            "object": { "type": "string" },
+                            "object-entity": { "type": "boolean" }
+                        },
+                        "required": ["type", "subject", "predicate", "object"]
+                    }
+                ]
+            }
+        },
+
+        "schema-selection":: {
+            "prompt": importstr "schema-selection.txt",
+            "response-type": "json",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "An array of schema names that are relevant to answering the given question"
+            }
+        },
+
+        "graphql-generation":: {
+            "prompt": importstr "graphql-generation.txt",
+            "response-type": "json",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The GraphQL query string generated to answer the question"
+                    },
+                    "variables": {
+                        "type": "object",
+                        "description": "Object containing any GraphQL variables needed for the query",
+                        "additionalProperties": true
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "minimum": 0.0,
+                        "maximum": 1.0,
+                        "description": "Float between 0.0-1.0 indicating confidence in the generated query"
+                    }
+                },
+                "required": ["query", "variables", "confidence"],
+                "additionalProperties": false
+            }
+        },
+
+        "diagnose-structured-data":: {
+            "prompt": importstr "diagnose-structured-data.txt",
+            "response-type": "json",
+        },
+
+        "diagnose-xml":: {
+            "prompt": importstr "diagnose-xml.txt",
+            "response-type": "json",
+        },
+        "diagnose-json":: {
+            "prompt": importstr "diagnose-json.txt",
+            "response-type": "json",
+        },
+        "diagnose-csv":: {
+            "prompt": importstr "diagnose-csv.txt",
+            "response-type": "json",
+        },
+
+        "extract-with-ontologies":: {
+            "prompt": importstr "ontology-prompt.txt",
+            "response-type": "jsonl",
+            "object-schema": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": { "const": "entity" },
+                            "entity": { "type": "string" },
+                            "entity_type": { "type": "string" }
+                        },
+                        "required": ["type", "entity", "entity_type"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": { "const": "relationship" },
+                            "subject": { "type": "string" },
+                            "subject_type": { "type": "string" },
+                            "relation": { "type": "string" },
+                            "object": { "type": "string" },
+                            "object_type": { "type": "string" }
+                        },
+                        "required": ["type", "subject", "subject_type", "relation", "object", "object_type"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": { "const": "attribute" },
+                            "entity": { "type": "string" },
+                            "entity_type": { "type": "string" },
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" }
+                        },
+                        "required": ["type", "entity", "entity_type", "attribute", "value"]
+                    }
+                ]
+            }
+        },
+
+        "task-type-classify":: {
+            "prompt": importstr "task-type-classify.txt",
+            "response-type": "text",
+        },
+
+        "pattern-select":: {
+            "prompt": importstr "pattern-select.txt",
+            "response-type": "text",
+        },
+
+        "plan-create":: {
+            "prompt": importstr "plan-create.txt",
+            "response-type": "json",
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "goal": {"type": "string"},
+                        "tool_hint": {"type": "string"},
+                        "depends_on": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        },
+                    },
+                    "required": ["goal"],
+                },
+            }
+        },
+
+
+        "plan-step-execute": {
+            "prompt": importstr "plan-step-execute.txt",
+            "response-type": "json",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "tool": {"type": "string"},
+                    "arguments": {"type": "object"}
+                },
+                "required": ["tool", "arguments"]
+              }
+        },
+
+        "plan-synthesise":: {
+            "prompt": importstr "plan-synthesise.txt",
+            "response-type": "text",
+        },
+
+        "supervisor-decompose":: {
+            "prompt": importstr "supervisor-decompose.txt",
+            "response-type": "json",
+            "schema": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+
+        "supervisor-synthesise":: {
+            "prompt": importstr "supervisor-synthesise.txt",
+            "response-type": "text",
+        },
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/prompts/diagnose-csv.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/diagnose-csv.txt
@@ -1,0 +1,370 @@
+You are an expert data engineer specializing in creating Structured Data Descriptor configurations for data import pipelines, with particular expertise in CSV processing and delimiter-separated value formats. Your task is to generate a complete JSON configuration that describes how to parse, transform, and import structured CSV data.
+
+## Your Role
+Generate a comprehensive Structured Data Descriptor configuration based on the user's requirements. The descriptor should be production-ready, include appropriate error handling, and follow best practices for data quality and transformation.
+
+## CSV Processing Expertise
+
+When working with CSV data, you must:
+
+1. **Analyze CSV Structure** - Examine headers, delimiters, quoting, and data patterns
+2. **Identify Column Mappings** - Map source column names to target fields
+3. **Handle Complex CSV Patterns** - Support various CSV formats including:
+   - Standard comma-separated values: `name,age,city`
+   - Alternative delimiters: tab-separated (TSV), pipe-separated, semicolon-separated
+   - Quoted fields with embedded delimiters: `"Last, First",25,"New York, NY"`
+   - Headers with spaces or special characters: `"Customer Name","Order Date","Total Amount"`
+   - Files with or without headers
+   - Multi-line fields with embedded newlines
+
+## CSV Format Configuration Guidelines
+
+For CSV format configurations, use these patterns:
+
+**Basic CSV Configuration:**
+```json
+{
+  "format": {
+    "type": "csv",
+    "encoding": "utf-8",
+    "options": {
+      "delimiter": ",",
+      "quote_char": "\"",
+      "has_header": true,
+      "skip_rows": 0
+    }
+  }
+}
+```
+
+**Advanced CSV Options:**
+```json
+{
+  "format": {
+    "type": "csv",
+    "encoding": "utf-8",
+    "options": {
+      "delimiter": "\t",                  // Tab-separated
+      "quote_char": "\"",
+      "escape_char": "\\",
+      "has_header": true,
+      "skip_rows": 2,                     // Skip metadata rows
+      "null_values": ["", "NULL", "N/A"],
+      "trim_whitespace": true,
+      "skip_blank_lines": true
+    }
+  }
+}
+```
+
+**CRITICAL: Source Field Names in Mappings**
+
+When processing CSV files, the parser uses column headers (if present) or generates column indices as field names. Your source field names in mappings must match exactly:
+
+**CORRECT Example with Headers:**
+CSV file:
+```csv
+Customer Name,Order Date,Total Amount,Status
+John Smith,2024-01-15,1000.50,Active
+Jane Doe,2024-01-16,750.25,Pending
+```
+
+Becomes parsed data:
+```json
+{
+  "Customer Name": "John Smith",
+  "Order Date": "2024-01-15", 
+  "Total Amount": "1000.50",
+  "Status": "Active"
+}
+```
+
+Your mappings should use:
+```json
+{
+  "source_field": "Customer Name",     // ✅ Correct - matches header exactly
+  "source_field": "Order Date",       // ✅ Correct - matches header exactly  
+  "source_field": "Total Amount",     // ✅ Correct - matches header exactly
+  "source_field": "Status"            // ✅ Correct - matches header exactly
+}
+```
+
+**CORRECT Example without Headers:**
+CSV file without headers uses column indices:
+```csv
+John Smith,2024-01-15,1000.50,Active
+Jane Doe,2024-01-16,750.25,Pending
+```
+
+Becomes parsed data:
+```json
+{
+  "0": "John Smith",
+  "1": "2024-01-15",
+  "2": "1000.50", 
+  "3": "Active"
+}
+```
+
+Your mappings should use:
+```json
+{
+  "source_field": "0",     // ✅ Correct - first column
+  "source_field": "1",     // ✅ Correct - second column
+  "source_field": "2",     // ✅ Correct - third column
+  "source_field": "3"      // ✅ Correct - fourth column
+}
+```
+
+## Required Information to Gather
+
+Before generating the descriptor, ask the user for these details if not provided:
+
+1. **Source Data Format**
+   - Delimiter character (comma, tab, pipe, semicolon, etc.)
+   - Quote character and escape character
+   - **For CSV**: Does the file have headers? Sample structure
+   - Text encoding (UTF-8, Windows-1252, etc.)
+   - Any rows to skip (metadata, blank lines)
+   - How null/empty values are represented
+
+2. **Target Schema**
+   - What fields should be in the final output?
+   - What data types are expected?
+   - Any required vs optional fields?
+
+3. **Data Transformations Needed**
+   - Field mappings (source column → target field)
+   - Data cleaning requirements (trim spaces, normalize case, etc.)
+   - Type conversions needed
+   - Any calculations or derived fields
+   - Lookup tables or reference data needed
+   - Date/time format conversions
+
+4. **Data Quality Requirements**
+   - Validation rules (format patterns, ranges, required fields)
+   - How to handle missing or invalid data
+   - Duplicate handling strategy
+   - Row-level validation rules
+
+5. **Processing Requirements**
+   - Any filtering needed (skip certain records)
+   - Sorting requirements
+   - Aggregation or grouping needs
+   - Error handling preferences
+
+## CSV Structure Analysis
+
+When presented with CSV data, analyze:
+
+1. **Delimiter Detection**: What character separates the fields?
+2. **Header Presence**: Does the first row contain column names?
+3. **Quote Pattern**: Are fields quoted? What quote character is used?
+4. **Data Types**: What types are present in each column?
+5. **Null Representation**: How are empty/null values represented?
+6. **Special Characters**: Are there embedded commas, quotes, or newlines?
+7. **Encoding Issues**: Are there any character encoding problems?
+
+## Configuration Template Structure
+
+Generate a JSON configuration following this structure:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "[Descriptive name]",
+    "description": "[What this config does]",
+    "author": "[Author or team]",
+    "created": "[ISO date]"
+  },
+  "format": {
+    "type": "csv",
+    "encoding": "utf-8",
+    "options": {
+      // CSV-specific parsing options
+      // delimiter, quote_char, has_header, skip_rows, etc.
+    }
+  },
+  "globals": {
+    "variables": {
+      // Global variables and constants
+    },
+    "lookup_tables": {
+      // Reference data for transformations
+    }
+  },
+  "preprocessing": [
+    // Global filters and operations before field mapping
+  ],
+  "mappings": [
+    // Field mapping definitions with transforms and validation
+  ],
+  "postprocessing": [
+    // Global operations after field mapping
+  ],
+  "output": {
+    "format": "trustgraph-objects",
+    "schema_name": "[target schema name]",
+    "options": {
+      "confidence": 0.85,
+      "batch_size": 1000
+    },
+    "error_handling": {
+      "on_validation_error": "log_and_skip",
+      "on_transform_error": "log_and_skip",
+      "max_errors": 100
+    }
+  }
+}
+```
+
+## Transform Types Available
+
+Use these transform types in your mappings:
+
+**String Operations:**
+- `trim`, `upper`, `lower`, `title_case`
+- `replace`, `regex_replace`, `substring`, `pad_left`
+- `split`, `strip_quotes`
+
+**Type Conversions:**
+- `to_string`, `to_int`, `to_float`, `to_bool`, `to_date`
+- `parse_number`, `parse_currency`
+
+**Data Operations:**
+- `default`, `lookup`, `concat`, `calculate`, `conditional`
+- `clean_whitespace`, `normalize_encoding`
+
+**Date/Time Operations:**
+- `parse_date`, `format_date`, `date_component`
+
+**Validation Types:**
+- `required`, `not_null`, `min_length`, `max_length`
+- `range`, `pattern`, `in_list`, `custom`
+- `numeric_range`, `date_range`
+
+## CSV-Specific Best Practices
+
+1. **Detect delimiters accurately** - test with sample data to confirm delimiter
+2. **Handle quoted fields properly** - account for embedded delimiters and quotes
+3. **Trim whitespace consistently** - decide whether to preserve or remove extra spaces
+4. **Validate data types early** - catch type conversion errors at the field level
+5. **Handle empty values explicitly** - distinguish between empty strings and nulls
+6. **Account for encoding issues** - especially with international characters
+7. **Validate row structure** - ensure consistent column counts across rows
+
+## Best Practices to Follow
+
+1. **Always include error handling** with appropriate policies
+2. **Use meaningful field names** that match target schema
+3. **Add validation** for critical fields
+4. **Include default values** for optional fields
+5. **Use lookup tables** for code translations
+6. **Add preprocessing filters** to exclude invalid records
+7. **Include metadata** for documentation and maintenance
+8. **Consider performance** with appropriate batch sizes
+9. **Handle CSV-specific edge cases** like malformed quotes, inconsistent delimiters
+10. **Test with sample data** to validate parsing configuration
+
+## Complete CSV Example
+
+Given this CSV structure:
+```csv
+Customer Name,Order Date,Total Amount,Currency,Status
+"Smith, John",2024-01-15,1000.50,USD,Active
+"Doe, Jane",2024-01-16,750.25,EUR,Pending
+"Johnson, Bob",2024-01-17,,USD,Cancelled
+```
+
+The parser will:
+1. Use `delimiter: ","` and `quote_char: "\""` to parse fields correctly
+2. Use `has_header: true` to treat first row as column names
+3. Create this parsed data structure for each record:
+   ```json
+   {
+     "Customer Name": "Smith, John",
+     "Order Date": "2024-01-15",
+     "Total Amount": "1000.50", 
+     "Currency": "USD",
+     "Status": "Active"
+   }
+   ```
+
+Generate this COMPLETE configuration:
+```json
+{
+  "format": {
+    "type": "csv",
+    "encoding": "utf-8", 
+    "options": {
+      "delimiter": ",",
+      "quote_char": "\"",
+      "has_header": true,
+      "trim_whitespace": true,
+      "null_values": ["", "NULL"]
+    }
+  },
+  "mappings": [
+    {
+      "source_field": "Customer Name",        // ✅ Matches header exactly
+      "target_field": "customer_name",
+      "transforms": [{"type": "trim"}]
+    },
+    {
+      "source_field": "Order Date",           // ✅ Matches header exactly
+      "target_field": "order_date",
+      "transforms": [{"type": "to_date", "format": "YYYY-MM-DD"}],
+      "validation": [{"type": "required"}]
+    },
+    {
+      "source_field": "Total Amount",         // ✅ Matches header exactly
+      "target_field": "amount",
+      "transforms": [
+        {"type": "to_float"},
+        {"type": "default", "value": 0.0}
+      ]
+    },
+    {
+      "source_field": "Currency",             // ✅ Matches header exactly
+      "target_field": "currency_code",
+      "transforms": [{"type": "upper"}],
+      "validation": [{"type": "in_list", "values": ["USD", "EUR", "GBP"]}]
+    },
+    {
+      "source_field": "Status",               // ✅ Matches header exactly
+      "target_field": "order_status",
+      "transforms": [{"type": "lower"}]
+    }
+  ]
+}
+```
+
+**KEY RULE: source_field names must match the column headers exactly, or use column indices (0, 1, 2, etc.) for files without headers.**
+
+## Output Format
+
+Provide the configuration as ONLY a properly formatted JSON document.
+
+## Schema
+
+The following schema describes the target result format:
+
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}
+- {{ field.name }} ({{ field.type }}){% if field.description %}: {{ field.description }}{% endif
+%}{% if field.primary_key %} [PRIMARY KEY]{% endif %}{% if field.required %} [REQUIRED]{% endif 
+%}{% if field.indexed %} [INDEXED]{% endif %}{% if field.enum_values %} [OPTIONS: {{
+field.enum_values|join(', ') }}]{% endif %}
+{% endfor %}
+
+{% endfor %}
+
+## Data sample
+
+Analyze the CSV structure and produce a Structured Data Descriptor by diagnosing the following data sample. Pay special attention to delimiter detection, header identification, quoting patterns, and data type inference:
+
+{{sample}}
+

--- a/trustgraph_configurator/templates/2.7/prompts/diagnose-json.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/diagnose-json.txt
@@ -1,0 +1,327 @@
+You are an expert data engineer specializing in creating Structured Data Descriptor configurations for data import pipelines, with particular expertise in JSON processing and JSONPath expressions. Your task is to generate a complete JSON configuration that describes how to parse, transform, and import structured JSON data.
+
+## Your Role
+Generate a comprehensive Structured Data Descriptor configuration based on the user's requirements. The descriptor should be production-ready, include appropriate error handling, and follow best practices for data quality and transformation.
+
+## JSON Processing Expertise
+
+When working with JSON data, you must:
+
+1. **Analyze JSON Structure** - Examine the hierarchy, array patterns, and object nesting
+2. **Generate Proper JSONPath Expressions** - Create efficient JSONPath selectors for record extraction
+3. **Handle Complex JSON Patterns** - Support various JSON formats including:
+   - Array of objects: `[{"name": "John", "age": 30}, {...}]`
+   - Nested object arrays: `{"data": {"records": [{"id": 1}, {...}]}}`
+   - Mixed hierarchies with both arrays and nested objects
+   - Single object records: `{"record": {"field1": "value1"}}`
+
+## JSONPath Expression Guidelines
+
+For JSON format configurations, use these JSONPath patterns:
+
+**Record Path Examples:**
+- Root array: `$[*]` (for arrays at the root level)
+- Nested arrays: `$.data.records[*]` or `$.response.items[*]`
+- Single object: `$.record` (when there's one record per file)
+- Deep nesting: `$.data.results.items[*]`
+
+**Field Access Patterns:**
+- Direct properties: Use property names directly in mappings
+- Nested properties: Use dot notation like `address.street` or `contact.email`
+- Array elements: Use bracket notation like `tags[0]` for first element
+
+**CRITICAL: Source Field Names in Mappings**
+
+When processing JSON, the parser creates a flat or nested dictionary based on the record structure. Your source field names in mappings must match the actual property names in the parsed records:
+
+**CORRECT Example:**
+```json
+{
+  "Country or Area": "Albania",
+  "Trade (USD)": "1000.50",
+  "metadata": {
+    "source": "UN",
+    "year": 2024
+  }
+}
+```
+
+Your mappings should use:
+```json
+{
+  "source_field": "Country or Area",     // ✅ Correct - matches property name
+  "source_field": "Trade (USD)",         // ✅ Correct - matches property name
+  "source_field": "metadata.source",     // ✅ Correct - nested property access
+  "source_field": "metadata.year"        // ✅ Correct - nested property access
+}
+```
+
+**JSON Format Configuration Template:**
+```json
+{
+  "format": {
+    "type": "json",
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "$[*]",              // JSONPath to extract records
+      "flatten_nested": true,             // Whether to flatten nested objects
+      "array_handling": "expand"          // How to handle arrays: expand, first, concat
+    }
+  }
+}
+```
+
+**Alternative JSON Options:**
+```json
+{
+  "format": {
+    "type": "json", 
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "$.data.items[*]",   // For nested array structures
+      "flatten_nested": false,            // Keep nested structure
+      "null_value_handling": "skip"       // skip, empty_string, or preserve
+    }
+  }
+}
+```
+
+## Required Information to Gather
+
+Before generating the descriptor, ask the user for these details if not provided:
+
+1. **Source Data Format**
+   - JSON structure type (array of objects, nested objects, single records)
+   - **For JSON**: Sample structure, nesting patterns, array locations
+   - Sample data or field descriptions
+   - Any format-specific details (encoding, special null handling, etc.)
+
+2. **Target Schema**
+   - What fields should be in the final output?
+   - What data types are expected?
+   - Any required vs optional fields?
+
+3. **Data Transformations Needed**
+   - Field mappings (source field → target field)
+   - Data cleaning requirements (trim spaces, normalize case, etc.)
+   - Type conversions needed
+   - Any calculations or derived fields
+   - Lookup tables or reference data needed
+   - Nested object flattening requirements
+
+4. **Data Quality Requirements**
+   - Validation rules (format patterns, ranges, required fields)
+   - How to handle missing or null values
+   - Duplicate handling strategy
+
+5. **Processing Requirements**
+   - Any filtering needed (skip certain records)
+   - Sorting requirements
+   - Aggregation or grouping needs
+   - Error handling preferences
+
+## JSON Structure Analysis
+
+When presented with JSON data, analyze:
+
+1. **Root Structure**: Is it an array, object, or nested structure?
+2. **Record Location**: Where are individual records located in the hierarchy?
+3. **Field Pattern**: How are field names and values structured?
+   - Direct properties: `{"name": "John"}`
+   - Nested objects: `{"contact": {"email": "john@example.com"}}`
+   - Arrays: `{"tags": ["red", "blue"]}`
+   - Mixed types: `{"data": [{"id": 1, "details": {"name": "John"}}]}`
+4. **Data Types**: What types are present (strings, numbers, booleans, nulls, arrays, objects)?
+5. **Hierarchy Depth**: How deeply nested are the records and fields?
+
+## Configuration Template Structure
+
+Generate a JSON configuration following this structure:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "[Descriptive name]",
+    "description": "[What this config does]",
+    "author": "[Author or team]",
+    "created": "[ISO date]"
+  },
+  "format": {
+    "type": "json",
+    "encoding": "utf-8",
+    "options": {
+      // JSON-specific parsing options
+      // record_path (JSONPath), flatten_nested, array_handling, etc.
+    }
+  },
+  "globals": {
+    "variables": {
+      // Global variables and constants
+    },
+    "lookup_tables": {
+      // Reference data for transformations
+    }
+  },
+  "preprocessing": [
+    // Global filters and operations before field mapping
+  ],
+  "mappings": [
+    // Field mapping definitions with transforms and validation
+  ],
+  "postprocessing": [
+    // Global operations after field mapping
+  ],
+  "output": {
+    "format": "trustgraph-objects",
+    "schema_name": "[target schema name]",
+    "options": {
+      "confidence": 0.85,
+      "batch_size": 1000
+    },
+    "error_handling": {
+      "on_validation_error": "log_and_skip",
+      "on_transform_error": "log_and_skip",
+      "max_errors": 100
+    }
+  }
+}
+```
+
+## Transform Types Available
+
+Use these transform types in your mappings:
+
+**String Operations:**
+- `trim`, `upper`, `lower`, `title_case`
+- `replace`, `regex_replace`, `substring`, `pad_left`
+
+**Type Conversions:**
+- `to_string`, `to_int`, `to_float`, `to_bool`, `to_date`
+
+**Data Operations:**
+- `default`, `lookup`, `concat`, `calculate`, `conditional`
+- `flatten_object`, `extract_array_element`, `join_array`
+
+**Validation Types:**
+- `required`, `not_null`, `min_length`, `max_length`
+- `range`, `pattern`, `in_list`, `custom`
+
+## JSON-Specific Best Practices
+
+1. **Use efficient JSONPath expressions** - Prefer specific paths over broad searches
+2. **Handle nested objects appropriately** - decide whether to flatten or preserve structure
+3. **Consider array handling strategies** - expand arrays to multiple records or extract specific elements
+4. **Account for null vs undefined** values in field mappings
+5. **Handle mixed data types** within the same field across records
+6. **Use appropriate flattening** for deeply nested structures
+
+## Best Practices to Follow
+
+1. **Always include error handling** with appropriate policies
+2. **Use meaningful field names** that match target schema
+3. **Add validation** for critical fields
+4. **Include default values** for optional fields
+5. **Use lookup tables** for code translations
+6. **Add preprocessing filters** to exclude invalid records
+7. **Include metadata** for documentation and maintenance
+8. **Consider performance** with appropriate batch sizes
+9. **Handle JSON-specific edge cases** like empty arrays, null objects, mixed types
+
+## Complete JSON Example
+
+Given this JSON structure:
+```json
+{
+  "data": {
+    "records": [
+      {
+        "Country": "USA",
+        "Year": 2024,
+        "Amount": 1000.50,
+        "metadata": {
+          "source": "World Bank",
+          "confidence": 0.95
+        }
+      }
+    ]
+  }
+}
+```
+
+The parser will:
+1. Use `record_path: "$.data.records[*]"` to extract record objects from the array
+2. Create this parsed data structure for each record: 
+   ```json
+   {
+     "Country": "USA", 
+     "Year": 2024, 
+     "Amount": 1000.50,
+     "metadata.source": "World Bank",      // If flattened
+     "metadata.confidence": 0.95           // If flattened
+   }
+   ```
+
+Generate this COMPLETE configuration:
+```json
+{
+  "format": {
+    "type": "json",
+    "encoding": "utf-8", 
+    "options": {
+      "record_path": "$.data.records[*]",
+      "flatten_nested": true,
+      "array_handling": "expand"
+    }
+  },
+  "mappings": [
+    {
+      "source_field": "Country",          // ✅ Matches property name
+      "target_field": "country_name"
+    },
+    {
+      "source_field": "Year",             // ✅ Matches property name  
+      "target_field": "year",
+      "transforms": [{"type": "to_int"}]
+    },
+    {
+      "source_field": "Amount",           // ✅ Matches property name
+      "target_field": "amount",
+      "transforms": [{"type": "to_float"}]
+    },
+    {
+      "source_field": "metadata.source",  // ✅ Flattened nested field
+      "target_field": "data_source"
+    }
+  ]
+}
+```
+
+**KEY RULE: source_field names must match the actual property names in the parsed JSON records, using dot notation for nested properties when flattened.**
+
+## Output Format
+
+Provide the configuration as ONLY a properly formatted JSON document.
+
+## Schema
+
+The following schema describes the target result format:
+
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}
+- {{ field.name }} ({{ field.type }}){% if field.description %}: {{ field.description }}{% endif
+%}{% if field.primary_key %} [PRIMARY KEY]{% endif %}{% if field.required %} [REQUIRED]{% endif 
+%}{% if field.indexed %} [INDEXED]{% endif %}{% if field.enum_values %} [OPTIONS: {{
+field.enum_values|join(', ') }}]{% endif %}
+{% endfor %}
+
+{% endfor %}
+
+## Data sample
+
+Analyze the JSON structure and produce a Structured Data Descriptor by diagnosing the following data sample. Pay special attention to JSON hierarchy, object patterns, array structures, and generate appropriate JSONPath expressions:
+
+{{sample}}
+

--- a/trustgraph_configurator/templates/2.7/prompts/diagnose-structured-data.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/diagnose-structured-data.txt
@@ -1,0 +1,309 @@
+
+You are an expert data engineer specializing in creating Structured Data Descriptor configurations for data import pipelines, with particular expertise in XML processing and XPath expressions. Your task is to generate a complete JSON configuration that describes how to parse, transform, and import structured data.
+
+## Your Role
+Generate a comprehensive Structured Data Descriptor configuration based on the user's requirements. The descriptor should be production-ready, include appropriate error handling, and follow best practices for data quality and transformation.
+
+## XML Processing Expertise
+
+When working with XML data, you must:
+
+1. **Analyze XML Structure** - Examine the hierarchy, namespaces, and element patterns
+2. **Generate Proper XPath Expressions** - Create efficient XPath selectors for record extraction
+3. **Handle Complex XML Patterns** - Support various XML formats including:
+   - Standard element structures: `<customer><name>John</name></customer>`
+   - Attribute-based fields: `<field name="country">USA</field>`
+   - Mixed content and nested hierarchies
+   - Namespaced XML documents
+
+## XPath Expression Guidelines
+
+For XML format configurations, use these XPath patterns:
+
+**Record Path Examples:**
+- Simple records: `//record` or `//customer`
+- Nested records: `//data/records/record` or `//customers/customer`
+- Absolute paths: `/ROOT/data/record` (will be converted to relative paths automatically)
+- With namespaces: `//ns:record` or `//soap:Body/data/record`
+
+**Field Attribute Patterns:**
+- When fields use name attributes: set `field_attribute: "name"` for `<field name="key">value</field>`
+- For other attribute patterns: set appropriate attribute name
+
+**CRITICAL: Source Field Names in Mappings**
+
+When using `field_attribute`, the XML parser extracts field names from the attribute values and creates a flat dictionary. Your source field names in mappings must match these extracted names:
+
+**CORRECT Example:**
+```xml
+<field name="Country or Area">Albania</field>
+<field name="Trade (USD)">1000.50</field>
+```
+
+Becomes parsed data:
+```json
+{
+  "Country or Area": "Albania",
+  "Trade (USD)": "1000.50"
+}
+```
+
+So your mappings should use:
+```json
+{
+  "source_field": "Country or Area",     // ✅ Correct - matches parsed field name
+  "source_field": "Trade (USD)"         // ✅ Correct - matches parsed field name
+}
+```
+
+**INCORRECT Example:**
+```json
+{
+  "source_field": "Field[@name='Country or Area']",  // ❌ Wrong - XPath not needed here
+  "source_field": "field[@name='Trade (USD)']"       // ❌ Wrong - XPath not needed here
+}
+```
+
+**XML Format Configuration Template:**
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//data/record",        // XPath to find record elements
+      "field_attribute": "name"              // For <field name="key">value</field> pattern
+    }
+  }
+}
+```
+
+**Alternative XML Options:**
+```json
+{
+  "format": {
+    "type": "xml", 
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//customer",           // Direct element-based records
+      // No field_attribute needed for standard XML
+    }
+  }
+}
+```
+
+## Required Information to Gather
+
+Before generating the descriptor, ask the user for these details if not provided:
+
+1. **Source Data Format**
+   - File type (CSV, JSON, XML, Excel, fixed-width, etc.)
+   - **For XML**: Sample structure, namespace prefixes, record element patterns
+   - Sample data or field descriptions
+   - Any format-specific details (delimiters, encoding, namespaces, etc.)
+
+2. **Target Schema**
+   - What fields should be in the final output?
+   - What data types are expected?
+   - Any required vs optional fields?
+
+3. **Data Transformations Needed**
+   - Field mappings (source field → target field)
+   - Data cleaning requirements (trim spaces, normalize case, etc.)
+   - Type conversions needed
+   - Any calculations or derived fields
+   - Lookup tables or reference data needed
+
+4. **Data Quality Requirements**
+   - Validation rules (format patterns, ranges, required fields)
+   - How to handle missing or invalid data
+   - Duplicate handling strategy
+
+5. **Processing Requirements**
+   - Any filtering needed (skip certain records)
+   - Sorting requirements
+   - Aggregation or grouping needs
+   - Error handling preferences
+
+## XML Structure Analysis
+
+When presented with XML data, analyze:
+
+1. **Document Root**: What is the root element?
+2. **Record Container**: Where are individual records located?
+3. **Field Pattern**: How are field names and values structured?
+   - Direct child elements: `<name>John</name>`
+   - Attribute-based: `<field name="name">John</field>`
+   - Mixed patterns
+4. **Namespaces**: Are there any namespace prefixes?
+5. **Hierarchy Depth**: How deeply nested are the records?
+
+## Configuration Template Structure
+
+Generate a JSON configuration following this structure:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "[Descriptive name]",
+    "description": "[What this config does]",
+    "author": "[Author or team]",
+    "created": "[ISO date]"
+  },
+  "format": {
+    "type": "[csv|json|xml|fixed-width|excel]",
+    "encoding": "utf-8",
+    "options": {
+      // Format-specific parsing options
+      // For XML: record_path (XPath), field_attribute (if applicable)
+    }
+  },
+  "globals": {
+    "variables": {
+      // Global variables and constants
+    },
+    "lookup_tables": {
+      // Reference data for transformations
+    }
+  },
+  "preprocessing": [
+    // Global filters and operations before field mapping
+  ],
+  "mappings": [
+    // Field mapping definitions with transforms and validation
+  ],
+  "postprocessing": [
+    // Global operations after field mapping
+  ],
+  "output": {
+    "format": "trustgraph-objects",
+    "schema_name": "[target schema name]",
+    "options": {
+      "confidence": 0.85,
+      "batch_size": 1000
+    },
+    "error_handling": {
+      "on_validation_error": "log_and_skip",
+      "on_transform_error": "log_and_skip",
+      "max_errors": 100
+    }
+  }
+}
+```
+
+## Transform Types Available
+
+Use these transform types in your mappings:
+
+**String Operations:**
+- `trim`, `upper`, `lower`, `title_case`
+- `replace`, `regex_replace`, `substring`, `pad_left`
+
+**Type Conversions:**
+- `to_string`, `to_int`, `to_float`, `to_bool`, `to_date`
+
+**Data Operations:**
+- `default`, `lookup`, `concat`, `calculate`, `conditional`
+
+**Validation Types:**
+- `required`, `not_null`, `min_length`, `max_length`
+- `range`, `pattern`, `in_list`, `custom`
+
+## XML-Specific Best Practices
+
+1. **Use efficient XPath expressions** - Prefer specific paths over broad searches
+2. **Handle namespace prefixes** when present
+3. **Identify field attribute patterns** correctly
+4. **Test XPath expressions** mentally against the provided structure
+5. **Consider XML element vs attribute data** in field mappings
+6. **Account for mixed content** and nested structures
+
+## Best Practices to Follow
+
+1. **Always include error handling** with appropriate policies
+2. **Use meaningful field names** that match target schema
+3. **Add validation** for critical fields
+4. **Include default values** for optional fields
+5. **Use lookup tables** for code translations
+6. **Add preprocessing filters** to exclude invalid records
+7. **Include metadata** for documentation and maintenance
+8. **Consider performance** with appropriate batch sizes
+
+## Complete XML Example
+
+Given this XML structure:
+```xml
+<ROOT>
+  <data>
+    <record>
+      <field name="Country">USA</field>
+      <field name="Year">2024</field>
+      <field name="Amount">1000.50</field>
+    </record>
+  </data>
+</ROOT>
+```
+
+The parser will:
+1. Use `record_path: "/ROOT/data/record"` to find record elements
+2. Use `field_attribute: "name"` to extract field names from the name attribute
+3. Create this parsed data structure: `{"Country": "USA", "Year": "2024", "Amount": "1000.50"}`
+
+Generate this COMPLETE configuration:
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8", 
+    "options": {
+      "record_path": "/ROOT/data/record",
+      "field_attribute": "name"
+    }
+  },
+  "mappings": [
+    {
+      "source_field": "Country",          // ✅ Matches parsed field name
+      "target_field": "country_name"
+    },
+    {
+      "source_field": "Year",             // ✅ Matches parsed field name  
+      "target_field": "year",
+      "transforms": [{"type": "to_int"}]
+    },
+    {
+      "source_field": "Amount",           // ✅ Matches parsed field name
+      "target_field": "amount",
+      "transforms": [{"type": "to_float"}]
+    }
+  ]
+}
+```
+
+**KEY RULE: source_field names must match the extracted field names, NOT the XML element structure.**
+
+## Output Format
+
+Provide the configuration as ONLY a properly formatted JSON document.
+
+## Schema
+
+The following schema describes the target result format:
+
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}
+- {{ field.name }} ({{ field.type }}){% if field.description %}: {{ field.description }}{% endif
+%}{% if field.primary_key %} [PRIMARY KEY]{% endif %}{% if field.required %} [REQUIRED]{% endif 
+%}{% if field.indexed %} [INDEXED]{% endif %}{% if field.enum_values %} [OPTIONS: {{
+field.enum_values|join(', ') }}]{% endif %}
+{% endfor %}
+
+{% endfor %}
+
+## Data sample
+
+Analyze the XML structure and produce a Structured Data Descriptor by diagnosing the following data sample. Pay special attention to XML hierarchy, element patterns, and generate appropriate XPath expressions:
+
+{{sample}}

--- a/trustgraph_configurator/templates/2.7/prompts/diagnose-xml.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/diagnose-xml.txt
@@ -1,0 +1,453 @@
+You are an expert data engineer specializing in creating Structured Data Descriptor configurations for XML data import pipelines, with particular expertise in XML processing and XPath expressions. Your task is to generate a complete JSON configuration that describes how to parse, transform, and import structured XML data.
+
+## Your Role
+Generate a comprehensive Structured Data Descriptor configuration based on the user's requirements. The descriptor should be production-ready, include appropriate error handling, and follow best practices for data quality and transformation.
+
+## XML Processing Expertise
+
+When working with XML data, you must:
+
+1. **Analyze XML Structure** - Examine the hierarchy, namespaces, and element patterns
+2. **Generate Proper XPath Expressions** - Create efficient XPath selectors for record extraction
+3. **Handle Complex XML Patterns** - Support various XML formats including:
+   - Standard element structures: `<customer><name>John</name></customer>`
+   - Attribute-based fields: `<field name="country">USA</field>`
+   - Mixed content and nested hierarchies
+   - Namespaced XML documents
+   - CDATA sections and text nodes
+
+## XPath Expression Guidelines
+
+For XML format configurations, use these XPath patterns:
+
+**Record Path Examples:**
+- Simple records: `//record` or `//customer`
+- Nested records: `//data/records/record` or `//customers/customer`
+- Absolute paths: `/ROOT/data/record`
+- With namespaces: `//ns:record` or `//soap:Body/data/record`
+- Attribute-filtered: `//record[@type='customer']`
+
+**Field Attribute Patterns:**
+- When fields use name attributes: set `field_attribute: "name"` for `<field name="key">value</field>`
+- For other attribute patterns: set appropriate attribute name like `field_attribute: "id"` or `field_attribute: "type"`
+
+## CRITICAL: Source Field Names in Mappings
+
+The behavior depends on whether you use `field_attribute`:
+
+### With field_attribute (Attribute-Based Fields)
+
+When using `field_attribute`, the XML parser extracts field names from the attribute values and creates a flat dictionary:
+
+**Example:**
+```xml
+<record>
+  <field name="Country or Area">Albania</field>
+  <field name="Trade (USD)">1000.50</field>
+  <field name="Status">Active</field>
+</record>
+```
+
+Parser configuration:
+```json
+{
+  "record_path": "//record",
+  "field_attribute": "name"
+}
+```
+
+Becomes parsed data:
+```json
+{
+  "Country or Area": "Albania",
+  "Trade (USD)": "1000.50",
+  "Status": "Active"
+}
+```
+
+Your mappings should use:
+```json
+{
+  "source_field": "Country or Area",     // ✅ Correct - matches parsed field name
+  "source_field": "Trade (USD)",         // ✅ Correct - matches parsed field name
+  "source_field": "Status"               // ✅ Correct - matches parsed field name
+}
+```
+
+### Without field_attribute (Element-Based Fields)
+
+When NOT using `field_attribute`, use direct element names or XPath expressions:
+
+**Example:**
+```xml
+<record>
+  <country>Albania</country>
+  <trade_amount>1000.50</trade_amount>
+  <status>Active</status>
+  <metadata>
+    <source>UN</source>
+    <year>2024</year>
+  </metadata>
+</record>
+```
+
+Parser configuration:
+```json
+{
+  "record_path": "//record"
+  // No field_attribute specified
+}
+```
+
+Your mappings should use:
+```json
+{
+  "source_field": "country",              // ✅ Direct element name
+  "source_field": "trade_amount",         // ✅ Direct element name
+  "source_field": "metadata/source",      // ✅ Nested element path
+  "source_field": "metadata/year"         // ✅ Nested element path
+}
+```
+
+## XML Format Configuration Templates
+
+**For Attribute-Based Fields:**
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//data/record",        // XPath to find record elements
+      "field_attribute": "name",             // Extract field names from 'name' attribute
+      "namespace_prefixes": {                // Optional: define namespaces
+        "ns": "http://example.com/namespace"
+      }
+    }
+  }
+}
+```
+
+**For Element-Based Fields:**
+```json
+{
+  "format": {
+    "type": "xml", 
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//customer",           // XPath to find record elements
+      "preserve_namespaces": true,           // Optional: keep namespace info
+      "ignore_attributes": false             // Optional: include element attributes
+    }
+  }
+}
+```
+
+**For Complex XML with Namespaces:**
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//soap:Body//data:record",
+      "namespace_prefixes": {
+        "soap": "http://schemas.xmlsoap.org/soap/envelope/",
+        "data": "http://example.com/data"
+      },
+      "field_attribute": "name"
+    }
+  }
+}
+```
+
+## Required Information to Gather
+
+Before generating the descriptor, ask the user for these details if not provided:
+
+1. **XML Structure Details**
+   - Sample XML structure or schema
+   - Root element and record location
+   - Field organization (elements vs attributes)
+   - Namespace declarations and prefixes
+   - Text encoding (UTF-8, ISO-8859-1, etc.)
+
+2. **Target Schema**
+   - What fields should be in the final output?
+   - What data types are expected?
+   - Any required vs optional fields?
+
+3. **Data Transformations Needed**
+   - Field mappings (source field → target field)
+   - Data cleaning requirements (trim spaces, normalize case, etc.)
+   - Type conversions needed
+   - Any calculations or derived fields
+   - Lookup tables or reference data needed
+
+4. **Data Quality Requirements**
+   - Validation rules (format patterns, ranges, required fields)
+   - How to handle missing or invalid data
+   - Duplicate handling strategy
+
+5. **Processing Requirements**
+   - Any filtering needed (skip certain records)
+   - Sorting requirements
+   - Aggregation or grouping needs
+   - Error handling preferences
+
+## XML Structure Analysis
+
+When presented with XML data, analyze:
+
+1. **Document Root**: What is the root element?
+2. **Namespaces**: Are there namespace declarations? What prefixes are used?
+3. **Record Container**: Where are individual records located in the hierarchy?
+4. **Field Pattern**: How are field names and values structured?
+   - Direct child elements: `<name>John</name>`
+   - Attribute-based: `<field name="name">John</field>`
+   - Mixed patterns: `<customer id="123"><name>John</name></customer>`
+5. **Data Location**: Are values in element text, attributes, or both?
+6. **Hierarchy Depth**: How deeply nested are the records?
+7. **Special Content**: Any CDATA sections, mixed content, or special characters?
+
+## Configuration Template Structure
+
+Generate a JSON configuration following this structure:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "[Descriptive name]",
+    "description": "[What this config does]",
+    "author": "[Author or team]",
+    "created": "[ISO date]"
+  },
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8",
+    "options": {
+      // XML-specific parsing options
+      // record_path (XPath), field_attribute (if applicable), namespace_prefixes
+    }
+  },
+  "globals": {
+    "variables": {
+      // Global variables and constants
+    },
+    "lookup_tables": {
+      // Reference data for transformations
+    }
+  },
+  "preprocessing": [
+    // Global filters and operations before field mapping
+  ],
+  "mappings": [
+    // Field mapping definitions with transforms and validation
+  ],
+  "postprocessing": [
+    // Global operations after field mapping
+  ],
+  "output": {
+    "format": "trustgraph-objects",
+    "schema_name": "[target schema name]",
+    "options": {
+      "confidence": 0.85,
+      "batch_size": 1000
+    },
+    "error_handling": {
+      "on_validation_error": "log_and_skip",
+      "on_transform_error": "log_and_skip",
+      "max_errors": 100
+    }
+  }
+}
+```
+
+## Transform Types Available
+
+Use these transform types in your mappings:
+
+**String Operations:**
+- `trim`, `upper`, `lower`, `title_case`
+- `replace`, `regex_replace`, `substring`, `pad_left`
+- `strip_cdata`, `decode_html_entities`
+
+**Type Conversions:**
+- `to_string`, `to_int`, `to_float`, `to_bool`, `to_date`
+- `parse_xml_date`, `parse_iso_date`
+
+**Data Operations:**
+- `default`, `lookup`, `concat`, `calculate`, `conditional`
+- `extract_attribute`, `get_text_content`
+
+**Validation Types:**
+- `required`, `not_null`, `min_length`, `max_length`
+- `range`, `pattern`, `in_list`, `custom`
+- `valid_xml_name`, `namespace_check`
+
+## XML-Specific Best Practices
+
+1. **Use efficient XPath expressions** - Prefer specific paths over broad searches like `//` when possible
+2. **Handle namespace prefixes** when present - define them in `namespace_prefixes`
+3. **Identify field attribute patterns** correctly - determine if using `field_attribute`
+4. **Test XPath expressions** mentally against the provided structure
+5. **Consider XML element vs attribute data** in field mappings
+6. **Account for mixed content** and nested structures
+7. **Handle CDATA sections** and special characters properly
+8. **Preserve or normalize whitespace** as appropriate
+9. **Consider XML schema validation** if XSD is available
+
+## Best Practices to Follow
+
+1. **Always include error handling** with appropriate policies
+2. **Use meaningful field names** that match target schema
+3. **Add validation** for critical fields
+4. **Include default values** for optional fields
+5. **Use lookup tables** for code translations
+6. **Add preprocessing filters** to exclude invalid records
+7. **Include metadata** for documentation and maintenance
+8. **Consider performance** with appropriate batch sizes
+9. **Handle XML-specific edge cases** like empty elements, mixed content, processing instructions
+
+## Complete XML Examples
+
+### Example 1: Attribute-Based Fields
+
+Given this XML structure:
+```xml
+<ROOT>
+  <data>
+    <record id="1">
+      <field name="Country">USA</field>
+      <field name="Year">2024</field>
+      <field name="Amount">1000.50</field>
+    </record>
+  </data>
+</ROOT>
+```
+
+The parser will:
+1. Use `record_path: "//data/record"` to find record elements
+2. Use `field_attribute: "name"` to extract field names from the name attribute
+3. Create this parsed data structure: `{"Country": "USA", "Year": "2024", "Amount": "1000.50"}`
+
+Generate this configuration:
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8", 
+    "options": {
+      "record_path": "//data/record",
+      "field_attribute": "name"
+    }
+  },
+  "mappings": [
+    {
+      "source_field": "Country",          // ✅ Matches parsed field name
+      "target_field": "country_name"
+    },
+    {
+      "source_field": "Year",             // ✅ Matches parsed field name  
+      "target_field": "year",
+      "transforms": [{"type": "to_int"}]
+    },
+    {
+      "source_field": "Amount",           // ✅ Matches parsed field name
+      "target_field": "amount",
+      "transforms": [{"type": "to_float"}]
+    }
+  ]
+}
+```
+
+### Example 2: Element-Based Fields
+
+Given this XML structure:
+```xml
+<customers>
+  <customer id="123">
+    <name>John Smith</name>
+    <email>john@example.com</email>
+    <address>
+      <street>123 Main St</street>
+      <city>New York</city>
+    </address>
+    <orders>
+      <order>
+        <id>456</id>
+        <total>100.50</total>
+      </order>
+    </orders>
+  </customer>
+</customers>
+```
+
+Generate this configuration:
+```json
+{
+  "format": {
+    "type": "xml",
+    "encoding": "utf-8",
+    "options": {
+      "record_path": "//customer"
+    }
+  },
+  "mappings": [
+    {
+      "source_field": "name",              // ✅ Direct element name
+      "target_field": "customer_name"
+    },
+    {
+      "source_field": "email",             // ✅ Direct element name
+      "target_field": "email_address"
+    },
+    {
+      "source_field": "address/street",    // ✅ Nested element path
+      "target_field": "street_address"
+    },
+    {
+      "source_field": "address/city",      // ✅ Nested element path
+      "target_field": "city"
+    },
+    {
+      "source_field": "@id",               // ✅ Attribute reference
+      "target_field": "customer_id",
+      "transforms": [{"type": "to_int"}]
+    }
+  ]
+}
+```
+
+**KEY RULES:**
+- With `field_attribute`: source_field names must match the extracted attribute values
+- Without `field_attribute`: use direct element names, nested paths, or XPath expressions
+- Use `@attribute` notation for XML element attributes
+
+## Output Format
+
+Provide the configuration as ONLY a properly formatted JSON document.
+
+## Schema
+
+The following schema describes the target result format:
+
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}
+- {{ field.name }} ({{ field.type }}){% if field.description %}: {{ field.description }}{% endif
+%}{% if field.primary_key %} [PRIMARY KEY]{% endif %}{% if field.required %} [REQUIRED]{% endif 
+%}{% if field.indexed %} [INDEXED]{% endif %}{% if field.enum_values %} [OPTIONS: {{
+field.enum_values|join(', ') }}]{% endif %}
+{% endfor %}
+
+{% endfor %}
+
+## Data sample
+
+Analyze the XML structure and produce a Structured Data Descriptor by diagnosing the following data sample. Pay special attention to XML hierarchy, element patterns, namespace usage, and generate appropriate XPath expressions:
+
+{{sample}}
+

--- a/trustgraph_configurator/templates/2.7/prompts/document-prompt.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/document-prompt.txt
@@ -1,0 +1,7 @@
+Study the following context. Use only the information provided in the context in your response. Do not speculate if the answer is not found in the provided set of knowledge statements.
+
+Here is the context:
+{{documents}}
+
+Use only the provided knowledge statements to respond to the following:
+{{query}}

--- a/trustgraph_configurator/templates/2.7/prompts/extract-concepts.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/extract-concepts.txt
@@ -1,0 +1,12 @@
+Extract core semantic concepts from the following query. These concepts will be used for semantic search and embedding.
+
+Output one concept per line. No numbering, no bullet points, no explanation.
+
+Focus on:
+- Key nouns and noun phrases
+- Domain-specific terminology
+- Languages or time periods mentioned
+- Technical terms
+
+Query:
+{{query}}

--- a/trustgraph_configurator/templates/2.7/prompts/extract-definitions.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/extract-definitions.txt
@@ -1,0 +1,31 @@
+<instructions>
+Study the following text and derive definitions for any discovered entities. Do not provide definitions for entities whose definitions are incomplete or unknown.
+
+Guidelines for high-quality definitions:
+- Capture what distinguishes this entity from related entities
+- Include comparative facts (e.g. more/less common, larger/smaller)
+- Include causal relationships and classifications
+- Be specific — name related entities rather than using vague references like "other types"
+
+Output each definition as a separate JSON object on its own line (JSONL format). Each object must have fields:
+- entity: the name of the entity
+- definition: English text which defines the entity
+</instructions>
+
+<text>
+{{text}}
+</text>
+
+<requirements>
+Output format: JSONL (one JSON object per line, no array wrapper)
+- Each line must be a complete, valid JSON object
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting or prefixes
+- Do not use special characters in the definition text
+- Do not include null or unknown definitions
+
+Example output format:
+{"entity": "photosynthesis", "definition": "The process by which plants convert sunlight into energy"}
+{"entity": "melanoma", "definition": "A type of skin cancer that is less common than basal cell carcinoma and squamous cell carcinoma but tends to be more aggressive"}
+</requirements>

--- a/trustgraph_configurator/templates/2.7/prompts/extract-relationships.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/extract-relationships.txt
@@ -1,0 +1,35 @@
+<instructions>
+Study the following text and extract important entity relationships.  For each relationship, derive the subject, predicate and object.
+
+Focus on relationships that capture key facts: definitions, causes, types, comparisons, properties, and classifications.
+
+Guidelines for high-quality relationships:
+- Use specific, meaningful predicates (avoid vague verbs like "is", "has", "can be")                                                           
+- Resolve pronouns and references to their concrete entities
+- Prefer one clear fact per relationship over compound statements
+- Skip trivial or self-evident relationships
+</instructions>
+
+<text>
+{{text}}        
+</text>
+
+<requirements>
+Output format: JSONL (one JSON object per line, no array wrapper)
+Each object must have fields:
+- subject: the subject of the relationship
+- predicate: the predicate
+- object: the object of the relationship
+- object-entity: false if the object is a simple data type (name, value, date). true if it is an entity.
+
+- Each line must be a complete, valid JSON object
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting or prefixes
+- Do not use special characters in the text fields
+
+Example output format:
+{"subject": "Earth", "predicate": "orbits", "object": "Sun", "object-entity": true}
+{"subject": "Earth", "predicate": "has diameter", "object": "12742 km", "object-entity": false}
+{"subject": "basal cell carcinoma", "predicate": "is more common than", "object": "melanoma", "object-entity": true}
+</requirements>

--- a/trustgraph_configurator/templates/2.7/prompts/extract-rows.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/extract-rows.txt
@@ -1,0 +1,27 @@
+<instructions>
+Study the following text and derive objects which match the schema provided.
+
+Output each discovered object as a separate JSON object on its own line (JSONL format).
+Each object's fields must carry the name field specified in the schema.
+</instructions>
+
+<schema>
+{{schema}}
+</schema>
+
+<text>
+{{text}}
+</text>
+
+<requirements>
+Output format: JSONL (one JSON object per line, no array wrapper)
+- Each line must be a complete, valid JSON object matching the schema
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting or prefixes
+- Do not provide explanations
+
+Example output format (assuming schema has fields: name, age, city):
+{"name": "Alice", "age": 30, "city": "London"}
+{"name": "Bob", "age": 25, "city": "Paris"}
+</requirements>

--- a/trustgraph_configurator/templates/2.7/prompts/extract-topics.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/extract-topics.txt
@@ -1,0 +1,26 @@
+You are a helpful assistant that performs information extraction tasks for a provided text.
+Read the provided text. You will identify topics and their definitions.
+
+Reading Instructions:
+- Ignore document formatting in the provided text.
+- Study the provided text carefully.
+
+Here is the text:
+{{text}}
+
+Response Instructions:
+- Output each topic as a separate JSON object on its own line (JSONL format)
+- Each object must have keys "topic" and "definition"
+- Do not respond with special characters
+- Return only topics that are concepts and unique to the provided text
+
+Output format: JSONL (one JSON object per line, no array wrapper)
+- Each line must be a complete, valid JSON object
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting or prefixes
+- Do not write any additional text or explanations
+
+Example output format:
+{"topic": "machine learning", "definition": "A subset of AI that enables systems to learn from data"}
+{"topic": "neural network", "definition": "A computing system inspired by biological neural networks"}

--- a/trustgraph_configurator/templates/2.7/prompts/gemini.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/gemini.jsonnet
@@ -1,0 +1,42 @@
+// For VertexAI Gemini.  Not currently overriding prompts
+
+local prompts = import "default-prompts.jsonnet";
+
+prompts + {
+
+    // "system-template":: "PROMPT GOES HERE.",
+
+    "templates" +:: {
+
+        "question" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-definitions" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-relationships" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-topics" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-rows" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "kg-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "document-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/prompts/graphql-generation.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/graphql-generation.txt
@@ -1,0 +1,59 @@
+You are a GraphQL query generation expert. Given a natural language question and provided database schemas, generate a valid GraphQL query embedded in valid JSON.
+
+## Question:
+{{ question }}
+
+## Provided Schemas:
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}- {{ field.name }} ({{ field.type }}){% if field.description %}: {{ field.description }}{% endif %}{% if field.primary_key %} [PRIMARY KEY]{% endif %}{% if field.required %} [REQUIRED]{% endif %}{% if field.indexed %} [INDEXED]{% endif %}{% if field.enum_values %} [OPTIONS: {{ field.enum_values|join(', ') }}]{% endif %}
+{% endfor %}
+{% endfor %}
+
+## GraphQL Query Rules:
+1. Use the schema names as GraphQL query fields (e.g., `customers`, `orders`)
+2. Apply filters using the `where` parameter with nested filter objects
+3. Available filter operators per field type:
+   - String fields: `eq`, `contains`, `startsWith`, `endsWith`, `in`, `not`, `not_in`
+   - Integer/Float fields: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `not`, `not_in`
+4. Use `order_by` for sorting (field name as string)
+5. Use `direction` for sort direction: `ASC` or `DESC`
+6. Use `limit` to restrict number of results
+7. Select specific fields in the query body
+
+## Task Instructions:
+1. Analyze the question to identify:
+   - What data to retrieve (which fields to select)
+   - What filters to apply (where conditions)
+   - What sorting is needed (order_by, direction)
+   - How many results (limit)
+
+2. Generate a GraphQL query that:
+   - Uses only the provided schema names and field names
+   - Applies appropriate filters based on the question
+   - Selects relevant fields for the response
+   - Includes reasonable limits (default 100 if not specified)
+
+3. If variables are needed, include them in the response
+
+## Output Format:
+Return ONLY a valid JSON object (no markdown, no code blocks) with these fields:
+- "query": the GraphQL query string
+- "variables": object with any GraphQL variables (empty object if none)
+- "confidence": float between 0.0-1.0 indicating confidence in the query
+
+Important: Return raw JSON only, with no markdown formatting, no code blocks, and no backticks.
+
+## Examples:
+
+Question: "Show me customers from California"
+{"query": "query { customers(where: {state: {eq: \"California\"}}, limit: 100) { customer_id name email state } }", "variables": {}, "confidence": 0.92}
+
+Question: "Top 10 products by price"
+{"query": "query { products(order_by: \"price\", direction: DESC, limit: 10) { product_id name price category } }", "variables": {}, "confidence": 0.88}
+
+Question: "Recent orders over $100"
+{"query": "query { orders(where: {total_amount: {gt: 100}, order_date: {gte: \"2024-01-01\"}}, order_by: \"order_date\", direction: DESC, limit: 50) { order_id customer_id total_amount order_date status } }", "variables": {}, "confidence": 0.96}
+
+Now generate the GraphQL query for the question above.

--- a/trustgraph_configurator/templates/2.7/prompts/kg-synthesis.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/kg-synthesis.txt
@@ -1,0 +1,8 @@
+Study the following knowledge statements in Cypher format, extracted from a knowledge graph. Base your response only on the provided statements. You may draw logical inferences by combining multiple statements, but do not introduce outside knowledge. Answer in natural language. Do not preface your response with references to the knowledge statements as source of information.  Be concise, helpful and give as complete an answer as possible.
+
+Here's the knowledge statements:
+{% for edge in knowledge %}({{edge.s}})-[{{edge.p}}]->({{edge.o}})
+{%endfor%}
+
+Use only the provided knowledge statements to respond to the following:
+{{query}}

--- a/trustgraph_configurator/templates/2.7/prompts/mixtral.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/mixtral.jsonnet
@@ -1,0 +1,42 @@
+// For Mixtral.  Not currently overriding prompts
+
+local prompts = import "default-prompts.jsonnet";
+
+prompts + {
+
+    // "system-template":: "PROMPT GOES HERE.",
+
+    "templates" +:: {
+
+        "question" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-definitions" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-relationships" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-topics" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-rows" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "kg-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "document-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/prompts/ontology-prompt.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/ontology-prompt.txt
@@ -1,0 +1,87 @@
+You are a knowledge extraction expert. Your task is to find entities, relationships, and attributes in text based on a provided schema.
+
+## Entity Types
+
+These are the types of entities you should look for:
+
+{% for class_id, class_def in classes.items() %}
+- **{{class_id}}**{% if class_def.subclass_of %} (subclass of {{class_def.subclass_of}}){% endif %}{% if class_def.comment %}: {{class_def.comment}}{% endif %}
+{% endfor %}
+
+## Relationships
+
+These relationships connect entities to other entities:
+
+{% for prop_id, prop_def in object_properties.items() %}
+- **{{prop_id}}**{% if prop_def.domain and prop_def.range %} ({{prop_def.domain}} → {{prop_def.range}}){% endif %}{% if prop_def.comment %}: {{prop_def.comment}}{% endif %}
+{% endfor %}
+
+## Attributes
+
+These attributes describe entity properties (text, numbers, etc.):
+
+{% for prop_id, prop_def in datatype_properties.items() %}
+- **{{prop_id}}**{% if prop_def.domain and prop_def.range %} ({{prop_def.domain}} → {{prop_def.range}}){% endif %}{% if prop_def.comment %}: {{prop_def.comment}}{% endif %}
+{% endfor %}
+
+## Text to Analyze
+
+{{text}}
+
+## Your Task
+
+Extract the following from the text above:
+
+1. **Entities**: Things mentioned in the text and their types
+2. **Relationships**: How entities relate to each other
+3. **Attributes**: Properties of entities (like quantities, descriptions, etc.)
+
+## Guidelines
+
+- Resolve pronouns and vague references to their concrete entity names
+- Focus on relationships that capture key facts: definitions, causes, types, comparisons, and classifications
+
+## Output Format
+
+Output format: JSONL (one JSON object per line, no array wrapper)
+Each line must include a "type" field to distinguish between entities, relationships, and attributes.
+
+For entities, output:
+{"type": "entity", "entity": "entity name as it appears in text", "entity_type": "EntityType"}
+
+For relationships, output:
+{"type": "relationship", "subject": "subject entity name", "subject_type": "SubjectType", "relation": "relationship_name", "object": "object entity name", "object_type": "ObjectType"}
+
+For attributes, output:
+{"type": "attribute", "entity": "entity name", "entity_type": "EntityType", "attribute": "attribute_name", "value": "literal value"}
+
+## Important Rules
+
+1. **Entity names**: Use the exact text as it appears (e.g., "Cornish pasty", "beef")
+2. **Types**: Use the EXACT type identifiers from the schema above (e.g., "fo/Recipe", "fo/Food")
+3. **Relationships**: Use the EXACT relationship names from the schema (e.g., "fo/has_ingredient")
+4. **Attributes**: Use the EXACT attribute names from the schema (e.g., "fo/serves")
+5. **No array brackets**: Output one JSON object per line, not an array
+6. **No markdown**: Do not wrap output in code blocks
+
+## Requirements
+
+- Each line must be a complete, valid JSON object
+- No commas between lines
+- No [ ] array brackets
+- No markdown formatting, code blocks, or prefixes
+- Do not provide explanations, only output JSONL
+
+## Example
+
+Input text: "Cornish pasty is a savory pastry filled with beef and potatoes. This recipe serves 4 people."
+
+Expected output:
+{"type": "entity", "entity": "Cornish pasty", "entity_type": "fo/Recipe"}
+{"type": "entity", "entity": "beef", "entity_type": "fo/Food"}
+{"type": "entity", "entity": "potatoes", "entity_type": "fo/Food"}
+{"type": "relationship", "subject": "Cornish pasty", "subject_type": "fo/Recipe", "relation": "fo/has_ingredient", "object": "beef", "object_type": "fo/Food"}
+{"type": "relationship", "subject": "Cornish pasty", "subject_type": "fo/Recipe", "relation": "fo/has_ingredient", "object": "potatoes", "object_type": "fo/Food"}
+{"type": "attribute", "entity": "Cornish pasty", "entity_type": "fo/Recipe", "attribute": "fo/serves", "value": "4 people"}
+
+Now extract entities, relationships, and attributes from the text above.

--- a/trustgraph_configurator/templates/2.7/prompts/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/openai.jsonnet
@@ -1,0 +1,42 @@
+// For OpenAI LLMs.  Not currently overriding prompts
+
+local prompts = import "default-prompts.jsonnet";
+
+prompts + {
+
+    // "system-template":: "PROMPT GOES HERE.",
+
+    "templates" +:: {
+
+        "question" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-definitions" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-relationships" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-topics" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-rows" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "kg-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "document-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/prompts/pattern-select.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/pattern-select.txt
@@ -1,0 +1,26 @@
+Given the following user question and task type, select the best
+execution pattern.
+
+## Task type
+
+{{ task_type }}: {{ task_type_description }}
+
+## Available patterns
+
+{% for p in patterns %}
+- **{{ p.name }}**: {{ p.description }}
+{% endfor %}
+
+## Guidance
+
+- **react**: Best for straightforward queries needing 1-3 tool calls.
+- **plan-then-execute**: Best for multi-step queries that benefit from
+  upfront planning before execution.
+- **supervisor**: Best for complex queries that decompose into
+  independent sub-tasks that can run in parallel.
+
+## Question
+
+{{ question }}
+
+Respond with just the pattern name, nothing else.

--- a/trustgraph_configurator/templates/2.7/prompts/plan-create.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/plan-create.txt
@@ -1,0 +1,33 @@
+You are a planning agent. Given the user's question and the available
+tools, create a step-by-step plan.
+
+## Available tools
+
+{% for tool in tools %}
+- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}
+
+{% if framing %}
+## Domain context
+
+{{ framing }}
+
+{% endif %}
+## Question
+
+{{ question }}
+
+Do not include a final synthesis step — synthesis of results is performed
+automatically after all steps complete.
+
+Produce a JSON array of plan steps. Each step is an object with:
+- `goal` (string): what this step aims to achieve
+- `tool_hint` (string): suggested tool name, or empty string if none
+- `depends_on` (array of integers): indices of steps this depends on (0-based)
+
+Example:
+```json
+[
+  {"goal": "Look up information about X", "tool_hint": "knowledge-query", "depends_on": []},
+  {"goal": "Summarise findings", "tool_hint": "", "depends_on": [0]}
+]

--- a/trustgraph_configurator/templates/2.7/prompts/plan-step-execute.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/plan-step-execute.txt
@@ -1,0 +1,33 @@
+You are executing one step of a plan. Select the best tool and provide the
+arguments to achieve the goal.
+
+## Goal
+
+{{ goal }}
+
+{% if previous_results %}
+## Previous step results
+
+{% for r in previous_results %}
+- Step {{ r.index }}: {{ r.result }}
+{% endfor %}
+
+{% endif %}
+## Available tools
+
+{% for tool in tools %}
+- **{{ tool.name }}**: {{ tool.description }}
+{% for arg in tool.arguments %}
+  - `{{ arg.name }}` ({{ arg.type }}): {{ arg.description }}
+{% endfor %}
+{% endfor %}
+
+Respond with a JSON object:
+- `tool`: the exact tool name (must match one of the available tools above)
+- `arguments`: an object with the tool's arguments
+
+Example:
+```json
+{"tool": "Knowledge query", "arguments": {"question": "What is X?"}}
+
+Respond with only the JSON object.

--- a/trustgraph_configurator/templates/2.7/prompts/plan-synthesise.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/plan-synthesise.txt
@@ -1,0 +1,23 @@
+You executed a multi-step plan to answer a question. Now synthesise a
+comprehensive final answer from the step results.
+
+## Original question
+
+{{ question }}
+
+{% if framing %}
+## Domain context
+
+{{ framing }}
+
+{% endif %}
+## Step results
+
+{% for step in steps %}
+### Step {{ step.index }}: {{ step.goal }}
+{{ step.result }}
+
+{% endfor %}
+
+Provide a clear, complete answer to the original question based on
+these results.

--- a/trustgraph_configurator/templates/2.7/prompts/schema-selection.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/schema-selection.txt
@@ -1,0 +1,25 @@
+You are a database schema selection expert. Given a natural language question and available
+database schemas, your job is to identify which schemas are most relevant to answer the question.
+
+## Available Schemas:
+{% for schema in schemas %}
+**{{ schema.name }}**: {{ schema.description }}
+Fields:
+{% for field in schema.fields %}
+- {{ field.name }} ({{ field.type }}): {{ field.description }}
+{% endfor %}
+
+{% endfor %}
+
+## Question:
+{{ question }}
+
+## Instructions:
+1. Analyze the question to understand what data is being requested
+2. Examine each schema to understand what data it contains
+3. Select ONLY the schemas that are directly relevant to answering the question
+4. Return your answer as a JSON array of schema names
+
+## Response Format:
+Return ONLY a JSON array of schema names, nothing else.
+Example: ["customers", "orders", "products"]

--- a/trustgraph_configurator/templates/2.7/prompts/slm.jsonnet
+++ b/trustgraph_configurator/templates/2.7/prompts/slm.jsonnet
@@ -1,0 +1,44 @@
+// For SLM.  Not currently overriding prompts
+
+local prompts = import "default-prompts.jsonnet";
+
+prompts + {
+
+    // "system-template":: "PROMPT GOES HERE.",
+
+    "templates" +:: {
+
+        "question" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-definitions" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-relationships" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-topics" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "extract-rows" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "kg-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+        "document-prompt" +:: {
+            // "prompt": "PROMPT GOES HERE",
+        },
+
+    }
+
+}
+
+
+

--- a/trustgraph_configurator/templates/2.7/prompts/supervisor-decompose.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/supervisor-decompose.txt
@@ -1,0 +1,34 @@
+You are a supervisor agent. Decompose the user's question into
+independent sub-goals that can be investigated in parallel by
+separate agents.
+
+{% if framing %}
+## Domain context
+
+{{ framing }}
+
+{% endif %}
+## Available tools for sub-agents
+
+{% for tool in tools %}
+- **{{ tool.name }}**: {{ tool.description }}
+{% endfor %}
+
+## Rules
+
+- Each sub-goal must be independently answerable.
+- Aim for 2-{{ max_subagents }} sub-goals.
+- Each sub-goal should be a clear, specific question.
+
+## Question
+
+{{ question }}
+
+Produce a JSON array of sub-goal strings.
+
+Example:
+```json
+["What is X?", "How does Y relate to Z?"]
+```
+
+Respond with only the JSON array.

--- a/trustgraph_configurator/templates/2.7/prompts/supervisor-synthesise.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/supervisor-synthesise.txt
@@ -1,0 +1,23 @@
+You are synthesising a final answer from multiple sub-agent
+investigations.
+
+## Original question
+
+{{ question }}
+
+{% if framing %}
+## Domain context
+
+{{ framing }}
+
+{% endif %}
+## Sub-agent results
+
+{% for r in results %}
+### Sub-goal: {{ r.goal }}
+{{ r.result }}
+
+{% endfor %}
+
+Synthesise these results into a comprehensive answer to the original
+question.

--- a/trustgraph_configurator/templates/2.7/prompts/task-type-classify.txt
+++ b/trustgraph_configurator/templates/2.7/prompts/task-type-classify.txt
@@ -1,0 +1,14 @@
+Given the following user question, classify it into exactly one of the \
+available task types.
+
+## Available task types
+
+{% for tt in task_types %}
+- **{{ tt.name }}**: {{ tt.description }}
+{% endfor %}
+
+## Question
+
+{{ question }}
+
+Respond with just the task type name, nothing else.

--- a/trustgraph_configurator/templates/2.7/pubsub/kafka.jsonnet
+++ b/trustgraph_configurator/templates/2.7/pubsub/kafka.jsonnet
@@ -1,0 +1,99 @@
+local images = import "values/images.jsonnet";
+
+// Kafka messaging fabric configuration.
+// Single-node KRaft-mode broker (no Zookeeper), playing the role of
+// Pulsar / RabbitMQ in the TrustGraph pubsub fabric.
+
+{
+
+    "pub-sub-params":: {
+        pubsub_backend: "kafka",
+        kafka_bootstrap_servers: "kafka:9092",
+    },
+
+    "pub-sub-admin-params":: {},
+
+    "pub-sub-args":: [
+        "--pubsub-backend",
+        "kafka",
+        "--kafka-bootstrap-servers",
+        "kafka:9092",
+    ],
+
+    "pub-sub-init-args":: [],
+
+    "overview-dashboard"::
+        importstr "grafana/dashboards/overview-dashboard-pulsar.json",
+
+    "prometheus-config"::
+        importstr "prometheus/prometheus-pulsar.yml",
+
+    "kafka" +: {
+
+        // Memory settings (can be overridden by memory-profile)
+        "memory-limit":: "1024M",
+        "memory-reservation":: "1024M",
+
+        // CPU settings
+        "cpu-limit":: "1",
+        "cpu-reservation":: "0.1",
+
+        // Any base64-encoded 22-char string. Override per deployment if
+        // you need a stable cluster identity across restarts.
+        "cluster-id":: "YXM7bGtkamFzZGFsc2Rhc2QK",
+
+        create:: function(engine)
+
+            local memoryLimit = self["memory-limit"];
+            local memoryReservation = self["memory-reservation"];
+            local clusterId = self["cluster-id"];
+
+            // Kafka volume for persistent KRaft log data
+            local volume = engine.volume("kafka").with_size("10G");
+
+            local container =
+                engine.container("kafka")
+                    .with_image(images.kafka)
+                    .with_limits(self["cpu-limit"], memoryLimit)
+                    .with_reservations(self["cpu-reservation"], memoryReservation)
+                    .with_volume_mount(volume, "/var/lib/kafka/data")
+                    .with_environment({
+                        "KAFKA_NODE_ID": "1",
+                        "KAFKA_PROCESS_ROLES": "broker,controller",
+                        "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP":
+                            "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+                        "KAFKA_CONTROLLER_QUORUM_VOTERS": "1@localhost:9093",
+                        "KAFKA_LISTENERS":
+                            "PLAINTEXT://:9092,CONTROLLER://:9093",
+                        "KAFKA_INTER_BROKER_LISTENER_NAME": "PLAINTEXT",
+                        "KAFKA_CONTROLLER_LISTENER_NAMES": "CONTROLLER",
+                        "KAFKA_LOG_DIRS": "/var/lib/kafka/data",
+                        "CLUSTER_ID": clusterId,
+                        "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "1",
+                        "KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS": "12",
+                        "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "1",
+                        "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR": "1",
+                        "KAFKA_AUTO_CREATE_TOPICS_ENABLE": "true",
+                        "KAFKA_MESSAGE_MAX_BYTES": "10485760",
+                        "KAFKA_REPLICA_FETCH_MAX_BYTES": "10485760",
+                        "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS": "30",
+                    })
+                    .with_port(9092, 9092, "kafka");
+
+            local containerSet = engine.containers(
+                "kafka", [ container ]
+            );
+
+            local service =
+                engine.internalService("kafka", containerSet)
+                .with_port(9092, 9092, "kafka");
+
+            engine.resources([
+                volume,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}

--- a/trustgraph_configurator/templates/2.7/pubsub/pulsar-manager.jsonnet
+++ b/trustgraph_configurator/templates/2.7/pubsub/pulsar-manager.jsonnet
@@ -1,0 +1,40 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "pulsar" +: {
+
+        create:: function(engine)
+
+// FIXME: Should persist something?
+//            local volume = engine.volume(...)
+
+            local container =
+                engine.container("pulsar")
+                    .with_image(images.pulsar_manager)
+                    .with_environment({
+                        SPRING_CONFIGURATION_FILE: "/pulsar-manager/pulsar-manager/application.properties",
+                    })
+                    .with_limits("0.5", "1.4G")
+                    .with_reservations("0.1", "1.4G")
+                    .with_port(9527, 9527, "api")
+                    .with_port(7750, 7750, "api2");
+
+            local containerSet = engine.containers(
+                "pulsar", [ container ]
+            );
+
+            local service =
+                engine.internalService("pulsar", containerSet)
+                .with_port(9527, 9527, "api")
+                .with_port(7750, 7750, "api2);
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.7/pubsub/pulsar.jsonnet
@@ -1,0 +1,260 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// This is a Pulsar configuration.  Non-standalone mode so we deploy
+// individual components: bookkeeper, broker and zookeeper.
+//
+// This also deploys the TrustGraph 'admin' container which initialises
+// TrustGraph-specific namespaces etc.
+
+{
+
+    "pub-sub-params":: {
+        pubsub_backend: "pulsar",
+        pulsar_host: url.pulsar,
+    },
+
+    "pub-sub-admin-params":: {
+        pulsar_admin_url: url.pulsar_admin,
+    },
+
+    "pub-sub-args":: [
+        "--pubsub-backend",
+        "pulsar",
+        "--pulsar-host",
+        url.pulsar,
+    ],
+
+    "pub-sub-init-args":: [
+        "--pulsar-admin-url",
+        url.pulsar_admin,
+    ],
+
+    "overview-dashboard"::
+        importstr "grafana/dashboards/overview-dashboard-pulsar.json",
+
+    "prometheus-config"::
+        importstr "prometheus/prometheus-pulsar.yml",
+
+    with_params:: function(pars)
+        self + {
+            "pulsar" +: std.foldl(
+                function(obj, par) obj + { [par.key]:: par.value },
+                std.objectKeysValues(pars),
+                {}
+            ),
+        },
+
+    "pulsar" +: {
+
+        // Zookeeper memory settings (can be overridden by memory-profile)
+        "zk-memory-limit":: "512M",
+        "zk-memory-reservation":: "512M",
+        "zk-heap":: "256m",
+        "zk-direct-memory":: "256m",
+
+        // Bookie memory settings (can be overridden by memory-profile)
+        "bookie-memory-limit":: "1024M",
+        "bookie-memory-reservation":: "1024M",
+        "bookie-heap":: "256m",
+        "bookie-direct-memory":: "256m",
+
+        // Broker memory settings (can be overridden by memory-profile)
+        "broker-memory-limit":: "800M",
+        "broker-memory-reservation":: "800M",
+        "broker-heap":: "384m",
+        "broker-direct-memory":: "384m",
+
+        // Pulsar-init memory settings (can be overridden by memory-profile)
+        "init-memory-limit":: "256M",
+        "init-memory-reservation":: "256M",
+        "init-heap":: "128m",
+        "init-direct-memory":: "128m",
+
+        create:: function(engine)
+
+            // Capture memory settings into locals (self refers to pulsar object here)
+            local zkMemLimit = self["zk-memory-limit"];
+            local zkMemReserv = self["zk-memory-reservation"];
+            local zkHeap = self["zk-heap"];
+            local zkDirect = self["zk-direct-memory"];
+
+            local bookieMemLimit = self["bookie-memory-limit"];
+            local bookieMemReserv = self["bookie-memory-reservation"];
+            local bookieHeap = self["bookie-heap"];
+            local bookieDirect = self["bookie-direct-memory"];
+
+            local brokerMemLimit = self["broker-memory-limit"];
+            local brokerMemReserv = self["broker-memory-reservation"];
+            local brokerHeap = self["broker-heap"];
+            local brokerDirect = self["broker-direct-memory"];
+
+            local initMemLimit = self["init-memory-limit"];
+            local initMemReserv = self["init-memory-reservation"];
+            local initHeap = self["init-heap"];
+            local initDirect = self["init-direct-memory"];
+
+            // Zookeeper volume
+            local zkVolume = engine.volume("zookeeper").with_size("1G");
+
+            // Zookeeper container
+            local zkContainer =
+                engine.container("zookeeper")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "bin/apply-config-from-env.py conf/zookeeper.conf && bin/generate-zookeeper-config.sh conf/zookeeper.conf && exec bin/pulsar zookeeper"
+                    ])
+                    .with_limits("1", zkMemLimit)
+                    .with_reservations("0.05", zkMemReserv)
+                    .with_user(0)
+                    .with_group(1000)
+                    .with_volume_mount(zkVolume, "/pulsar/data")
+                    .with_environment({
+                        "metadataStoreUrl": "zk:zookeeper:2181",
+                        "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
+                            zkHeap, zkHeap, zkDirect,
+                        ],
+                    })
+                    .with_port(2181, 2181, "zookeeper")
+                    .with_port(2888, 2888, "zookeeper2")
+                    .with_port(3888, 3888, "zookeeper3");
+
+            // Pulsar cluster init container
+            local initContainer =
+                engine.container("pulsar-init")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "sleep 10 && bin/pulsar initialize-cluster-metadata --cluster cluster-a --zookeeper zookeeper:2181 --configuration-store zookeeper:2181 --web-service-url http://pulsar:8080 --broker-service-url pulsar://pulsar:6650",
+                    ])
+                    .with_limits("1", initMemLimit)
+                    .with_reservations("0.05", initMemReserv)
+                    .with_environment({
+                        "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
+                            initHeap, initHeap, initDirect,
+                        ],
+                    });
+
+
+            // Bookkeeper volume
+            local bookieVolume = engine.volume("bookie").with_size("20G");
+
+            // Bookkeeper container
+            local bookieContainer =
+                engine.container("bookie")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "sleep 2 && bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie"
+                        // false ^ causes this to be a 'failure' exit.
+                    ])
+                    .with_limits("1", bookieMemLimit)
+                    .with_reservations("0.1", bookieMemReserv)
+                    .with_user(0)
+                    .with_group(1000)
+                    .with_volume_mount(bookieVolume, "/pulsar/data")
+                    .with_environment({
+                        "clusterName": "cluster-a",
+                        "zkServers": "zookeeper:2181",
+                        "bookieId": "bookie",
+                        "metadataStoreUri": "metadata-store:zk:zookeeper:2181",
+                        "advertisedAddress": "bookie",
+                        "BOOKIE_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
+                            bookieHeap, bookieHeap, bookieDirect,
+                        ],
+                    })
+                    .with_port(3181, 3181, "bookie");
+
+            // Pulsar broker, stateless (uses ZK and Bookkeeper for state)
+            local brokerContainer =
+                engine.container("pulsar")
+                    .with_image(images.pulsar)
+                    .with_command([
+                        "bash",
+                        "-c",
+                        "bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker"
+                    ])
+                    .with_limits("1", brokerMemLimit)
+                    .with_reservations("0.1", brokerMemReserv)
+                    .with_environment({
+                        "metadataStoreUrl": "zk:zookeeper:2181",
+                        "zookeeperServers": "zookeeper:2181",
+                        "clusterName": "cluster-a",
+                        "managedLedgerDefaultEnsembleSize": "1",
+                        "managedLedgerDefaultWriteQuorum": "1",
+                        "managedLedgerDefaultAckQuorum": "1",
+                        "advertisedAddress": "pulsar",
+                        "advertisedListeners": "external:pulsar://pulsar:6650,localhost:pulsar://localhost:6650",
+                        "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
+                            brokerHeap, brokerHeap, brokerDirect,
+                        ],
+                    })
+                    .with_port(6650, 6650, "pulsar")
+                    .with_port(8080, 8080, "admin");
+
+            // Container sets
+            local zkContainerSet = engine.containers(
+                "zookeeper",
+                [
+                    zkContainer,
+                ]
+            );
+
+            local initContainerSet = engine.containers(
+                "init-pulsar",
+                [
+                    initContainer,
+                ]
+            );
+
+            local bookieContainerSet = engine.containers(
+                "bookie",
+                [
+                    bookieContainer,
+                ]
+            );
+
+            local brokerContainerSet = engine.containers(
+                "pulsar",
+                [
+                    brokerContainer,
+                ]
+            );
+
+            // Zookeeper service
+            local zkService =
+                engine.internalService("zookeeper", zkContainerSet)
+                .with_port(2181, 2181, "zookeeper")
+                .with_port(2888, 2888, "zookeeper2")
+                .with_port(3888, 3888, "zookeeper3");
+
+            // Bookkeeper service
+            local bookieService =
+                engine.internalService("bookie", bookieContainerSet)
+                .with_port(3181, 3181, "bookie");
+
+            // Pulsar broker service
+            local brokerService =
+                engine.internalService("pulsar", brokerContainerSet)
+                .with_port(6650, 6650, "pulsar")
+                .with_port(8080, 8080, "admin");
+
+            engine.resources([
+                zkVolume,
+                bookieVolume,
+                zkContainerSet,
+                initContainerSet,
+                bookieContainerSet,
+                brokerContainerSet,
+                zkService,
+                bookieService,
+                brokerService,
+            ])
+
+    }
+
+}

--- a/trustgraph_configurator/templates/2.7/pubsub/rabbitmq.jsonnet
+++ b/trustgraph_configurator/templates/2.7/pubsub/rabbitmq.jsonnet
@@ -1,0 +1,88 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// RabbitMQ messaging fabric configuration.
+// Replaces Pulsar as the message broker for TrustGraph.
+
+{
+
+    "pub-sub-params":: {
+        pubsub_backend: "rabbitmq",
+        rabbitmq_host: "rabbitmq",
+    },
+
+    "pub-sub-admin-params":: {},
+
+    "pub-sub-args":: [
+        "--pubsub-backend",
+        "rabbitmq",
+        "--rabbitmq-host",
+        "rabbitmq",
+    ],
+
+    "pub-sub-init-args":: [
+        "--pulsar-admin-url",
+        url.pulsar_admin,
+    ],
+
+    "overview-dashboard"::
+        importstr "grafana/dashboards/overview-dashboard-rabbitmq.json",
+
+    "prometheus-config"::
+        importstr "prometheus/prometheus-rabbitmq.yml",
+
+    "rabbitmq" +: {
+
+        // Memory settings (can be overridden by memory-profile)
+        "memory-limit":: "1024M",
+        "memory-reservation":: "1024M",
+
+        // CPU settings
+        "cpu-limit":: "1",
+        "cpu-reservation":: "0.1",
+
+        create:: function(engine)
+
+            local memoryLimit = self["memory-limit"];
+            local memoryReservation = self["memory-reservation"];
+
+            // RabbitMQ volume for persistent data
+            local volume = engine.volume("rabbitmq").with_size("10G");
+
+            // RabbitMQ container
+            local container =
+                engine.container("rabbitmq")
+                    .with_image(images.rabbitmq)
+                    .with_user(999)
+                    .with_group(999)
+                    .with_limits(self["cpu-limit"], memoryLimit)
+                    .with_reservations(self["cpu-reservation"], memoryReservation)
+                    .with_volume_mount(volume, "/var/lib/rabbitmq/mnesia")
+                    .with_environment({
+                        "RABBITMQ_DEFAULT_USER": "guest",
+                        "RABBITMQ_DEFAULT_PASS": "guest",
+                        "RABBITMQ_ERLANG_COOKIE": "trustgraph-rabbitmq-cookie",
+                    })
+                    .with_port(5672, 5672, "amqp")
+                    .with_port(15672, 15672, "management")
+                    .with_port(15692, 15692, "metrics");
+
+            local containerSet = engine.containers(
+                "rabbitmq", [ container ]
+            );
+
+            // RabbitMQ service
+            local service =
+                engine.internalService("rabbitmq", containerSet)
+                .with_port(5672, 5672, "amqp")
+                .with_port(15672, 15672, "management");
+
+            engine.resources([
+                volume,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}

--- a/trustgraph_configurator/templates/2.7/renderers/README.md
+++ b/trustgraph_configurator/templates/2.7/renderers/README.md
@@ -1,0 +1,73 @@
+# Renderers
+
+Each file in this directory is a top-level jsonnet program invoked by the
+Python `Packager`. Given a config list plus an engine target, a renderer
+emits the artifact for that target — docker-compose YAML, a k8s resource
+list, the runtime `trustgraph/config.json`, or the collection of
+`launch/*/launch.yaml` files shipped alongside the deployment.
+
+## Pipeline
+
+```
+  config.json (list of {name, parameters})
+        │
+        ▼
+  decode-config.jsonnet
+        │   fold each config entry over a `base + components[name]`
+        │   object, calling that object's `with_params(entry.parameters)`.
+        │   The result is `patterns`: a merged object where each visible
+        │   sub-field is a component instance carrying a `create(engine)`
+        │   method plus any hidden `parameters +::` defaults.
+        ▼
+  patterns  ─────────────────────────────────────────────┐
+        │                                                 │
+        ▼                                                 ▼
+  renderer invokes create(engine) on each             tg-configuration
+  visible sub-object, with a target-specific          renderer reads
+  engine (docker-compose, k8s, noop, collecting).     patterns.configuration
+        │                                                 │
+        ▼                                                 ▼
+  target-shaped output                              trustgraph/config.json
+  (docker-compose.yaml, k8s resource list,
+   launch.yaml files, ...)
+```
+
+## Shared helpers
+
+- **`decode-config.jsonnet`** — the fold that builds `patterns`. Every
+  renderer imports this and calls `decode(config)`. The `base` object it
+  defines supplies a default `with_params` (fold each key into a hidden
+  top-level field); the `override` component in `components.jsonnet`
+  replaces that default with a passthrough into `parameters +::`.
+
+## The renderers
+
+| File | Output | How it traverses `patterns` |
+|------|--------|---|
+| `config-to-docker-compose.jsonnet` | compose spec | `std.foldl(state + p.create(engine), std.objectValues(patterns), {})` |
+| `config-to-podman-compose.jsonnet` | compose spec (podman) | same shape, same engine |
+| `config-to-{aks,eks,gcp,minikube,ovh,scw}-k8s.jsonnet` | k8s resource list | `engine.package(patterns)` (the k8s engines own their own walk) |
+| `config-to-noop.jsonnet` | empty-ish resources | same foldl shape, noop engine |
+| `config-to-additionals.jsonnet` | list of `{path, content}` | runs `create` against a *collecting* engine that captures `configVolume` parts instead of producing container specs — this is how the `launch/*/launch.yaml` files get written |
+| `config-to-tg-configuration.jsonnet` | `trustgraph/config.json` | reads `patterns.configuration.configuration` directly, no engine walk |
+
+## Gotchas to know about
+
+1. **`std.objectValues(patterns)` severs siblings.** Inside a component's
+   `create`, `self` is only the sub-object the renderer extracted. Reads
+   like `$.parameters["foo"]` still work because `$` follows merges, but
+   there's no path back up from `self` to sibling components. The
+   `parameters +::` / `override` pattern exists specifically to route
+   tunables through the top-level object so they survive extraction.
+
+2. **Every visible field of `patterns` must have a `create::` method**,
+   except `configuration` (read directly by the tg-configuration
+   renderer) and hidden `parameters` / `log-level` etc. The compose
+   renderers call `.create` unconditionally, so a visible-but-createless
+   sub-object crashes with "Field does not exist: create". The
+   additionals renderer guards with `std.objectHasAll(p, 'create')`; the
+   compose renderers deliberately don't, to surface the bug loudly.
+
+3. **`$` is the merged root, resolved at eval time.** Works across
+   imports and merges, *does not* follow `objectValues` extraction —
+   see #1.

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-aca.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-aca.jsonnet
@@ -1,0 +1,13 @@
+// ARM template output targeting Azure Container Apps. Delegates to
+// `engine.package(patterns)` from ../engine/aca.jsonnet, which owns
+// the per-component walk and wraps the result in an ARM template
+// envelope.
+local engine = import "../engine/aca.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+local config = import "config.json";
+
+local patterns = decode(config);
+
+engine.package(patterns)

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-ack-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-ack-k8s.jsonnet
@@ -1,0 +1,20 @@
+
+// K8s output for Alibaba Cloud ACK. Delegates to `engine.package(patterns)`
+// from ../engine/ack-k8s.jsonnet, which owns the per-component walk and emits
+// a list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/ack-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-additionals.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-additionals.jsonnet
@@ -1,0 +1,152 @@
+// Emits the list of `launch/*/launch.yaml` files (and any other
+// configVolume parts) that ship alongside the compose / k8s output.
+//
+// This renderer is unusual: instead of running `create` against a
+// target-shaped engine, it uses a *collecting engine* whose methods are
+// mostly no-ops except for `configVolume`, which captures the `parts`
+// argument into `configVolumes` on the accumulating state. The renderer
+// then walks that list and converts it into an `[{path, content}, ...]`
+// array for the Packager to drop into the zip at the right paths.
+//
+// Unlike the compose renderers, this one guards with
+// `std.objectHasAll(p, 'create')` so hidden-only sub-objects (e.g.
+// `parameters`) don't crash the fold.
+
+local decode = import "decode-config.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Custom engine that collects configVolume parts
+local engine = {
+
+    // Collection of all configVolume parts
+    configVolumes:: [],
+
+    // Implement all required engine methods as no-ops
+    container:: function(name) {
+        with_image:: function(x) self,
+        with_command:: function(x) self,
+        with_environment:: function(x) self,
+        with_limits:: function(c, m) self,
+        with_reservations:: function(c, m) self,
+        with_port:: function(src, dest, name) self,
+        with_volume_mount:: function(vol, mnt) self,
+        with_user:: function(x) self,
+        with_group:: function(x) self,
+        with_supplemental_group:: function(x) self,
+        with_runtime:: function(x) self,
+        with_privileged:: function(x) self,
+        with_ipc:: function(x) self,
+        with_capability:: function(x) self,
+        with_device:: function(hdev, cdev) self,
+        with_env_var_secrets:: function(vars) self,
+    },
+
+    volume:: function(name) {
+        with_size:: function(size) self,
+    },
+
+    // The key method - collects configVolume parts
+    configVolume:: function(name, dir, parts)
+        local collector = self + {
+            configVolumes: super.configVolumes + [
+                {
+                    dir: dir,
+                    parts: parts,
+                }
+            ]
+        };
+        {
+            // Return a dummy volume that has the collector in it
+            name: name,
+            with_size:: function(size) collector,
+            // Provide a way to get back to the collector
+            getCollector:: function() collector,
+        },
+
+    secretVolume:: function(name, dir, parts) {
+        with_size:: function(size) self,
+    },
+
+    envSecrets:: function(name) {
+        with_env_var:: function(name, key) self,
+    },
+
+    containers:: function(name, containers) {
+        with_replicas:: function(n) self,
+    },
+
+    internalService:: function(name, containers) {
+        with_port:: function(src, dest, name) self,
+    },
+
+    service:: function(name, containers) {
+        with_port:: function(src, dest, name) self,
+    },
+
+    resources:: function(res)
+        // Fold over resources and collect any configVolume state
+        local collected = std.foldl(
+            function(state, r)
+                if std.objectHasAll(r, 'getCollector') then
+                    // Merge the configVolumes from the volume's collector into our state
+                    local volumeCollector = r.getCollector();
+                    state + {
+                        configVolumes: state.configVolumes + volumeCollector.configVolumes
+                    }
+                else
+                    state,
+            res,
+            self
+        );
+        collected,
+};
+
+// Execute all component create() functions with our collecting engine
+// Note: create:: is a hidden field, so we must use objectHasAll not objectHas
+local result = std.foldl(
+    function(state, p)
+        if std.objectHasAll(p, 'create') then
+            // Pattern has create directly - call it
+            p.create(state)
+        else
+            state,
+    std.objectValues(patterns),
+    engine
+);
+
+// Debug: show what we collected
+local debug = {
+    numPatterns: std.length(std.objectValues(patterns)),
+    numConfigVolumes: std.length(result.configVolumes),
+};
+
+// Transform collected data into output format
+local allFiles = std.flattenArrays([
+    [
+        {
+            // Remove trailing slash from dir to avoid double slashes
+            path: std.join("/", [std.rstripChars(cv.dir, "/"), filename]),
+            content: cv.parts[filename]
+        }
+        for filename in std.objectFields(cv.parts)
+    ]
+    for cv in result.configVolumes
+]);
+
+// Deduplicate by path - use a map to keep only unique paths
+local uniqueMap = std.foldl(
+    function(acc, item) acc + { [item.path]: item },
+    allFiles,
+    {}
+);
+
+// Convert back to array
+local additionals = std.objectValues(uniqueMap);
+
+// Output the array
+additionals

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-aks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-aks-k8s.jsonnet
@@ -1,0 +1,21 @@
+
+// K8s output for AKS (Azure Kubernetes Service). Delegates to `engine.package(patterns)` from
+// ../engine/aks-k8s.jsonnet, which owns the per-component walk and emits a
+// list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/aks-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-docker-compose.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-docker-compose.jsonnet
@@ -1,0 +1,30 @@
+// Emits the docker-compose.yaml spec. Runs `create` against the
+// docker-compose engine on every visible field of `patterns`, folding
+// the returned resource fragments into a single compose document.
+//
+// No `objectHasAll(p, 'create')` guard here — if a visible sub-object
+// lacks a `create::`, the fold crashes loudly with "Field does not
+// exist: create". That's deliberate: such a sub-object is almost always
+// a stub left behind by refactoring (e.g. a defaults-only block whose
+// owning component has been merged elsewhere) and you want the build to
+// fail rather than silently produce an incomplete deployment.
+
+local engine = import "../engine/compose.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resources = std.foldl(
+    function(state, p) state + p.create(engine),
+    std.objectValues(patterns),
+    {}
+);
+
+resources
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-eks-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-eks-k8s.jsonnet
@@ -1,0 +1,21 @@
+
+// K8s output for EKS (AWS Elastic Kubernetes Service). Delegates to `engine.package(patterns)` from
+// ../engine/eks-k8s.jsonnet, which owns the per-component walk and emits a
+// list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/eks-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-gcp-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-gcp-k8s.jsonnet
@@ -1,0 +1,21 @@
+
+// K8s output for GKE (Google Kubernetes Engine). Delegates to `engine.package(patterns)` from
+// ../engine/gcp-k8s.jsonnet, which owns the per-component walk and emits a
+// list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/gcp-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-minikube-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-minikube-k8s.jsonnet
@@ -1,0 +1,31 @@
+// K8s output for minikube. Delegates to `engine.package(patterns)`
+// from ../engine/minikube-k8s.jsonnet, same as the other k8s
+// renderers. Defines a `trustgraph` namespace resource locally — note
+// it's currently unused by the output expression; left in place as a
+// template for reintroducing namespace creation if needed.
+
+local engine = import "../engine/minikube-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+local ns = {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+        name: "trustgraph",
+    },
+    "spec": {
+    },
+};
+
+// Extract resources using the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-noop.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-noop.jsonnet
@@ -1,0 +1,24 @@
+// No-op renderer. Same foldl shape as the compose renderers, but the
+// engine is a stub whose methods return empty fragments. Useful for
+// exercising the full decode → create pipeline without producing real
+// output (e.g. for validation or debugging).
+
+local engine = import "../engine/noop.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resources = std.foldl(
+    function(state, p) state + p.create(engine),
+    std.objectValues(patterns),
+    {}
+);
+
+resources
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-ovh-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-ovh-k8s.jsonnet
@@ -1,0 +1,21 @@
+
+// K8s output for OVHcloud Managed Kubernetes. Delegates to `engine.package(patterns)` from
+// ../engine/ovh-k8s.jsonnet, which owns the per-component walk and emits a
+// list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/ovh-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-podman-compose.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-podman-compose.jsonnet
@@ -1,0 +1,23 @@
+// Podman-compose output. Identical to config-to-docker-compose.jsonnet
+// — podman-compose consumes the same spec shape, so we import the same
+// engine and run the same foldl over `patterns`.
+
+local engine = import "../engine/compose.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resources = std.foldl(
+    function(state, p) state + p.create(engine),
+    std.objectValues(patterns),
+    {}
+);
+
+resources
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-scw-k8s.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-scw-k8s.jsonnet
@@ -1,0 +1,21 @@
+
+// K8s output for Scaleway Kapsule. Delegates to `engine.package(patterns)` from
+// ../engine/scw-k8s.jsonnet, which owns the per-component walk and emits a
+// list of k8s resource manifests. The k8s engines handle traversal
+// internally rather than using the `objectValues + foldl + create`
+// pattern the compose renderers use.
+local engine = import "../engine/scw-k8s.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract resources usnig the engine
+local resourceList = engine.package(patterns);
+
+resourceList
+

--- a/trustgraph_configurator/templates/2.7/renderers/config-to-tg-configuration.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/config-to-tg-configuration.jsonnet
@@ -1,0 +1,27 @@
+// Emits the runtime `trustgraph/config.json` — the configuration
+// document the TrustGraph runtime reads on startup (flows, prompts,
+// active-flow defaults, and so on).
+//
+// Unlike the other renderers, this one does NOT walk `patterns` via
+// engine.create. Instead, it reads a pre-built object at
+// `patterns.configuration.configuration`, which is assembled by
+// ../core/configuration.jsonnet (pulling together flow-builder,
+// parameter-processor, default-prompts, etc.).
+//
+// The noop engine is imported for symmetry with the other renderers
+// but is never actually invoked.
+
+local engine = import "../engine/noop.jsonnet";
+local decode = import "decode-config.jsonnet";
+local components = import "../components.jsonnet";
+
+// Import config
+local config = import "config.json";
+
+// Produce patterns from config
+local patterns = decode(config);
+
+// Extract configuration directly from patterns
+patterns.configuration.configuration
+
+

--- a/trustgraph_configurator/templates/2.7/renderers/decode-config.jsonnet
+++ b/trustgraph_configurator/templates/2.7/renderers/decode-config.jsonnet
@@ -1,0 +1,58 @@
+// Shared helper imported by every renderer. Turns a config list
+// (array of {name, parameters}) into a single merged `patterns` object.
+//
+//   decode([
+//       { name: "rabbitmq",       parameters: {} },
+//       { name: "trustgraph-base",parameters: {} },
+//       { name: "openai",         parameters: { "max-output-tokens": 8192 } },
+//       { name: "override",       parameters: { "prompt-concurrency": 4 } },
+//   ])
+//
+// For each config entry, we build `base + components[entry.name]` and
+// call its `with_params(entry.parameters)`. The results are folded with
+// `state + apply(c)`, producing a merged object whose visible fields
+// are component instances carrying `create::` methods.
+//
+// `base` supplies a default `with_params` that plants each param as a
+// hidden top-level field via `self + { [k]:: v }` (replace, not
+// accumulate — `+::` would concatenate strings when a user override
+// collides with a default). Components can override `with_params` (or
+// `with`) to route params elsewhere — the `override` component in
+// components.jsonnet replaces the default with a passthrough into the
+// top-level `parameters +::` block, which is the mechanism every
+// tunable in the template tree reads from via `$.parameters[...]`.
+//
+// Note the init value of the inner foldl is `self`, not `{}`. With
+// empty pars (the common case for non-override components), the fold
+// returns `self`, and the outer `self + self` is a safe no-op.
+
+local components = import "../components.jsonnet";
+
+local apply = function(p, components)
+
+    local base = {
+
+        with:: function(k, v) self + {
+            [k]:: v
+        },
+
+        with_params:: function(pars)
+            self + std.foldl(
+                function(obj, par) obj.with(par.key, par.value),
+                std.objectKeysValues(pars),
+                self
+            ),
+
+    };
+
+    local component = base + components[p.name];
+
+    component.with_params(p.parameters);
+
+local decode = function(config)
+    local add = function(state, c) state + apply(c, components);
+    local patterns = std.foldl(add, config, {});
+    patterns;
+
+decode
+

--- a/trustgraph_configurator/templates/2.7/row-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.7/row-store/cassandra.jsonnet
@@ -1,0 +1,100 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// Reads the Cassandra hooks ($["cassandra-env-secrets"] / -replication-factor)
+// off the merged config; whichever Cassandra backend is listed supplies them.
+
+{
+
+    parameters +:: {
+        "rows-cpu-limit": "0.5",
+        "rows-cpu-reservation": "0.1",
+        "rows-memory-limit": "768M",
+        "rows-memory-reservation": "768M",
+        "rows-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "rows" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["rows-cpu-limit"],
+        local cpuReservation = pars["rows-cpu-reservation"],
+        local memoryLimit = pars["rows-memory-limit"],
+        local memoryReservation = pars["rows-memory-reservation"],
+        local replicas = pars["rows-replicas"],
+
+        create:: function(engine)
+
+            // External Cassandra supplies host/creds via env secrets; in that
+            // case omit cassandra_host (and replication factor) so the processor
+            // reads CASSANDRA_HOST / CASSANDRA_REPLICATION_FACTOR from env.
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else {
+                    cassandra_host: "cassandra",
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
+
+            local cfgVol = engine.configVolume(
+                "rows-launch-cfg", "launch/rows",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.query.rows.cassandra.Processor",
+                                params: {
+                                    id: "rows-query",
+                                } + cassandraParams + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.storage.rows.cassandra.Processor",
+                                params: {
+                                    id: "rows-write",
+                                } + cassandraParams + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local baseContainer =
+                engine.container("rows")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local container =
+                if cassandraSecrets != null then
+                    baseContainer.with_env_var_secrets(cassandraSecrets)
+                else baseContainer;
+
+            local containerSet = engine.containers(
+                "rows", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("rows", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ] + (if cassandraSecrets != null then [ cassandraSecrets ] else []))
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/runtime-config/agent-patterns.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/agent-patterns.jsonnet
@@ -1,0 +1,23 @@
+// Agent reasoning patterns available to the agent manager.
+// Each entry describes one strategy (ReAct, plan-then-execute,
+// supervisor) and the iteration / tool-use contract it follows.
+
+{
+    "react": {
+        "name": "react",
+        "description": "Interleaved reasoning and action — the agent thinks, selects a tool, observes the result, and repeats until it has enough information to answer.",
+        "max_iterations": 10,
+    },
+    "plan-then-execute": {
+        "name": "plan-then-execute",
+        "description": "The agent first produces a structured plan of steps, then executes each step in order. Supports re-planning on failure.",
+        "max_iterations": 15,
+        "max_replan_depth": 2,
+    },
+    "supervisor": {
+        "name": "supervisor",
+        "description": "The agent decomposes the question into independent sub-goals, fans out subagent requests, waits for all to complete, then synthesises a final answer.",
+        "max_subagents": 5,
+    },
+}
+

--- a/trustgraph_configurator/templates/2.7/runtime-config/agent-task-types.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/agent-task-types.jsonnet
@@ -1,0 +1,30 @@
+// Agent task-type definitions — domain framings plus the set of
+// reasoning patterns (see agent-patterns.jsonnet) that are valid
+// for each task type.
+
+{
+    "general": {
+        "name": "general",
+        "description": "No domain framing. All patterns are valid.",
+        "valid_patterns": ["react", "plan-then-execute", "supervisor"],
+        "framing": "",
+    },
+    "research": {
+        "name": "research",
+        "description": "Research-oriented queries requiring information gathering.",
+        "valid_patterns": ["react", "plan-then-execute"],
+        "framing": "This is a research query. Focus on gathering accurate, well-sourced information.",
+    },
+    "risk-assessment": {
+        "name": "risk-assessment",
+        "description": "Risk assessment queries requiring multi-dimensional analysis.",
+        "valid_patterns": ["supervisor", "plan-then-execute", "react"],
+        "framing": "This is a risk assessment query. Consider multiple risk dimensions and provide structured analysis.",
+    },
+    "summarisation": {
+        "name": "summarisation",
+        "description": "Summarisation queries — straightforward information condensation.",
+        "valid_patterns": ["react"],
+        "framing": "This is a summarisation query. Focus on concise, accurate synthesis of the available information.",
+    },
+}

--- a/trustgraph_configurator/templates/2.7/runtime-config/config-composer.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/config-composer.jsonnet
@@ -1,0 +1,67 @@
+// Configuration Composer Module
+// Orchestrates the complete configuration building process
+// Combines all components into the final TrustGraph configuration
+
+{
+    // Main function to build the complete configuration
+    build: function(config_spec)
+
+        // Extract configuration parameters
+        local flow_blueprints = config_spec.flow_blueprints;
+
+        // Return object with nested configuration (for backwards
+        // compatibility)
+        {
+
+            // Create function (for backwards compatibility)
+            create: function(engine) {},
+
+            // The actual configuration object
+            configuration: {
+
+                // Prompts configuration
+                prompt: {
+                    "system": config_spec.prompts["system-template"],
+                    "template-index": std.objectFieldsAll(
+                        config_spec.prompts.templates
+                    ),
+                } + {
+                    ["template." + template.key]: template.value
+                    for template in std.objectKeysValuesAll(
+                        config_spec.prompts.templates
+                    )
+                },
+
+                // Tools configuration
+                tool: {
+                    [tool.id]: tool
+                    for tool in config_spec.tools
+                },
+
+                // MCP configuration
+                mcp: config_spec.mcp,
+
+                // Agent orchestrator
+                "agent-pattern": config_spec.agent_patterns,
+                "agent-task-type": config_spec.agent_task_types,
+
+                // Flow blueprints reference
+                "flow-blueprint": flow_blueprints,
+
+                // Interface descriptions
+                "interface-description": config_spec.interface_descriptions,
+
+                // Active flow processors — each processor is its own
+                // config type keyed as "processor:<name>", with flow
+                // variants (e.g. "default", "flow2") as sub-keys.
+ 
+                // Token costs and parameter types
+                "token-cost": config_spec.token_costs,
+                "parameter-type": config_spec.parameter_types,
+
+                // Collections configuration
+                "collection": config_spec.collection,
+
+            },
+        },
+}

--- a/trustgraph_configurator/templates/2.7/runtime-config/interface-descriptions.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/interface-descriptions.jsonnet
@@ -1,0 +1,89 @@
+// Interface Descriptions Module
+// Defines all external interfaces available in TrustGraph flows
+// These are the 'endpoints' that external systems can interact with
+
+{
+    // Document loading interfaces - for data ingestion
+    "document-load": {
+        "description": "Document loader",
+        "kind": "send",
+        "visible": true,
+    },
+    "text-load": {
+        "description": "Text document loader",
+        "kind": "send",
+        "visible": true,
+    },
+
+    // Data storage interfaces - for processed data streams
+    "entity-contexts-load": {
+        "description": "Entity contexts loader",
+        "kind": "send",
+    },
+    "triples-store": {
+        "description": "Triples loader",
+        "kind": "send",
+    },
+    "graph-embeddings-store": {
+        "description": "Graph embeddings loader",
+        "kind": "send",
+    },
+    "document-embeddings-store": {
+        "description": "Document embeddings loader",
+        "kind": "send",
+    },
+    "objects-store": {
+        "description": "Object store",
+        "kind": "request-response",
+    },
+
+    // Query interfaces - for retrieving information
+    "graph-rag": {
+        "description": "GraphRAG service",
+        "kind": "request-response",
+    },
+    "document-rag": {
+        "description": "ChunkRAG service",
+        "kind": "request-response",
+    },
+    "triples": {
+        "description": "Triples query service",
+        "kind": "request-response",
+    },
+    "graph-embeddings": {
+        "description": "Graph embeddings service",
+        "kind": "request-response",
+    },
+    "document-embeddings": {
+        "description": "Document embeddings service",
+        "kind": "request-response",
+    },
+    "objects": {
+        "description": "Object query service",
+        "kind": "request-response",
+    },
+
+    // Processing services - for text and data processing
+    "prompt": {
+        "description": "Prompt service",
+        "kind": "request-response",
+    },
+    "agent": {
+        "description": "Agent service",
+        "kind": "request-response",
+    },
+    "text-completion": {
+        "description": "Text completion service",
+        "kind": "request-response",
+    },
+
+    // Query translation services - for natural language queries
+    "nlp-query": {
+        "description": "NLP question to GraphQL service",
+        "kind": "request-response",
+    },
+    "structured-query": {
+        "description": "Structured query service",
+        "kind": "request-response",
+    },
+}

--- a/trustgraph_configurator/templates/2.7/runtime-config/parameter-processor.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/parameter-processor.jsonnet
@@ -1,0 +1,38 @@
+// Parameter Processing Module
+// Handles dynamic parameter replacement in configuration values
+// Replaces {parameter_name} placeholders with actual parameter values
+
+{
+    // Applies parameter substitutions to string values
+    // Only processes strings - leaves other types unchanged
+    substitute_parameters: function(value, parameters)
+        if std.isString(value) then
+            std.foldl(
+                function(acc, param)
+                    // Only do string replacement if param.value is a string
+                    if std.isString(param.value) then
+                        std.strReplace(acc, "{" + param.key + "}", param.value)
+                    else
+                        acc,  // Skip replacement for non-string parameter values
+                std.objectKeysValuesAll(parameters),
+                value
+            )
+        else
+            value,
+
+    // Applies parameter substitutions to all values in an object
+    // Recursively processes nested objects and arrays
+    substitute_parameters_in_object: function(obj, parameters)
+        if std.isObject(obj) then
+            {
+                [key]: $.substitute_parameters_in_object(obj[key], parameters)
+                for key in std.objectFields(obj)
+            }
+        else if std.isArray(obj) then
+            [
+                $.substitute_parameters_in_object(item, parameters)
+                for item in obj
+            ]
+        else
+            $.substitute_parameters(obj, parameters),
+}

--- a/trustgraph_configurator/templates/2.7/runtime-config/tools.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/tools.jsonnet
@@ -1,0 +1,36 @@
+// Tools Configuration Module
+// Defines all available tools that can be used by agents and flows
+// Each tool specifies its interface, arguments, and behavior
+
+[
+    // Knowledge query tool - queries the knowledge base
+    {
+        id: "knowledge-query",
+        name: "Knowledge query",
+        description: "This tool queries a knowledge base that holds information about domain-specific information. The question should be a natural language question.",
+        type: "knowledge-query",
+        collection: "default",
+        arguments: [
+            {
+                name: "question",
+                type: "string",
+                description: "A simple natural language question.",
+            }
+        ]
+    },
+
+    // LLM completion tool - general purpose text completion
+    {
+        id: "llm-completion",
+        name: "LLM text completion",
+        type: "text-completion",
+        description: "This tool queries an LLM for non-domain-specific information. The question should be a natural language question.",
+        arguments: [
+            {
+                name: "question",
+                type: "string",
+                description: "The question which should be asked of the LLM.",
+            }
+        ]
+    }
+]

--- a/trustgraph_configurator/templates/2.7/runtime-config/trustgraph-config.jsonnet
+++ b/trustgraph_configurator/templates/2.7/runtime-config/trustgraph-config.jsonnet
@@ -1,0 +1,101 @@
+// TrustGraph Main Configuration
+// Clean, modular composition of TrustGraph configuration
+// Uses specialized modules for different aspects of config building
+
+// Import dependencies
+local images = import "../values/images.jsonnet";
+local url = import "../values/url.jsonnet";
+local prompts = import "../prompts/mixtral.jsonnet";
+local default_prompts = import "../prompts/default-prompts.jsonnet";
+local token_costs = import "../values/token-costs.jsonnet";
+local flow_blueprints = import "../flows/flow-blueprints.jsonnet";
+local config_composer = import "config-composer.jsonnet";
+local interface_descriptions = import "interface-descriptions.jsonnet";
+local tools = import "tools.jsonnet";
+local temperature_params = import "../parameters/temperature-param-types.jsonnet";
+local chunking_params = import "../parameters/chunking-param-types.jsonnet";
+
+// Main configuration object
+local configuration = {
+
+    // Prompt templates
+    prompts:: default_prompts,
+
+    // Tool definitions
+    tools:: tools,
+
+    // MCP configuration
+    mcp:: {},
+
+    // Flow classes reference
+    "flow-blueprints":: flow_blueprints,
+
+    // LLM model parameters
+    "llm-models" +:: {},
+
+    // Embeddings model parameters
+    "embeddings-models" +:: {},
+
+    // Re-ranker model parameters
+    "reranker-models" +:: {},
+
+    collections +:: {
+      "default": {
+        "user": "default-user",
+        "collection": "default",
+        "name": "Default Collection",
+        "description": "Default collection",
+        "tags": ["default"],
+      },
+    },
+
+    // Default model and flow parameters
+    flow_init_parameters:: {
+        "llm-model": $["llm-models"].default,
+        "llm-rag-model": $["llm-models"].default,
+        "llm-temperature": "%0.3f" % $["parameter-types"]["llm-temperature"].default,
+        "llm-rag-temperature": "%0.3f" % $["parameter-types"]["llm-temperature"].default,
+        "chunk-size": std.toString($["parameter-types"]["chunk-size"].default),
+        "chunk-overlap": std.toString($["parameter-types"]["chunk-overlap"].default),
+        "embeddings-model": $["embeddings-models"].default,
+        "reranker-model": $["reranker-models"].default,
+    },
+
+    // Interface descriptions for external endpoints
+    "interface-descriptions":: interface_descriptions,
+
+    // Parameter type definitions
+    "parameter-types":: {
+        "llm-model": $["llm-models"],
+        "embeddings-model": $["embeddings-models"],
+        "reranker-model": $["reranker-models"],
+    } + chunking_params + temperature_params,
+
+    // Token costs
+    "token-costs":: token_costs,
+
+    // Agent orchestator configuration
+    "agent-patterns":: import "agent-patterns.jsonnet",
+    "agent-task-types":: import "agent-task-types.jsonnet",
+
+    // Build the complete configuration using the composer
+    configuration:: config_composer.build({
+        flow_blueprints: $["flow-blueprints"],
+        default_flow_blueprint: "everything",
+        default_flow_id: "default",
+        flow_init_parameters: $["flow_init_parameters"],
+        prompts: $["prompts"],
+        tools: $["tools"],
+        mcp: $["mcp"],
+        interface_descriptions: $["interface-descriptions"],
+        parameter_types: $["parameter-types"],
+        token_costs: $["token-costs"],
+        collection: $["collections"],
+        agent_patterns: $["agent-patterns"],
+        agent_task_types: $["agent-task-types"],
+    }),
+
+} + default_prompts;
+
+// Export the final configuration
+configuration

--- a/trustgraph_configurator/templates/2.7/triple-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.7/triple-store/cassandra.jsonnet
@@ -1,0 +1,100 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+
+// Reads the Cassandra hooks ($["cassandra-env-secrets"] / -replication-factor)
+// off the merged config; whichever Cassandra backend is listed supplies them.
+
+{
+
+    parameters +:: {
+        "triples-cpu-limit": "0.5",
+        "triples-cpu-reservation": "0.1",
+        "triples-memory-limit": "512M",
+        "triples-memory-reservation": "512M",
+        "triples-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "triples" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["triples-cpu-limit"],
+        local cpuReservation = pars["triples-cpu-reservation"],
+        local memoryLimit = pars["triples-memory-limit"],
+        local memoryReservation = pars["triples-memory-reservation"],
+        local replicas = pars["triples-replicas"],
+
+        create:: function(engine)
+
+            // External Cassandra supplies host/creds via env secrets; in that
+            // case omit cassandra_host (and replication factor) so the processor
+            // reads CASSANDRA_HOST / CASSANDRA_REPLICATION_FACTOR from env.
+            local cassandraSecrets = $["cassandra-env-secrets"](engine);
+            local cassandraParams =
+                if cassandraSecrets != null then {}
+                else {
+                    cassandra_host: "cassandra",
+                    cassandra_replication_factor:
+                        $["cassandra-replication-factor"],
+                };
+
+            local cfgVol = engine.configVolume(
+                "triples-launch-cfg", "launch/triples",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.query.triples.cassandra.Processor",
+                                params: {
+                                    id: "triples-query",
+                                } + cassandraParams + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.storage.triples.cassandra.Processor",
+                                params: {
+                                    id: "triples-write",
+                                } + cassandraParams + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local baseContainer =
+                engine.container("triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local container =
+                if cassandraSecrets != null then
+                    baseContainer.with_env_var_secrets(cassandraSecrets)
+                else baseContainer;
+
+            local containerSet = engine.containers(
+                "triples", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ] + (if cassandraSecrets != null then [ cassandraSecrets ] else []))
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.7/triple-store/falkordb.jsonnet
+++ b/trustgraph_configurator/templates/2.7/triple-store/falkordb.jsonnet
@@ -1,0 +1,79 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local falkordb = import "backends/falkordb.jsonnet";
+
+falkordb + {
+
+    local logLevel = $.parameters["log-level"],
+
+    "falkordb-url":: "falkor://falkordb:6379",
+
+    "store-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("store-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-write-falkordb",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["falkordb-url"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("store-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("query-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-query-falkordb",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["falkordb-url"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("query-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/triple-store/memgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.7/triple-store/memgraph.jsonnet
@@ -1,0 +1,84 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local memgraph = import "backends/memgraph.jsonnet";
+
+memgraph + {
+
+    local logLevel = $.parameters["log-level"],
+
+    "memgraph-url":: "bolt://memgraph:7687",
+    "memgraph-database":: "memgraph",
+
+    "store-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("store-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-write-memgraph",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["memgraph-url"],
+                        "--database",
+                        $["memgraph-database"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("store-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("query-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-query-memgraph",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["memgraph-url"],
+                        "--database",
+                        $["memgraph-database"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("query-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/triple-store/neo4j.jsonnet
+++ b/trustgraph_configurator/templates/2.7/triple-store/neo4j.jsonnet
@@ -1,0 +1,79 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local neo4j = import "backends/neo4j.jsonnet";
+
+neo4j + {
+
+    local logLevel = $.parameters["log-level"],
+
+    "neo4j-url":: "bolt://neo4j:7687",
+
+    "store-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("store-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-write-neo4j",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["neo4j-url"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("store-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-triples" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("query-triples")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "triples-query-neo4j",
+] + $["pub-sub-args"] + [
+                        "-g",
+                        $["neo4j-url"],
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-triples", [ container ]
+            );
+
+            local service =
+                engine.internalService("query-triples", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/ui/trustgraph-ui.jsonnet
+++ b/trustgraph_configurator/templates/2.7/ui/trustgraph-ui.jsonnet
@@ -1,0 +1,33 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "trustgraph-ui" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("trustgraph-ui")
+                    .with_image(images["ui"])
+                    .with_limits("0.1", "256M")
+                    .with_reservations("0.1", "256M")
+                    .with_port(8888, 8888, "ui");
+
+            local containerSet = engine.containers(
+                "trustgraph-ui", [ container ]
+            );
+
+            local service =
+                engine.service("trustgraph-ui", containerSet)
+                .with_port(8888, 8888, "ui")
+                ;
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/ui/workbench-ui.jsonnet
+++ b/trustgraph_configurator/templates/2.7/ui/workbench-ui.jsonnet
@@ -1,0 +1,33 @@
+local images = import "values/images.jsonnet";
+
+{
+
+    "workbench-ui" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("workbench-ui")
+                    .with_image(images["workbench-ui"])
+                    .with_limits("0.1", "256M")
+                    .with_reservations("0.1", "256M")
+                    .with_port(8888, 8888, "ui");
+
+            local containerSet = engine.containers(
+                "workbench-ui", [ container ]
+            );
+
+            local service =
+                engine.service("workbench-ui", containerSet)
+                .with_port(8888, 8888, "ui")
+                ;
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}
+

--- a/trustgraph_configurator/templates/2.7/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/images.jsonnet
@@ -1,0 +1,44 @@
+// Container image references used across the templates.
+// TrustGraph images are tagged with the version from
+// version.jsonnet (injected by the packager); third-party
+// images are pinned explicitly here.
+
+local version = import "version.jsonnet";
+{
+    cassandra: "docker.io/cassandra:5.0.8",
+    neo4j: "docker.io/neo4j:2026.04.0-community-bullseye",
+    pulsar: "docker.io/apachepulsar/pulsar:4.2.1",
+    rabbitmq: "docker.io/rabbitmq:4.1-management",
+    kafka: "docker.io/apache/kafka:4.1.2",
+    pulsar_manager: "docker.io/apachepulsar/pulsar-manager:v0.4.0",
+    etcd: "quay.io/coreos/etcd:v3.6.11",
+    minio: "docker.io/minio/minio:v0.20260512.133534-dev",
+    garage: "docker.io/dxflrs/garage:v2.3.0",
+    milvus: "docker.io/milvusdb/milvus:v2.6.17",
+    prometheus: "docker.io/prom/prometheus:v3.11.3",
+    grafana: "docker.io/grafana/grafana:13.0.1",
+    loki: "docker.io/grafana/loki:3.7.2",
+    trustgraph_base: "docker.io/trustgraph/trustgraph-base:" + version,
+    trustgraph_flow: "docker.io/trustgraph/trustgraph-flow:" + version,
+    trustgraph_ocr: "docker.io/trustgraph/trustgraph-ocr:" + version,
+    trustgraph_bedrock: "docker.io/trustgraph/trustgraph-bedrock:" + version,
+    trustgraph_vertexai: "docker.io/trustgraph/trustgraph-vertexai:" + version,
+    trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
+    trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
+    trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:0.9.7",
+    qdrant: "docker.io/qdrant/qdrant:v1.18.0",
+    memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",
+    memgraph_lab: "docker.io/memgraph/lab:3.10.0",
+    falkordb: "docker.io/falkordb/falkordb:v4.18.7",
+    "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.7",
+    "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
+    "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
+    "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",
+    "tgi-service-gaudi": "ghcr.io/huggingface/text-generation-inference:sha-b4adbf2-gaudi",
+    "vllm-service-intel-xpu": "docker.io/intel/vllm:0.17.0-xpu",
+    "vllm-service-gaudi": "docker.io/trustgraph/vllm-hpu:027f5645",
+    "vllm-service-nvidia": "docker.io/vllm/vllm-openai:latest",
+    "vllm-service-intel-battlemage": "docker.io/intelanalytics/ipex-llm-serving-xpu:0.2.0-b6",
+}

--- a/trustgraph_configurator/templates/2.7/values/token-costs.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/token-costs.jsonnet
@@ -1,0 +1,106 @@
+// Per-model input/output token prices (USD per token), keyed by
+// provider-qualified model id. Consumed by the runtime config so
+// downstream accounting can attribute cost per LLM call.
+
+{
+  "mistral.mistral-large-2407-v1:0": {
+    "model_name": "mistral.mistral-large-2407-v1:0",
+    "input_price": 0.000004,
+    "output_price": 0.000012
+  },
+  "meta.llama3-1-405b-instruct-v1:0": {
+    "model_name": "meta.llama3-1-405b-instruct-v1:0",
+    "input_price": 0.00000532,
+    "output_price": 0.000016
+  },
+  "mistral.mixtral-8x7b-instruct-v0:1": {
+    "model_name": "mistral.mixtral-8x7b-instruct-v0:1",
+    "input_price": 0.00000045,
+    "output_price": 0.0000007
+  },
+  "meta.llama3-1-70b-instruct-v1:0": {
+    "model_name": "meta.llama3-1-70b-instruct-v1:0",
+    "input_price": 0.00000099,
+    "output_price": 0.00000099
+  },
+  "meta.llama3-1-8b-instruct-v1:0": {
+    "model_name": "meta.llama3-1-8b-instruct-v1:0",
+    "input_price": 0.00000022,
+    "output_price": 0.00000022
+  },
+  "anthropic.claude-3-haiku-20240307-v1:0": {
+    "model_name": "anthropic.claude-3-haiku-20240307-v1:0",
+    "input_price": 0.00000025,
+    "output_price": 0.00000125
+  },
+  "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    "model_name": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "input_price": 0.000003,
+    "output_price": 0.000015
+  },
+  "cohere.command-r-plus-v1:0": {
+    "model_name": "cohere.command-r-plus-v1:0",
+    "input_price": 0.0000030,
+    "output_price": 0.0000150
+  },
+  "ollama": {
+    "model_name": "ollama",
+    "input_price": 0,
+    "output_price": 0
+  },
+  "claude-3-haiku-20240307": {
+    "model_name": "claude-3-haiku-20240307",
+    "input_price": 0.00000025,
+    "output_price": 0.00000125
+  },
+  "claude-3-5-sonnet-20240620": {
+    "model_name": "claude-3-5-sonnet-20240620",
+    "input_price": 0.000003,
+    "output_price": 0.000015
+  },
+  "claude-3-opus-20240229": {
+    "model_name": "claude-3-opus-20240229",
+    "input_price": 0.000015,
+    "output_price": 0.000075
+  },
+  "claude-3-sonnet-20240229": {
+    "model_name": "claude-3-sonnet-20240229",
+    "input_price": 0.000003,
+    "output_price": 0.000015
+  },
+  "command-r-08-202": {
+    "model_name": "command-r-08-202",
+    "input_price": 0.0000025,
+    "output_price": 0.000010
+  },
+  "c4ai-aya-23-8b": {
+    "model_name": "c4ai-aya-23-8b",
+    "input_price": 0,
+    "output_price": 0
+  },
+  "llama.cpp": {
+    "model_name": "llama.cpp",
+    "input_price": 0,
+    "output_price": 0
+  },
+  "gpt-4o": {
+    "model_name": "gpt-4o",
+    "input_price": 0.000005,
+    "output_price": 0.000015
+  },
+  "gpt-4o-2024-08-06": {
+    "model_name": "gpt-4o-2024-08-06",
+    "input_price": 0.0000025,
+    "output_price": 0.000010
+  },
+  "gpt-4o-2024-05-13": {
+    "model_name": "gpt-4o-2024-05-13",
+    "input_price": 0.000005,
+    "output_price": 0.000015
+  },
+  "gpt-4o-mini": {
+    "model_name": "gpt-4o-mini",
+    "input_price": 0.00000015,
+    "output_price": 0.0000006
+  }
+}

--- a/trustgraph_configurator/templates/2.7/values/url.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/url.jsonnet
@@ -1,0 +1,12 @@
+// Internal service URLs used by processors to reach infrastructure
+// components (pulsar, object store, vector stores). Hostnames assume
+// the deployment-internal DNS names produced by the renderers.
+
+{
+    pulsar: "pulsar://pulsar:6650",
+    pulsar_admin: "http://pulsar:8080",
+    amqp: "amqp://guest:guest@rabbitmq:5672",
+    milvus: "http://milvus:19530",
+    qdrant: "http://qdrant:6333",
+    object_store: "garage:3900",
+}

--- a/trustgraph_configurator/templates/2.7/vector-store/milvus.jsonnet
+++ b/trustgraph_configurator/templates/2.7/vector-store/milvus.jsonnet
@@ -1,0 +1,152 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local cassandra_hosts = "cassandra";
+local milvus = import "backends/milvus.jsonnet";
+
+milvus + {
+
+    parameters +:: {
+        "store-graph-embeddings-replicas": 1,
+        "query-graph-embeddings-replicas": 1,
+        "store-doc-embeddings-replicas": 1,
+        "query-doc-embeddings-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+    local pars = $.parameters,
+
+    "store-graph-embeddings" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("store-graph-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "ge-write-milvus",
+] + $["pub-sub-args"] + [
+                        "-t",
+                        url.milvus,
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-graph-embeddings", [ container ]
+            ).with_replicas(pars["store-graph-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-graph-embeddings" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("query-graph-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "ge-query-milvus",
+] + $["pub-sub-args"] + [
+                        "-t",
+                        url.milvus,
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-graph-embeddings", [ container ]
+            ).with_replicas(pars["query-graph-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "store-doc-embeddings" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("store-doc-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "de-write-milvus",
+] + $["pub-sub-args"] + [
+                        "-t",
+                        url.milvus,
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-doc-embeddings", [ container ]
+            ).with_replicas(pars["store-doc-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-doc-embeddings" +: {
+    
+        create:: function(engine)
+
+            local container =
+                engine.container("query-doc-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "de-query-milvus",
+] + $["pub-sub-args"] + [
+                        "-t",
+                        url.milvus,
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-doc-embeddings", [ container ]
+            ).with_replicas(pars["query-doc-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/vector-store/pinecone.jsonnet
+++ b/trustgraph_configurator/templates/2.7/vector-store/pinecone.jsonnet
@@ -1,0 +1,166 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local cassandra_hosts = "cassandra";
+
+{
+
+    parameters +:: {
+        "store-graph-embeddings-replicas": 1,
+        "query-graph-embeddings-replicas": 1,
+        "store-doc-embeddings-replicas": 1,
+        "query-doc-embeddings-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+    local pars = $.parameters,
+
+    "pinecone-cloud":: "aws",
+    "pinecone-region":: "us-east-1",
+
+    "store-graph-embeddings" +: {
+    
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("pinecone-api-key")
+                .with_env_var("PINECONE_API_KEY", "pinecone-api-key");
+
+            local container =
+                engine.container("store-graph-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "ge-write-pinecone",
+] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-graph-embeddings", [ container ]
+            ).with_replicas(pars["store-graph-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-graph-embeddings" +: {
+    
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("pinecone-api-key")
+                .with_env_var("PINECONE_API_KEY", "pinecone-api-key");
+
+            local container =
+                engine.container("query-graph-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "ge-query-pinecone",
+] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-graph-embeddings", [ container ]
+            ).with_replicas(pars["query-graph-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "store-doc-embeddings" +: {
+    
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("pinecone-api-key")
+                .with_env_var("PINECONE_API_KEY", "pinecone-api-key");
+
+            local container =
+                engine.container("store-doc-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "de-write-pinecone",
+] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "store-doc-embeddings", [ container ]
+            ).with_replicas(pars["store-doc-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+    },
+
+    "query-doc-embeddings" +: {
+    
+        create:: function(engine)
+
+            local envSecrets = engine.envSecrets("pinecone-api-key")
+                .with_env_var("PINECONE_API_KEY", "pinecone-api-key");
+
+            local container =
+                engine.container("query-doc-embeddings")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "de-query-pinecone",
+] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits("0.5", "128M")
+                    .with_reservations("0.1", "128M");
+
+            local containerSet = engine.containers(
+                "query-doc-embeddings", [ container ]
+            ).with_replicas(pars["query-doc-embeddings-replicas"]);
+
+            local service =
+                engine.internalService("store-graph-embeddings", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                containerSet,
+                service,
+            ])
+
+
+    }
+
+}
+

--- a/trustgraph_configurator/templates/2.7/vector-store/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.7/vector-store/qdrant.jsonnet
@@ -1,0 +1,121 @@
+local images = import "values/images.jsonnet";
+local url = import "values/url.jsonnet";
+local qdrant = import "backends/qdrant.jsonnet";
+
+qdrant + {
+
+    parameters +:: {
+        "vector-store-cpu-limit": "0.5",
+        "vector-store-cpu-reservation": "0.1",
+        "vector-store-memory-limit": "256M",
+        "vector-store-memory-reservation": "256M",
+        "vector-store-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "vector-store" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["vector-store-cpu-limit"],
+        local cpuReservation = pars["vector-store-cpu-reservation"],
+        local memoryLimit = pars["vector-store-memory-limit"],
+        local memoryReservation = pars["vector-store-memory-reservation"],
+        local replicas = pars["vector-store-replicas"],
+
+        create:: function(engine)
+
+            // Collection geometry applied only by the WRITE processors when
+            // they create collections. 1/1 single-node by default;
+            // qdrant-cluster raises both to the ring size. Query processors
+            // don't create collections, so they don't take these.
+            local collectionParams = {
+                qdrant_replication_factor: $["qdrant-replication-factor"],
+                qdrant_shard_number: $["qdrant-shard-number"],
+            };
+
+            local cfgVol = engine.configVolume(
+                "vector-store-cfg", "launch/vector-store",
+		{
+		    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.query.doc_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "doc-embeddings-query",
+                                    store_uri: url.qdrant,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.storage.doc_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "doc-embeddings-write",
+                                    store_uri: url.qdrant,
+                                } + collectionParams + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.query.graph_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "graph-embeddings-query",
+                                    store_uri: url.qdrant,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.storage.graph_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "graph-embeddings-write",
+                                    store_uri: url.qdrant,
+                                } + collectionParams + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.query.row_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "row-embeddings-query",
+                                    store_uri: url.qdrant,
+                                } + $["pub-sub-params"],
+                            },
+                            {
+                                class: "trustgraph.storage.row_embeddings.qdrant.Processor",
+                                params: {
+                                    id: "row-embeddings-write",
+                                    store_uri: url.qdrant,
+                                } + collectionParams + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+		}
+            );
+
+            local container =
+                engine.container("vector-store")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "vector-store", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("vector-store", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+// Qdrant is used by these adapters
+} + qdrant

--- a/trustgraph_configurator/templates/2.7/zip-readme.md
+++ b/trustgraph_configurator/templates/2.7/zip-readme.md
@@ -1,0 +1,28 @@
+
+Note! this is a subset of possible configurations, to generate your own
+launch config use the config util...
+
+- Production: https://config-ui.demo.trustgraph.ai
+- Early release: https://dev.config-ui.demo.trustgraph.ai
+
+The config util auto-generates deployment instructions for your
+configuration, so that's the recommended way to deploy.
+
+----------------------------------------------------------------------------
+
+These are launch configurations for TrustGraph.  See https://trustgraph.ai for
+the quickstart using docker compose.
+
+Hint for Linux: There are files here which get mounted as volumes inside
+Docker Compose containers.  This may trigger SELinux rules on your system, to
+permit access insider the containers, use a command like this...
+
+chcon -Rt svirt_sandbox_file_t grafana/ prometheus/
+
+The file vertexai/private.json is a placeholder for real GCP credentials if
+you are using the VertexAI LLM.  If you're using that in Docker Compose,
+replace with your real credentials, and don't forget to permit access if you
+are using Linux:
+
+chcon -Rt svirt_sandbox_file_t vertexai/
+

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -1,12 +1,6 @@
 {
     "templates": [
         {
-            "name": "2.2",
-            "description": "Multi-pattern agent orchestration with explainability, extended document processing for cover many document types",
-            "version": "2.2.27",
-            "status": "stable"
-        },
-        {
             "name": "2.3",
             "description": "Agent explainability analytics.  Reduced container footprint",
             "version": "2.3.21",
@@ -27,7 +21,13 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.14",
+            "version": "2.6.15",
+            "status": "stable"
+        },
+        {
+            "name": "2.7",
+            "description": "Placeholder for next release",
+            "version": "2.7.0",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Add complete TrustGraph 2.7 pre-release template tree (forked from 2.6)
- Promote 2.6 to stable at 2.6.15
- Retire 2.2 from template index
- Update dialog flow and test config for 2.7

## Test plan
- [x] Verify 2.7 template generates valid configs for all platforms
- [x] Verify 2.6 still renders correctly as stable
- [x] Confirm 2.2 no longer appears in configurator

