### PR TITLE
fix: add explicit concurrency defaults to 2.7 processor-group services

### DIFF
--- a/trustgraph_configurator/templates/2.7/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.7/core/rag.jsonnet
@@ -7,6 +7,7 @@ local url = import "values/url.jsonnet";
 {
 
     parameters +:: {
+        "agent-manager-concurrency": 1,
         "graph-rag-concurrency": 1,
         "graph-rag-entity-limit": 50,
         "graph-rag-triple-limit": 30,
@@ -14,11 +15,17 @@ local url = import "values/url.jsonnet";
         "graph-rag-edge-score-limit": 10,
         "graph-rag-max-subgraph-size": 100,
         "graph-rag-max-path-length": 2,
+        "document-rag-concurrency": 1,
         "document-rag-doc-limit": 20,
         // vector | keyword | hybrid; the keyword-index component overrides
         // this to hybrid when included
         "document-rag-retrieval-mode": "vector",
+        "nlp-query-concurrency": 1,
+        "structured-query-concurrency": 1,
+        "structured-diag-concurrency": 1,
+        "sparql-query-concurrency": 1,
         "prompt-rag-concurrency": 1,
+        "mcp-tool-concurrency": 1,
         "rag-cpu-limit": "0.5",
         "rag-cpu-reservation": "0.1",
         "rag-memory-limit": "640M",
@@ -32,6 +39,7 @@ local url = import "values/url.jsonnet";
 
         local pars = $.parameters,
 
+        local agentManagerConc = pars["agent-manager-concurrency"],
         local graphRagConc = pars["graph-rag-concurrency"],
         local entityLimit = pars["graph-rag-entity-limit"],
         local tripleLimit = pars["graph-rag-triple-limit"],
@@ -39,9 +47,15 @@ local url = import "values/url.jsonnet";
         local edgeScoreLimit = pars["graph-rag-edge-score-limit"],
         local maxSubgraphSize = pars["graph-rag-max-subgraph-size"],
         local maxPathLength = pars["graph-rag-max-path-length"],
+        local documentRagConc = pars["document-rag-concurrency"],
         local docLimit = pars["document-rag-doc-limit"],
         local retrievalMode = pars["document-rag-retrieval-mode"],
+        local nlpQueryConc = pars["nlp-query-concurrency"],
+        local structuredQueryConc = pars["structured-query-concurrency"],
+        local structuredDiagConc = pars["structured-diag-concurrency"],
+        local sparqlQueryConc = pars["sparql-query-concurrency"],
         local promptRagConc = pars["prompt-rag-concurrency"],
+        local mcpToolConc = pars["mcp-tool-concurrency"],
         local cpuLimit = pars["rag-cpu-limit"],
         local cpuReservation = pars["rag-cpu-reservation"],
         local memoryLimit = pars["rag-memory-limit"],
@@ -70,6 +84,7 @@ local url = import "values/url.jsonnet";
                                 class: agentOrchestrator,
                                 params: {
                                     id: "agent-manager",
+                                    concurrency: agentManagerConc,
                                 } + $["pub-sub-params"],
                             },
                             {
@@ -89,6 +104,7 @@ local url = import "values/url.jsonnet";
                                 class: documentRag,
                                 params: {
                                     id: "document-rag",
+                                    concurrency: documentRagConc,
                                     doc_limit: docLimit,
                                     retrieval_mode: retrievalMode,
                                 } + $["pub-sub-params"],
@@ -97,24 +113,28 @@ local url = import "values/url.jsonnet";
                                 class: nlpQuery,
                                 params: {
                                     id: "nlp-query",
+                                    concurrency: nlpQueryConc,
                                 } + $["pub-sub-params"],
                             },
                             {
                                 class: structuredQuery,
                                 params: {
                                     id: "structured-query",
+                                    concurrency: structuredQueryConc,
                                 } + $["pub-sub-params"],
                             },
                             {
                                 class: structuredDiag,
                                 params: {
                                     id: "structured-diag",
+                                    concurrency: structuredDiagConc,
                                 } + $["pub-sub-params"],
                             },
                             {
                                 class: sparql,
                                 params: {
                                     id: "sparql-query",
+                                    concurrency: sparqlQueryConc,
                                 } + $["pub-sub-params"],
                             },
                             {
@@ -128,6 +148,7 @@ local url = import "values/url.jsonnet";
                                 class: mcpTool,
                                 params: {
                                     id: "mcp-tool",
+                                    concurrency: mcpToolConc,
                                 } + $["pub-sub-params"],
                             },
                         ]

--- a/trustgraph_configurator/templates/2.7/keyword-index/fts5.jsonnet
+++ b/trustgraph_configurator/templates/2.7/keyword-index/fts5.jsonnet
@@ -12,6 +12,7 @@ local images = import "values/images.jsonnet";
 
     parameters +:: {
         "document-rag-retrieval-mode": "hybrid",
+        "keyword-index-concurrency": 1,
         "keyword-index-cpu-limit": "0.5",
         "keyword-index-cpu-reservation": "0.1",
         "keyword-index-memory-limit": "128M",
@@ -24,6 +25,7 @@ local images = import "values/images.jsonnet";
 
         local pars = $.parameters,
 
+        local kwIndexConc = pars["keyword-index-concurrency"],
         local cpuLimit = pars["keyword-index-cpu-limit"],
         local cpuReservation = pars["keyword-index-cpu-reservation"],
         local memoryLimit = pars["keyword-index-memory-limit"],
@@ -40,6 +42,7 @@ local images = import "values/images.jsonnet";
                                 class: "trustgraph.storage.kw_index.fts5.Processor",
                                 params: {
                                     id: "kw-index",
+                                    concurrency: kwIndexConc,
                                     index_path: "/data/kw-index.db",
                                 } + $["pub-sub-params"],
                             },

--- a/trustgraph_configurator/templates/2.7/row-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.7/row-store/cassandra.jsonnet
@@ -7,6 +7,8 @@ local url = import "values/url.jsonnet";
 {
 
     parameters +:: {
+        "rows-query-concurrency": 1,
+        "rows-write-concurrency": 1,
         "rows-cpu-limit": "0.5",
         "rows-cpu-reservation": "0.1",
         "rows-memory-limit": "768M",
@@ -20,6 +22,8 @@ local url = import "values/url.jsonnet";
 
         local pars = $.parameters,
 
+        local rowsQueryConc = pars["rows-query-concurrency"],
+        local rowsWriteConc = pars["rows-write-concurrency"],
         local cpuLimit = pars["rows-cpu-limit"],
         local cpuReservation = pars["rows-cpu-reservation"],
         local memoryLimit = pars["rows-memory-limit"],
@@ -49,12 +53,14 @@ local url = import "values/url.jsonnet";
                                 class: "trustgraph.query.rows.cassandra.Processor",
                                 params: {
                                     id: "rows-query",
+                                    concurrency: rowsQueryConc,
                                 } + cassandraParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.storage.rows.cassandra.Processor",
                                 params: {
                                     id: "rows-write",
+                                    concurrency: rowsWriteConc,
                                 } + cassandraParams + $["pub-sub-params"],
                             },
                         ]

--- a/trustgraph_configurator/templates/2.7/triple-store/cassandra.jsonnet
+++ b/trustgraph_configurator/templates/2.7/triple-store/cassandra.jsonnet
@@ -7,6 +7,8 @@ local url = import "values/url.jsonnet";
 {
 
     parameters +:: {
+        "triples-query-concurrency": 3,
+        "triples-write-concurrency": 1,
         "triples-cpu-limit": "0.5",
         "triples-cpu-reservation": "0.1",
         "triples-memory-limit": "512M",
@@ -20,6 +22,8 @@ local url = import "values/url.jsonnet";
 
         local pars = $.parameters,
 
+        local triplesQueryConc = pars["triples-query-concurrency"],
+        local triplesWriteConc = pars["triples-write-concurrency"],
         local cpuLimit = pars["triples-cpu-limit"],
         local cpuReservation = pars["triples-cpu-reservation"],
         local memoryLimit = pars["triples-memory-limit"],
@@ -49,12 +53,14 @@ local url = import "values/url.jsonnet";
                                 class: "trustgraph.query.triples.cassandra.Processor",
                                 params: {
                                     id: "triples-query",
+                                    concurrency: triplesQueryConc,
                                 } + cassandraParams + $["pub-sub-params"],
                             },
                             {
                                 class: "trustgraph.storage.triples.cassandra.Processor",
                                 params: {
                                     id: "triples-write",
+                                    concurrency: triplesWriteConc,
                                 } + cassandraParams + $["pub-sub-params"],
                             },
                         ]

--- a/trustgraph_configurator/templates/2.7/vector-store/qdrant.jsonnet
+++ b/trustgraph_configurator/templates/2.7/vector-store/qdrant.jsonnet
@@ -5,6 +5,12 @@ local qdrant = import "backends/qdrant.jsonnet";
 qdrant + {
 
     parameters +:: {
+        "doc-embeddings-query-concurrency": 1,
+        "doc-embeddings-write-concurrency": 1,
+        "graph-embeddings-query-concurrency": 1,
+        "graph-embeddings-write-concurrency": 1,
+        "row-embeddings-query-concurrency": 1,
+        "row-embeddings-write-concurrency": 1,
         "vector-store-cpu-limit": "0.5",
         "vector-store-cpu-reservation": "0.1",
         "vector-store-memory-limit": "256M",
@@ -18,6 +24,12 @@ qdrant + {
 
         local pars = $.parameters,
 
+        local docEmbQueryConc = pars["doc-embeddings-query-concurrency"],
+        local docEmbWriteConc = pars["doc-embeddings-write-concurrency"],
+        local graphEmbQueryConc = pars["graph-embeddings-query-concurrency"],
+        local graphEmbWriteConc = pars["graph-embeddings-write-concurrency"],
+        local rowEmbQueryConc = pars["row-embeddings-query-concurrency"],
+        local rowEmbWriteConc = pars["row-embeddings-write-concurrency"],
         local cpuLimit = pars["vector-store-cpu-limit"],
         local cpuReservation = pars["vector-store-cpu-reservation"],
         local memoryLimit = pars["vector-store-memory-limit"],
@@ -44,6 +56,7 @@ qdrant + {
                                 class: "trustgraph.query.doc_embeddings.qdrant.Processor",
                                 params: {
                                     id: "doc-embeddings-query",
+                                    concurrency: docEmbQueryConc,
                                     store_uri: url.qdrant,
                                 } + $["pub-sub-params"],
                             },
@@ -51,6 +64,7 @@ qdrant + {
                                 class: "trustgraph.storage.doc_embeddings.qdrant.Processor",
                                 params: {
                                     id: "doc-embeddings-write",
+                                    concurrency: docEmbWriteConc,
                                     store_uri: url.qdrant,
                                 } + collectionParams + $["pub-sub-params"],
                             },
@@ -58,6 +72,7 @@ qdrant + {
                                 class: "trustgraph.query.graph_embeddings.qdrant.Processor",
                                 params: {
                                     id: "graph-embeddings-query",
+                                    concurrency: graphEmbQueryConc,
                                     store_uri: url.qdrant,
                                 } + $["pub-sub-params"],
                             },
@@ -65,6 +80,7 @@ qdrant + {
                                 class: "trustgraph.storage.graph_embeddings.qdrant.Processor",
                                 params: {
                                     id: "graph-embeddings-write",
+                                    concurrency: graphEmbWriteConc,
                                     store_uri: url.qdrant,
                                 } + collectionParams + $["pub-sub-params"],
                             },
@@ -72,6 +88,7 @@ qdrant + {
                                 class: "trustgraph.query.row_embeddings.qdrant.Processor",
                                 params: {
                                     id: "row-embeddings-query",
+                                    concurrency: rowEmbQueryConc,
                                     store_uri: url.qdrant,
                                 } + $["pub-sub-params"],
                             },
@@ -79,6 +96,7 @@ qdrant + {
                                 class: "trustgraph.storage.row_embeddings.qdrant.Processor",
                                 params: {
                                     id: "row-embeddings-write",
+                                    concurrency: rowEmbWriteConc,
                                     store_uri: url.qdrant,
                                 } + collectionParams + $["pub-sub-params"],
                             },


### PR DESCRIPTION
## Summary
- Add explicit `concurrency` parameters (default 1) to all processor-group services that were missing them, preventing the runtime default of 10
- Affected services: RAG path processors (agent-manager, document-rag, nlp-query, structured-query, structured-diag, sparql-query, mcp-tool), triple store (cassandra), row store (cassandra), vector store (qdrant), and keyword index (fts5)
- Triples query defaults to 3

## Test plan
- [ ] Render a 2.7 config and verify all launch.yaml files include `concurrency` for every processor
- [ ] Confirm no regressions in existing concurrency settings (graph-rag, prompt-rag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)