### PR TITLE
maint: bump TrustGraph 2.8 to 2.8.3, enterprise to 1.1.1

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.0",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.1",
     trustgraph_docling: "docker.io/trustgraph/trustgraph-docling:" + version,
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -33,7 +33,7 @@
         {
             "name": "2.8",
             "description": "Removes scale-bottlenecks to better support large multi-tenant deployments",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bump TrustGraph 2.8 version from 2.8.2 to 2.8.3
- Bump trustgraph-enterprise image from 1.1.0 to 1.1.1

## Test plan
- [x] Verify configurator renders correct image tags for 2.8 deployments
