### PR TITLE
maint: bump TrustGraph 2.7 to 2.7.5

### DIFF
--- a/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
@@ -20,7 +20,7 @@ steps:
       options:
         - label: "TrustGraph 2.7"
           value: "2.7"
-          description: "Placeholder for pre-release"
+          description: "LLM-native structured output, pluggable image-to-text vision service"
           badge: pre-release
           recommended: false
         - label: "TrustGraph 2.6"

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -26,8 +26,8 @@
         },
         {
             "name": "2.7",
-            "description": "Hybrid retrieval: sparse keyword (FTS5/BM25) + vector search with RRF fusion in Document-RAG",
-            "version": "2.7.1",
+            "description": "LLM-native structured output, pluggable image-to-text vision service",
+            "version": "2.7.5",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.7 version from 2.7.1 to 2.7.5
- Update description in `index.json` and `trustgraph-flow.yaml` to reflect new features: structured output, image-to-text vision service, i18n entity-name fix, JWT retry hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)