### PR TITLE
fix: use explicit regex for Pulsar subscription metric filtering

### DIFF
--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
@@ -80,21 +80,19 @@ scrape_configs:
 
   - job_name: 'pulsar'
     metric_relabel_configs:
-
-      # Step A: Drop all storage eviction metrics
+      # Step 1: Drop storage eviction metrics
       - source_labels: [__name__]
         regex: 'pulsar_storage_backlog_quota_exceeded_evictions_total'
         action: drop
 
-      # Step B: Drop producer and consumer labels if Pulsar still sends them
+      # Step 2: Drop non-backlog subscription telemetry (timestamps, rates, replays, etc.)
+      - source_labels: [__name__]
+        regex: 'pulsar_subscription_(dispatch_throttled.*|blocked_on_unacked.*|last_.*|msg_ack.*|msg_drop.*|in_replay|filter_.*|total_msg_.*)'
+        action: drop
+
+      # Step 3: Strip producer and consumer labels if still emitted
       - regex: '(producer|consumer)'
         action: labeldrop
-
-      # Step C: Drop ALL subscription metrics EXCEPT actual backlog metrics
-      # Drops timestamps, drop rates, ack rates, replay counts, etc.
-      - source_labels: [__name__]
-        regex: 'pulsar_subscription_(?!backlog|msg_backlog).*'
-        action: drop
 
     static_configs:
       - targets:

--- a/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
@@ -80,21 +80,19 @@ scrape_configs:
 
   - job_name: 'pulsar'
     metric_relabel_configs:
-
-      # Step A: Drop all storage eviction metrics
+      # Step 1: Drop storage eviction metrics
       - source_labels: [__name__]
         regex: 'pulsar_storage_backlog_quota_exceeded_evictions_total'
         action: drop
 
-      # Step B: Drop producer and consumer labels if Pulsar still sends them
+      # Step 2: Drop non-backlog subscription telemetry (timestamps, rates, replays, etc.)
+      - source_labels: [__name__]
+        regex: 'pulsar_subscription_(dispatch_throttled.*|blocked_on_unacked.*|last_.*|msg_ack.*|msg_drop.*|in_replay|filter_.*|total_msg_.*)'
+        action: drop
+
+      # Step 3: Strip producer and consumer labels if still emitted
       - regex: '(producer|consumer)'
         action: labeldrop
-
-      # Step C: Drop ALL subscription metrics EXCEPT actual backlog metrics
-      # Drops timestamps, drop rates, ack rates, replay counts, etc.
-      - source_labels: [__name__]
-        regex: 'pulsar_subscription_(?!backlog|msg_backlog).*'
-        action: drop
 
     static_configs:
       - targets:


### PR DESCRIPTION
## Summary
- Replace negative lookahead regex with explicit metric name list for dropping Pulsar subscription telemetry
- Move labeldrop rule after metric drops so source_labels are still available for matching
- Applied to both 2.7 and 2.8

## Test plan
- [x] Deploy with Pulsar and verify subscription backlog metrics still present
- [x] Confirm dispatch_throttled, blocked_on_unacked, last_*, msg_ack/drop, replay, and filter metrics are dropped
