### PR TITLE
fix: whitelist Pulsar metrics instead of blacklisting

### DIFF
--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
@@ -80,17 +80,13 @@ scrape_configs:
 
   - job_name: 'pulsar'
     metric_relabel_configs:
-      # Step 1: Drop storage eviction metrics
+      # Whitelist ONLY backlog & basic health metrics.
+      # EVERYTHING ELSE from Pulsar is immediately dropped!
       - source_labels: [__name__]
-        regex: 'pulsar_storage_backlog_quota_exceeded_evictions_total'
-        action: drop
+        regex: 'pulsar_(subscription_back_?log.*|msg_back_?log.*|rate_in|rate_out|throughput_in|throughput_out|active_connections)'
+        action: keep
 
-      # Step 2: Drop non-backlog subscription telemetry (timestamps, rates, replays, etc.)
-      - source_labels: [__name__]
-        regex: 'pulsar_subscription_(dispatch_throttled.*|blocked_on_unacked.*|last_.*|msg_ack.*|msg_drop.*|in_replay|filter_.*|total_msg_.*)'
-        action: drop
-
-      # Step 3: Strip producer and consumer labels if still emitted
+      # Strip producer/consumer labels if present on kept metrics
       - regex: '(producer|consumer)'
         action: labeldrop
 

--- a/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
@@ -80,17 +80,13 @@ scrape_configs:
 
   - job_name: 'pulsar'
     metric_relabel_configs:
-      # Step 1: Drop storage eviction metrics
+      # Whitelist ONLY backlog & basic health metrics.
+      # EVERYTHING ELSE from Pulsar is immediately dropped!
       - source_labels: [__name__]
-        regex: 'pulsar_storage_backlog_quota_exceeded_evictions_total'
-        action: drop
+        regex: 'pulsar_(subscription_back_?log.*|msg_back_?log.*|rate_in|rate_out|throughput_in|throughput_out|active_connections)'
+        action: keep
 
-      # Step 2: Drop non-backlog subscription telemetry (timestamps, rates, replays, etc.)
-      - source_labels: [__name__]
-        regex: 'pulsar_subscription_(dispatch_throttled.*|blocked_on_unacked.*|last_.*|msg_ack.*|msg_drop.*|in_replay|filter_.*|total_msg_.*)'
-        action: drop
-
-      # Step 3: Strip producer and consumer labels if still emitted
+      # Strip producer/consumer labels if present on kept metrics
       - regex: '(producer|consumer)'
         action: labeldrop
 


### PR DESCRIPTION
## Summary
- Switch from blacklist to whitelist approach for Pulsar metric filtering in 2.7 and 2.8
- Only keep backlog and basic health metrics: subscription_backlog, msg_backlog, rate_in/out, throughput_in/out, active_connections
- Everything else from Pulsar is immediately dropped
- Strip producer/consumer labels on kept metrics

## Test plan
- [x] Deploy with Pulsar and verify only whitelisted metrics appear in Prometheus
- [x] Confirm backlog metrics still available for Grafana dashboards

