### PR TITLE
feat: add Docling document decoder to 2.8 templates

### DIFF
--- a/trustgraph_configurator/templates/2.8/core/docling-decoder.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/docling-decoder.jsonnet
@@ -1,0 +1,57 @@
+// Document decoder processor — turns uploaded files (PDF, etc.)
+// into the text representation consumed by the ingest pipeline.
+
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "document-decoder-cpu-limit": "0.5",
+        "document-decoder-cpu-reservation": "0.1",
+        "document-decoder-memory-limit": "1400M",
+        "document-decoder-memory-reservation": "1400M",
+        "document-decoder-replicas": 1,
+    },
+
+    local logLevel = $.parameters["log-level"],
+
+    "document-decoder" +: {
+
+        local pars = $.parameters,
+
+        local cpuLimit = pars["document-decoder-cpu-limit"],
+        local cpuReservation = pars["document-decoder-cpu-reservation"],
+        local memoryLimit = pars["document-decoder-memory-limit"],
+        local memoryReservation = pars["document-decoder-memory-reservation"],
+        local replicas = pars["document-decoder-replicas"],
+
+        create:: function(engine)
+
+            local container =
+                engine.container("document-decoder")
+                    .with_image(images.trustgraph_docling)
+                    .with_command([
+                        "docling-decoder",
+                    ] + $["pub-sub-args"] + [
+                        "--log-level",
+                        logLevel,
+                    ])
+                    .with_limits(cpuLimit, memoryLimit)
+                    .with_reservations(cpuReservation, memoryReservation);
+
+            local containerSet = engine.containers(
+                "document-decoder", [ container ]
+            ).with_replicas(replicas);
+
+            local service =
+                engine.internalService("document-decoder", containerSet)
+                .with_port(8000, 8000, "metrics");
+
+            engine.resources([
+                containerSet,
+                service,
+            ])
+
+    },
+
+}

--- a/trustgraph_configurator/templates/2.8/core/trustgraph.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/trustgraph.jsonnet
@@ -11,7 +11,7 @@ local control = import "control.jsonnet";
 local ingest = import "ingest.jsonnet";
 local rag = import "rag.jsonnet";
 local api_gateway = import "api-gateway.jsonnet";
-local document_decoder = import "document-decoder.jsonnet";
+local docling_decoder = import "docling-decoder.jsonnet";
 local ui = import "../ui/trustgraph-ui.jsonnet";
 local ddg = import "mcp/ddg-mcp-server.jsonnet";
 
@@ -26,6 +26,6 @@ local ddg = import "mcp/ddg-mcp-server.jsonnet";
         "log-level":: "INFO",
     },
 
-} + control + ingest + rag + api_gateway + document_decoder
+} + control + ingest + rag + api_gateway + docling_decoder
   + ui + config + ddg
 

--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -27,6 +27,7 @@ local version = import "version.jsonnet";
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
     trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.0.1",
+    trustgraph_docling: "docker.io/trustgraph/trustgraph-docling:" + version,
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",


### PR DESCRIPTION
## Summary
- Add Docling-based document decoder as the default decoder in TG 2.8, replacing the unstructured decoder
- Docling supports PDF (with OCR), DOCX, XLSX, PPTX, HTML, Markdown, and CSV
- The old `document-decoder.jsonnet` (unstructured) remains in 2.8 but is no longer imported — available as a fallback if needed

## Test plan
- [x] Render a 2.8 config and verify the document-decoder container uses the `trustgraph-docling` image
- [x] Confirm 2.7 configs still use the unstructured decoder
