### PR TITLE
maint: bump TrustGraph 2.7 to 2.7.13, enterprise to 1.0.0

### DIFF
--- a/trustgraph_configurator/templates/2.7/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:0.9.7",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.0.0",
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -27,7 +27,7 @@
         {
             "name": "2.7",
             "description": "LLM-native structured output, pluggable image-to-text vision service",
-            "version": "2.7.12",
+            "version": "2.7.13",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.7 version from 2.7.12 to 2.7.13
- Bump trustgraph-enterprise image from 0.9.7 to 1.0.0

## Test plan
- [x] Verify configurator renders correct image tags for 2.7 deployments
- [x] Confirm enterprise container starts with the 1.0.0 image