### PR TITLE
Image-to-text (OpenAI-compatible vision) component (#879)

### DIFF
--- a/tests/features/test_components.py
+++ b/tests/features/test_components.py
@@ -305,3 +305,49 @@ class TestKeywordIndex:
         kw = bp["flow"]["kw-index:{id}"]["topics"]
         assert kw["input"] == "flow:tg:chunk-load:{workspace}:{id}"
         assert kw["request"] == "request:tg:keyword-index:{workspace}:{id}"
+
+
+# ---------------------------------------------------------------------------
+# Image-to-text (OpenAI-compatible vision) — optional service (2.7 template)
+# ---------------------------------------------------------------------------
+
+class TestImageToText:
+
+    def test_component_deploys_image_to_text_processor(self):
+        _, launches, _ = _build_27(["image-to-text-openai"])
+        proc = find_processor(launches["image-to-text"], "image-to-text")
+        assert proc["class"] == \
+            "trustgraph.model.image_to_text.openai.Processor"
+        assert proc["params"]["model"] == "gpt-5-mini"
+        assert proc["params"]["max_output"] == 4096
+        assert proc["params"]["concurrency"] == 1
+
+    def test_component_gets_openai_credentials(self):
+        compose, _, _ = _build_27(["image-to-text-openai"])
+        env = compose["services"]["image-to-text"]["environment"]
+        assert "OPENAI_TOKEN" in env
+        assert "OPENAI_BASE_URL" in env
+
+    def test_without_component_nothing_deploys(self):
+        compose, launches, _ = _build_27([])
+        assert "image-to-text" not in compose["services"]
+        assert "image-to-text" not in launches
+
+    def test_blueprint_wires_image_to_text(self):
+        _, _, additionals = _build_27(["image-to-text-openai"])
+        cfg = json.loads(next(
+            a["content"] for a in additionals
+            if a["path"] == "trustgraph/config.json"
+        ))
+        bp = cfg["flow-blueprint"]["everything"]
+        if isinstance(bp, str):
+            bp = json.loads(bp)
+        topics = bp["flow"]["image-to-text:{id}"]["topics"]
+        assert topics["request"] == \
+            "request:tg:image-to-text:{workspace}:{id}"
+        assert topics["response"] == \
+            "response:tg:image-to-text:{workspace}:{id}"
+        assert bp["interfaces"]["image-to-text"] == {
+            "request": "request:tg:image-to-text:{workspace}:{id}",
+            "response": "response:tg:image-to-text:{workspace}:{id}",
+        }

--- a/trustgraph_configurator/templates/2.7/components.jsonnet
+++ b/trustgraph_configurator/templates/2.7/components.jsonnet
@@ -41,6 +41,10 @@
    // Including it turns on hybrid retrieval (vector + keyword, RRF-fused).
    "keyword-index-fts5": import "keyword-index/fts5.jsonnet",
 
+   // Image-to-text - describes images with a vision-capable model over an
+   // OpenAI-compatible endpoint (serves the optional image-to-text service)
+   "image-to-text-openai": import "image-to-text/openai.jsonnet",
+
    // Object store (S3-compatible) for the librarian. Import exactly one of
    // these to select how the librarian gets its object store.
    "garage": import "backends/garage.jsonnet",

--- a/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/document-store.jsonnet
@@ -16,9 +16,11 @@ local llm_services = import "llm-services.jsonnet";
 local embeddings_service = import "embeddings-service.jsonnet";
 local reranker_service = import "reranker-service.jsonnet";
 local keyword_index_service = import "keyword-index-service.jsonnet";
+local image_to_text_service = import "image-to-text-service.jsonnet";
 
 // Merge shared services with document store configuration
-llm_services + embeddings_service + reranker_service + keyword_index_service + {
+llm_services + embeddings_service + reranker_service + keyword_index_service +
+image_to_text_service + {
 
     // External interfaces for document store
     "interfaces" +: {

--- a/trustgraph_configurator/templates/2.7/flows/image-to-text-service.jsonnet
+++ b/trustgraph_configurator/templates/2.7/flows/image-to-text-service.jsonnet
@@ -1,0 +1,32 @@
+// Shared image-to-text service module
+// Provides image description via a vision-capable model
+// Import this module in any flow that requires image description
+
+local helpers = import "helpers.jsonnet";
+local request = helpers.request;
+local response = helpers.response;
+local request_response_if = helpers.request_response_if;
+
+{
+    // Interfaces exposed by image-to-text service
+    "interfaces" +: {
+        "image-to-text": request_response_if("image-to-text:{workspace}:{id}"),
+    },
+
+    "parameters" +: {
+    },
+
+    // Flow-level processor for image-to-text. Only bound when an
+    // image-to-text processor is deployed; the entry is inert otherwise.
+    "flow" +: {
+        "image-to-text:{id}": {
+            topics: {
+                request: request("image-to-text:{workspace}:{id}"),
+                response: response("image-to-text:{workspace}:{id}"),
+            },
+        },
+    },
+
+    "blueprint" +: {
+    },
+}

--- a/trustgraph_configurator/templates/2.7/image-to-text/openai.jsonnet
+++ b/trustgraph_configurator/templates/2.7/image-to-text/openai.jsonnet
@@ -1,0 +1,99 @@
+// Image-to-text (OpenAI-compatible vision) - describes images with a
+// vision-capable chat-completions model. Deploys the image-to-text
+// processor, which serves the optional image-to-text request/response
+// interface (tg-describe-image, service/image-to-text). Uses the same
+// openai-credentials secrets as the OpenAI LLM component (OPENAI_TOKEN,
+// OPENAI_BASE_URL), so it can point at any OpenAI-compatible endpoint
+// serving a vision model; override the model with
+// .with("model", "...").
+
+local images = import "values/images.jsonnet";
+
+{
+
+    with:: function(key, value)
+        self + {
+            ["image-to-text-" + key]:: value,
+        },
+
+    "image-to-text-model":: "gpt-5-mini",
+    "image-to-text-max-output":: 4096,
+
+    parameters +:: {
+        "image-to-text-cpu-limit": "0.5",
+        "image-to-text-cpu-reservation": "0.1",
+        "image-to-text-memory-limit": "128M",
+        "image-to-text-memory-reservation": "128M",
+        "image-to-text-concurrency": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "image-to-text" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["image-to-text-cpu-limit"],
+        local cpuReservation = pars["image-to-text-cpu-reservation"],
+        local memoryLimit = pars["image-to-text-memory-limit"],
+        local memoryReservation = pars["image-to-text-memory-reservation"],
+        local concurrency = pars["image-to-text-concurrency"],
+
+        create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "image-to-text-launch-cfg", "launch/image-to-text",
+                {
+                    "launch.yaml": std.manifestYamlDoc({
+                        processors: [
+                            {
+                                class: "trustgraph.model.image_to_text.openai.Processor",
+                                params: {
+                                    id: "image-to-text",
+                                    concurrency: concurrency,
+                                    model: $["image-to-text-model"],
+                                    max_output: $["image-to-text-max-output"],
+                                } + $["pub-sub-params"],
+                            },
+                        ]
+                    })
+                }
+            );
+
+            local envSecrets = engine.envSecrets("openai-credentials")
+                .with_env_var("OPENAI_TOKEN", "openai-token")
+                .with_env_var("OPENAI_BASE_URL", "openai-url");
+
+            local container =
+                engine.container("image-to-text")
+                    .with_image(images.trustgraph_flow)
+                    .with_command([
+                        "processor-group",
+                        "--log-level",
+                        logLevel,
+                        "-c",
+                        "/etc/trustgraph/launch.yaml"
+                    ])
+                    .with_volume_mount(cfgVol, "/etc/trustgraph/")
+                    .with_env_var_secrets(envSecrets)
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "image-to-text", [ container ]
+            );
+
+            local service =
+                engine.internalService("image-to-text", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                envSecrets,
+                cfgVol,
+                containerSet,
+                service,
+            ])
+
+    }
+
+}


### PR DESCRIPTION
Companion to the image-to-text service in the trustgraph monorepo (trustgraph-ai/trustgraph#1038, for trustgraph-ai/trustgraph#879), mirroring the #297 keyword-index component surface.

Adds an `image-to-text-openai` component to the 2.7 template tree: deploys the image-to-text processor from the standard flow image (model `gpt-5-mini`, `max_output` 4096, concurrency 1, overridable via component parameters) and reuses the `openai-credentials` secrets (OPENAI_TOKEN / OPENAI_BASE_URL), so it can point at any OpenAI-compatible endpoint serving a vision model. The document-store flow module gains an `image-to-text` interface plus request/response topics, inert unless the component is included, so existing deployments are unchanged.

Tests: 4 component-contract tests (processor params, credentials, absent by default, blueprint wiring); full configurator suite passes.
