### PR TITLE
maint: bump TrustGraph 2.7 to 2.7.1

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -26,8 +26,8 @@
         },
         {
             "name": "2.7",
-            "description": "Placeholder for next release",
-            "version": "2.7.0",
+            "description": "Hybrid retrieval: sparse keyword (FTS5/BM25) + vector search with RRF fusion in Document-RAG",
+            "version": "2.7.1",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.7 version to 2.7.1
- Update 2.7 description from placeholder to reflect hybrid retrieval feature
- Adds pluggable sparse keyword retrieval (SQLite FTS5/BM25) alongside vector search in Document-RAG, fused by weighted Reciprocal Rank Fusion (trustgraph#875)

## Test plan
- [ ] Verify hybrid retrieval with `--retrieval-mode hybrid`
- [ ] Confirm default `vector` mode is unchanged
