### PR TITLE
maint: bump TrustGraph 2.6 to 2.6.17, 2.7 to 2.7.6

### DIFF
--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -21,13 +21,13 @@
         {
             "name": "2.6",
             "description": "Multi-step cross-encoder reranker replaces LLM edge scoring in GraphRAG for faster, more accurate retrieval",
-            "version": "2.6.15",
+            "version": "2.6.17",
             "status": "stable"
         },
         {
             "name": "2.7",
             "description": "LLM-native structured output, pluggable image-to-text vision service",
-            "version": "2.7.5",
+            "version": "2.7.6",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.6 from 2.6.15 to 2.6.17
- Bump TrustGraph 2.7 from 2.7.5 to 2.7.6
- Fixes literal object indexing for object-based graph queries (quads_by_entity table with role='O')