### PR TITLE
Keyword-index (FTS5) component + hybrid retrieval wiring for Document-RAG (#875)

### DIFF
--- a/tests/features/helpers.py
+++ b/tests/features/helpers.py
@@ -54,10 +54,11 @@ def minimal_config(components, overrides=None, without=None):
     return config
 
 
-def run_packager(config, platform="docker-compose"):
+def run_packager(config, platform="docker-compose", template=TEMPLATE,
+                 version=VERSION):
     pkg = Packager(
-        version=VERSION,
-        template=TEMPLATE,
+        version=version,
+        template=template,
         platform=platform,
         latest=False,
         latest_stable=False,

--- a/tests/features/test_components.py
+++ b/tests/features/test_components.py
@@ -4,9 +4,13 @@ the feature it's supposed to produce: correct processor classes, ids, and
 baked-in default param values in the generated launch.yaml.
 """
 
+import json
+
 import pytest
 
-from helpers import minimal_config, find_processor
+from helpers import (
+    minimal_config, find_processor, run_packager, extract_launches, _entry,
+)
 
 
 pytestmark = pytest.mark.features
@@ -237,3 +241,67 @@ def test_llm_concurrency_defaults(name, build):
     tc = launches["text-completion"]
     assert find_processor(tc, "text-completion")["params"]["concurrency"] == 1
     assert find_processor(tc, "text-completion-rag")["params"]["concurrency"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Keyword index (FTS5) — sparse retrieval for Document-RAG (2.7 template)
+# ---------------------------------------------------------------------------
+
+# 2.7 baseline differs from the 2.3 BASELINE above: the control group needs
+# the cassandra backend and garage object store to compile.
+BASELINE_27 = [
+    "rabbitmq", "trustgraph-base", "openai", "embeddings-fastembed",
+    "cassandra", "triple-store-cassandra", "vector-store-qdrant",
+    "garage",
+]
+
+
+def _build_27(components):
+    config = [_entry(name) for name in BASELINE_27 + components]
+    compose, additionals = run_packager(
+        config, template="2.7", version="2.7.0",
+    )
+    return compose, extract_launches(additionals), additionals
+
+
+class TestKeywordIndex:
+
+    def test_component_deploys_kw_index_processor(self):
+        _, launches, _ = _build_27(["keyword-index-fts5"])
+        proc = find_processor(launches["keyword-index"], "kw-index")
+        assert proc["class"] == "trustgraph.storage.kw_index.fts5.Processor"
+        assert proc["params"]["index_path"] == "/data/kw-index.db"
+
+    def test_component_mounts_data_volume(self):
+        compose, _, _ = _build_27(["keyword-index-fts5"])
+        volumes = compose["services"]["keyword-index"]["volumes"]
+        assert any(v.startswith("keyword-index:/data") for v in volumes)
+
+    def test_component_flips_document_rag_to_hybrid(self):
+        _, launches, _ = _build_27(["keyword-index-fts5"])
+        doc_rag = find_processor(launches["rag"], "document-rag")
+        assert doc_rag["params"]["retrieval_mode"] == "hybrid"
+
+    def test_without_component_document_rag_stays_vector(self):
+        compose, launches, _ = _build_27([])
+        doc_rag = find_processor(launches["rag"], "document-rag")
+        assert doc_rag["params"]["retrieval_mode"] == "vector"
+        assert "keyword-index" not in compose["services"]
+
+    def test_blueprint_wires_keyword_index_topics(self):
+        _, _, additionals = _build_27(["keyword-index-fts5"])
+        cfg = json.loads(next(
+            a["content"] for a in additionals
+            if a["path"] == "trustgraph/config.json"
+        ))
+        bp = cfg["flow-blueprint"]["everything"]
+        if isinstance(bp, str):
+            bp = json.loads(bp)
+        topics = bp["flow"]["document-rag:{id}"]["topics"]
+        assert topics["keyword-index-request"] == \
+            "request:tg:keyword-index:{workspace}:{id}"
+        assert topics["keyword-index-response"] == \
+            "response:tg:keyword-index:{workspace}:{id}"
+        kw = bp["flow"]["kw-index:{id}"]["topics"]
+        assert kw["input"] == "flow:tg:chunk-load:{workspace}:{id}"
+        assert kw["request"] == "request:tg:keyword-index:{workspace}:{id}"

--- a/trustgraph_configurator/templates/2.7/components.jsonnet
+++ b/trustgraph_configurator/templates/2.7/components.jsonnet
@@ -37,6 +37,10 @@
    "vector-store-qdrant": import "vector-store/qdrant.jsonnet",
    "vector-store-pinecone": import "vector-store/pinecone.jsonnet",
 
+   // Keyword (BM25) index - sparse retrieval path for Document-RAG.
+   // Including it turns on hybrid retrieval (vector + keyword, RRF-fused).
+   "keyword-index-fts5": import "keyword-index/fts5.jsonnet",
+
    // Object store (S3-compatible) for the librarian. Import exactly one of
    // these to select how the librarian gets its object store.
    "garage": import "backends/garage.jsonnet",

--- a/trustgraph_configurator/templates/2.7/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/rag.jsonnet
@@ -15,6 +15,9 @@ local url = import "values/url.jsonnet";
         "graph-rag-max-subgraph-size": 100,
         "graph-rag-max-path-length": 2,
         "document-rag-doc-limit": 20,
+        // vector | keyword | hybrid; the keyword-index component overrides
+        // this to hybrid when included
+        "document-rag-retrieval-mode": "vector",
         "prompt-rag-concurrency": 1,
         "rag-cpu-limit": "0.5",
         "rag-cpu-reservation": "0.1",
@@ -37,6 +40,7 @@ local url = import "values/url.jsonnet";
         local maxSubgraphSize = pars["graph-rag-max-subgraph-size"],
         local maxPathLength = pars["graph-rag-max-path-length"],
         local docLimit = pars["document-rag-doc-limit"],
+        local retrievalMode = pars["document-rag-retrieval-mode"],
         local promptRagConc = pars["prompt-rag-concurrency"],
         local cpuLimit = pars["rag-cpu-limit"],
         local cpuReservation = pars["rag-cpu-reservation"],
@@ -86,6 +90,7 @@ local url = import "values/url.jsonnet";
                                 params: {
                                     id: "document-rag",
                                     doc_limit: docLimit,
+                                    retrieval_mode: retrievalMode,
                                 } + $["pub-sub-params"],
                             },
                             {

--- a/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
@@ -15,9 +15,10 @@ local librarian_response = helpers.librarian_response;
 local llm_services = import "llm-services.jsonnet";
 local embeddings_service = import "embeddings-service.jsonnet";
 local reranker_service = import "reranker-service.jsonnet";
+local keyword_index_service = import "keyword-index-service.jsonnet";
 
 // Merge shared services with document store configuration
-llm_services + embeddings_service + reranker_service + {
+llm_services + embeddings_service + reranker_service + keyword_index_service + {
 
     // External interfaces for document store
     "interfaces" +: {
@@ -54,6 +55,8 @@ llm_services + embeddings_service + reranker_service + {
                 "document-embeddings-response": response("document-embeddings:{workspace}:{id}"),
                 "reranker-request": request("reranker:{workspace}:{id}"),
                 "reranker-response": response("reranker:{workspace}:{id}"),
+                "keyword-index-request": request("keyword-index:{workspace}:{id}"),
+                "keyword-index-response": response("keyword-index:{workspace}:{id}"),
                 explainability: flow("triples-store:{workspace}:{id}"),
                 "librarian-request": librarian_request,
                 "librarian-response": librarian_response,

--- a/trustgraph_configurator/templates/2.7/flows/keyword-index-service.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/keyword-index-service.jsonnet
@@ -1,0 +1,36 @@
+// Shared keyword index service module
+// Provides sparse (BM25) keyword search over document chunks
+// Import this module in any flow that requires keyword retrieval
+
+local helpers = import "helpers.jsonnet";
+local flow = helpers.flow;
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+{
+    // Interfaces exposed by keyword index service
+    "interfaces" +: {
+        "keyword-index": request_response_if("keyword-index:{workspace}:{id}"),
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for the keyword index: indexes chunks off the
+    // same ingestion stream document-embeddings consumes, answers keyword
+    // queries. Only bound when a kw-index processor is deployed; the entry
+    // is inert otherwise.
+    "flow" +: {
+        "kw-index:{id}": {
+            topics: {
+                input: flow("chunk-load:{workspace}:{id}"),
+                request: request("keyword-index:{workspace}:{id}"),
+                response: response("keyword-index:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/keyword-index/fts5.jsonnet
+++ b/trustgraph_configurator/templates/2.7/keyword-index/fts5.jsonnet
@@ -1,0 +1,85 @@
+// Keyword index (SQLite FTS5) - sparse/BM25 retrieval for Document-RAG.
+// Deploys the kw-index processor, which consumes chunks off the ingestion
+// stream and answers BM25 keyword queries. Ingest and query live in one
+// service because the FTS5 index is a single local file (on the volume
+// below). Including this component also flips Document-RAG to hybrid
+// retrieval (vector + keyword fused by reciprocal rank fusion); override
+// document-rag-retrieval-mode to choose another mode.
+
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "document-rag-retrieval-mode": "hybrid",
+        "keyword-index-cpu-limit": "0.5",
+        "keyword-index-cpu-reservation": "0.1",
+        "keyword-index-memory-limit": "128M",
+        "keyword-index-memory-reservation": "128M",
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "keyword-index" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["keyword-index-cpu-limit"],
+        local cpuReservation = pars["keyword-index-cpu-reservation"],
+        local memoryLimit = pars["keyword-index-memory-limit"],
+        local memoryReservation = pars["keyword-index-memory-reservation"],
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "keyword-index-launch-cfg", "launch/keyword-index",
+                {
+                    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.storage.kw_index.fts5.Processor",
+                                params: {
+                                    id: "kw-index",
+                                    index_path: "/data/kw-index.db",
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+                }
+            );
+
+            local dataVol = engine.volume("keyword-index").with_size("5G");
+
+            local container =
+                engine.container("keyword-index")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_volume_mount(dataVol, "/data")
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "keyword-index", [ container ]
+            );
+
+            local service =
+                engine.internalService("keyword-index", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                cfgVol,
+                dataVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}


### PR DESCRIPTION
Companion to the trustgraph monorepo hybrid-retrieval change (trustgraph-ai/trustgraph#1030, for trustgraph-ai/trustgraph#875), mirroring how #288 wired the reranker into `document-store.jsonnet`.

Adds a `keyword-index-fts5` component to the 2.7 template tree: deploys the kw-index processor (BM25 over chunk text, SQLite FTS5 on its own volume) and flips Document-RAG to `retrieval_mode=hybrid` (overridable via `document-rag-retrieval-mode`). The flow blueprint gains keyword-index request/response topics on `document-rag` and a `kw-index` service consuming the `chunk-load` stream — inert unless the component is included, so existing deployments are unchanged (Document-RAG stays `retrieval_mode=vector`).

Tests: 5 component-contract tests (processor/volume/param/blueprint-wiring, with and without the component); full configurator suite passes.
