### PR TITLE
fix: drop verbose Pulsar subscription metrics in Prometheus

### DIFF
--- a/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
@@ -91,6 +91,11 @@ scrape_configs:
         - 'garage:3903'
 
   - job_name: 'pulsar'
+    metric_relabel_configs:
+      # Keep backlog metrics, but drop verbose subscription telemetry
+      - source_labels: [__name__]
+        regex: 'pulsar_subscription_(dispatch_throttled.*|blocked_on_unacked.*|last_consumed_flow.*|last_mark_delete.*)'
+        action: drop
     scrape_interval: 5s
     static_configs:
       - targets:


### PR DESCRIPTION
## Summary
- Add metric_relabel_configs to the 2.8 Pulsar Prometheus scrape job to drop high-cardinality subscription metrics
- Drops: dispatch_throttled, blocked_on_unacked, last_consumed_flow, last_mark_delete
- Keeps backlog metrics intact

## Test plan
- [x] Deploy 2.8 with Pulsar and verify dropped metrics no longer appear in Prometheus
- [x] Confirm backlog and other subscription metrics still scraped

