### PR TITLE
fix: disable high-cardinality Pulsar producer/consumer metrics

### DIFF
--- a/trustgraph_configurator/templates/2.7/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.7/pubsub/pulsar.jsonnet
@@ -192,6 +192,12 @@ local url = import "values/url.jsonnet";
                         "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
                             brokerHeap, brokerHeap, brokerDirect,
                         ],
+
+                        // Turn off high-cardinality low-value Prometheus
+                        // metrics
+                        "exposeProducerLevelMetricsInPrometheus": "false",
+                        "exposeConsumerLevelMetricsInPrometheus": "false",
+
                     })
                     .with_port(6650, 6650, "pulsar")
                     .with_port(8080, 8080, "admin");

--- a/trustgraph_configurator/templates/2.8/pubsub/pulsar.jsonnet
+++ b/trustgraph_configurator/templates/2.8/pubsub/pulsar.jsonnet
@@ -192,6 +192,12 @@ local url = import "values/url.jsonnet";
                         "PULSAR_MEM": "-Xms%s -Xmx%s -XX:MaxDirectMemorySize=%s" % [
                             brokerHeap, brokerHeap, brokerDirect,
                         ],
+
+                        // Turn off high-cardinality low-value Prometheus
+                        // metrics
+                        "exposeProducerLevelMetricsInPrometheus": "false",
+                        "exposeConsumerLevelMetricsInPrometheus": "false",
+
                     })
                     .with_port(6650, 6650, "pulsar")
                     .with_port(8080, 8080, "admin");


### PR DESCRIPTION
## Summary
- Disable `exposeProducerLevelMetricsInPrometheus` and `exposeConsumerLevelMetricsInPrometheus` on Pulsar broker in 2.7 and 2.8
- These per-topic per-producer/consumer metrics create high cardinality without meaningful monitoring value

## Test plan
- [x] Deploy with Pulsar and verify producer/consumer-level metrics no longer appear in Prometheus
- [x] Confirm broker-level and topic-level metrics still present

