### PR TITLE
maint: bump trustgraph-ui across releases

### DIFF
--- a/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
+++ b/trustgraph_configurator/resources/dialog/trustgraph-flow.yaml
@@ -20,7 +20,7 @@ steps:
       options:
         - label: "TrustGraph 2.8"
           value: "2.8"
-          description: "LLM-native structured output, pluggable image-to-text vision service"
+          description: "Removes scale-bottlenecks to better support large multi-tenant deployments"
           badge: pre-release
           recommended: false
         - label: "TrustGraph 2.7"

--- a/trustgraph_configurator/templates/2.6/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.6/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:0.3.12",
+    ui: "docker.io/trustgraph/trustgraph-ui:0.3.13",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",

--- a/trustgraph_configurator/templates/2.7/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.7/values/images.jsonnet
@@ -32,7 +32,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:1.0.0",
+    ui: "docker.io/trustgraph/trustgraph-ui:1.0.1",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",

--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -33,7 +33,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:1.0.0",
+    ui: "docker.io/trustgraph/trustgraph-ui:1.0.1",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -32,7 +32,7 @@
         },
         {
             "name": "2.8",
-            "description": "LLM-native structured output, pluggable image-to-text vision service",
+            "description": "Removes scale-bottlenecks to better support large multi-tenant deployments",
             "version": "2.8.0",
             "status": "pre-release"
         }


### PR DESCRIPTION
## Summary
- Bump trustgraph-ui on 2.6: 0.3.12 → 0.3.13 (back-ported 3D context graph viewer)
- Bump trustgraph-ui on 2.7 and 2.8: 1.0.0 → 1.0.1
- Update TG 2.8 release description to reflect scale improvements for large multi-tenant deployments

## Test plan
- [ ] Verify configurator renders correct UI image tags for 2.6, 2.7, and 2.8
- [ ] Confirm 2.8 description shows updated text in dialog and index

🤖 Generated with [Claude Code](https://claude.com/claude-code)