### PR TITLE
maint: bump trustgraph-enterprise to 1.0.1

### DIFF
--- a/trustgraph_configurator/templates/2.7/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.0.0",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.0.1",
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",


### PR DESCRIPTION
## Summary
- Bump trustgraph-enterprise image from 1.0.0 to 1.0.1 in TG 2.7

## Test plan
- [x] Verify enterprise container starts with the 1.0.1 image

🤖 Generated with [Claude Code](https://claude.com/claude-code)