### PR TITLE
maint: bump trustgraph-ui to 0.3.10

### DIFF
--- a/trustgraph_configurator/templates/2.6/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.6/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.3.7",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.10",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",

--- a/trustgraph_configurator/templates/2.7/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.3.7",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.10",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Bump `trustgraph-ui` from 0.3.7 to 0.3.10 in both 2.6 and 2.7 templates
- Adds new innovation ecosystem explorer demo

## Test plan
- [x] Verify UI loads and ecosystem explorer demo is accessible
