### PR TITLE
feat: image-to-text engine selection in configuration dialog

### DIFF
--- a/trustgraph_configurator/resources/dialog/docs/model/image-to-text-openai-compose.md
+++ b/trustgraph_configurator/resources/dialog/docs/model/image-to-text-openai-compose.md
@@ -1,0 +1,13 @@
+The image-to-text service uses an OpenAI-compatible vision endpoint.
+It reuses the same credentials as the OpenAI LLM component. If you
+are not already using OpenAI as your LLM, you must provide the
+credentials in environment variables.
+
+```
+OPENAI_TOKEN=TOKEN-GOES-HERE
+OPENAI_BASE_URL=https://api.openai.com/v1
+```
+
+Set `OPENAI_BASE_URL` to point at any OpenAI-compatible endpoint
+serving a vision model. If you are using the OpenAI API directly,
+the default URL shown above is correct.

--- a/trustgraph_configurator/resources/dialog/docs/model/image-to-text-openai-k8s.md
+++ b/trustgraph_configurator/resources/dialog/docs/model/image-to-text-openai-k8s.md
@@ -1,0 +1,15 @@
+The image-to-text service uses an OpenAI-compatible vision endpoint.
+It reuses the same `openai-credentials` Kubernetes secret as the
+OpenAI LLM component. If you are not already using OpenAI as your
+LLM, you must create this secret.
+
+```bash
+kubectl -n {{namespace}} create secret \
+    generic openai-credentials \
+    --from-literal=openai-token=OPENAI-TOKEN-HERE \
+    --from-literal=openai-url=https://api.openai.com/v1
+```
+
+Set `openai-url` to point at any OpenAI-compatible endpoint serving
+a vision model. If you are using the OpenAI API directly, the
+default URL shown above is correct.

--- a/trustgraph_configurator/resources/dialog/trustgraph-docs.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-docs.yaml
@@ -355,6 +355,25 @@ documentation:
         namespace: "k8s.namespace"
 
     # ─────────────────────────────────────────────────────────────
+    # Image-to-Text Configuration
+    # ─────────────────────────────────────────────────────────────
+    - id: image-to-text-setup
+      goal: "Configure image-to-text credentials"
+      category: model
+      priority: 2
+      file: model/image-to-text-openai-compose.md
+      when: "image_to_text = 'openai' and platform in ['docker-compose', 'podman-compose']"
+
+    - id: image-to-text-setup
+      goal: "Configure image-to-text credentials"
+      category: model
+      priority: 2
+      file: model/image-to-text-openai-k8s.md
+      when: "image_to_text = 'openai' and platform in ['gke', 'eks', 'aks', 'minikube', 'scw', 'ovh', 'ali']"
+      vars:
+        namespace: "k8s.namespace"
+
+    # ─────────────────────────────────────────────────────────────
     # Storage Setup
     # ─────────────────────────────────────────────────────────────
     - id: vector-db-setup

--- a/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
@@ -374,6 +374,8 @@ steps:
         next: review
       - when: "embeddings.enabled = true"
         next: embeddings-engine
+      - when: "version >= '2.7'"
+        next: image-to-text
       - when: "version >= '2.4'"
         next: mcp-server-enabled
       - next: review
@@ -400,6 +402,31 @@ steps:
           value: "ollama"
           icon: "ollama"
           description: "Use Ollama for embeddings. Requires Ollama to be running with an embedding model loaded."
+    transitions:
+      - when: "version >= '2.7'"
+        next: image-to-text
+      - when: "version >= '2.4'"
+        next: mcp-server-enabled
+      - next: review
+
+  # ─────────────────────────────────────────────────────────────
+  # Image-to-Text (>= 2.7 only)
+  # ─────────────────────────────────────────────────────────────
+  image-to-text:
+    title: "Which image-to-text engine?"
+    description: "Describe images with a vision-capable model for use in document processing"
+    state_key: image_to_text
+    input:
+      type: select
+      options:
+        - label: "None"
+          value: "none"
+          description: "No image-to-text processing"
+          recommended: true
+        - label: "OpenAI-compatible"
+          value: "openai"
+          icon: "openai"
+          description: "Use an OpenAI-compatible vision endpoint to describe images. Reuses the OpenAI API credentials."
     transitions:
       - when: "version >= '2.4'"
         next: mcp-server-enabled

--- a/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
+++ b/trustgraph_configurator/resources/dialog/trustgraph-output.jsonata
@@ -133,6 +133,15 @@
   );
 
   /* ─────────────────────────────────────────────────────────────
+   * Image-to-Text (conditional)
+   * ───────────────────────────────────────────────────────────── */
+  $image_to_text_components := (
+    image_to_text and image_to_text != "none"
+    ? [ $component("image-to-text-" & image_to_text) ]
+    : []
+  );
+
+  /* ─────────────────────────────────────────────────────────────
    * MCP Server (conditional)
    * ───────────────────────────────────────────────────────────── */
   $mcp_components := (
@@ -157,16 +166,19 @@
         $append(
           $append(
             $append(
-              $base_components,
-              $infrastructure
+              $append(
+                $base_components,
+                $infrastructure
+              ),
+              $backend_components
             ),
-            $backend_components
+            $model_components
           ),
-          $model_components
+          $ocr_components
         ),
-        $ocr_components
+        $embeddings_components
       ),
-      $embeddings_components
+      $image_to_text_components
     ),
     $mcp_components
   );


### PR DESCRIPTION
## Summary
- Add image-to-text engine selection step to the wizard flow, gated on version >= 2.7
- Select with "None" (default) and "OpenAI-compatible" options, extensible for future backends
- Wire `image-to-text-openai` component into the output transform when selected
- Add deployment docs for OpenAI credentials (compose + k8s variants)

## Test plan
- [ ] Walk the wizard with version 2.7, verify image-to-text step appears after embeddings
- [ ] Walk with version 2.6, verify image-to-text step is skipped
- [ ] Select "None" — confirm no image-to-text component in output
- [ ] Select "OpenAI-compatible" — confirm `image-to-text-openai` component in output
- [ ] Verify credential docs appear for compose and k8s platforms when OpenAI selected
