### PR TITLE
fix: correct Prometheus scrape target names and remove per-job intervals

### DIFF
--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-pulsar.yml
@@ -40,15 +40,15 @@ scrape_configs:
       - targets:
         - 'vector-store:8000'
 
-  - job_name: 'row-store'
+  - job_name: 'rows'
     static_configs:
       - targets:
-        - 'row-store:8000'
+        - 'rows:8000'
 
-  - job_name: 'triple-store'
+  - job_name: 'triples'
     static_configs:
       - targets:
-        - 'triple-store:8000'
+        - 'triples:8000'
 
   - job_name: 'text-completion'
     static_configs:
@@ -59,7 +59,7 @@ scrape_configs:
   - job_name: 'api-gateway'
     static_configs:
       - targets:
-        - 'api-gateway-metrics:8000'
+        - 'api-gateway:8000'
 
   - job_name: 'mcp-server'
     static_configs:

--- a/trustgraph_configurator/resources/2.7/prometheus/prometheus-rabbitmq.yml
+++ b/trustgraph_configurator/resources/2.7/prometheus/prometheus-rabbitmq.yml
@@ -16,68 +16,57 @@ scrape_configs:
 
   # TrustGraph services in processor groups
   - job_name: 'control'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'control:8000'
 
   - job_name: 'ingest'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'ingest:8000'
 
   - job_name: 'rag'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'rag:8000'
 
   - job_name: 'embeddings'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'embeddings:8000'
 
   - job_name: 'vector-store'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'vector-store:8000'
 
-  - job_name: 'row-store'
-    scrape_interval: 5s
+  - job_name: 'rows'
     static_configs:
       - targets:
-        - 'row-store:8000'
+        - 'rows:8000'
 
-  - job_name: 'triple-store'
-    scrape_interval: 5s
+  - job_name: 'triples'
     static_configs:
       - targets:
-        - 'triple-store:8000'
+        - 'triples:8000'
 
   - job_name: 'text-completion'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'text-completion:8000'
 
   # TrustGraph services standalone
   - job_name: 'api-gateway'
-    scrape_interval: 5s
     static_configs:
       - targets:
-        - 'api-gateway-metrics:8000'
+        - 'api-gateway:8000'
 
   - job_name: 'mcp-server'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'mcp-server:8000'
 
   - job_name: 'document-decoder'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'document-decoder:8000'
@@ -85,14 +74,12 @@ scrape_configs:
   # Non-Trustgraph services
   - job_name: 'garage'
     metrics_path: '/metrics'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'garage:3903'
 
   - job_name: 'rabbitmq'
     metrics_path: '/metrics/per-object'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'rabbitmq:15692'

--- a/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
+++ b/trustgraph_configurator/resources/2.8/prometheus/prometheus-pulsar.yml
@@ -40,15 +40,15 @@ scrape_configs:
       - targets:
         - 'vector-store:8000'
 
-  - job_name: 'row-store'
+  - job_name: 'rows'
     static_configs:
       - targets:
-        - 'row-store:8000'
+        - 'rows:8000'
 
-  - job_name: 'triple-store'
+  - job_name: 'triples'
     static_configs:
       - targets:
-        - 'triple-store:8000'
+        - 'triples:8000'
 
   - job_name: 'text-completion'
     static_configs:
@@ -59,7 +59,7 @@ scrape_configs:
   - job_name: 'api-gateway'
     static_configs:
       - targets:
-        - 'api-gateway-metrics:8000'
+        - 'api-gateway:8000'
 
   - job_name: 'mcp-server'
     static_configs:

--- a/trustgraph_configurator/resources/2.8/prometheus/prometheus-rabbitmq.yml
+++ b/trustgraph_configurator/resources/2.8/prometheus/prometheus-rabbitmq.yml
@@ -16,68 +16,57 @@ scrape_configs:
 
   # TrustGraph services in processor groups
   - job_name: 'control'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'control:8000'
 
   - job_name: 'ingest'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'ingest:8000'
 
   - job_name: 'rag'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'rag:8000'
 
   - job_name: 'embeddings'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'embeddings:8000'
 
   - job_name: 'vector-store'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'vector-store:8000'
 
-  - job_name: 'row-store'
-    scrape_interval: 5s
+  - job_name: 'rows'
     static_configs:
       - targets:
-        - 'row-store:8000'
+        - 'rows:8000'
 
-  - job_name: 'triple-store'
-    scrape_interval: 5s
+  - job_name: 'triples'
     static_configs:
       - targets:
-        - 'triple-store:8000'
+        - 'triples:8000'
 
   - job_name: 'text-completion'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'text-completion:8000'
 
   # TrustGraph services standalone
   - job_name: 'api-gateway'
-    scrape_interval: 5s
     static_configs:
       - targets:
-        - 'api-gateway-metrics:8000'
+        - 'api-gateway:8000'
 
   - job_name: 'mcp-server'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'mcp-server:8000'
 
   - job_name: 'document-decoder'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'document-decoder:8000'
@@ -85,14 +74,12 @@ scrape_configs:
   # Non-Trustgraph services
   - job_name: 'garage'
     metrics_path: '/metrics'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'garage:3903'
 
   - job_name: 'rabbitmq'
     metrics_path: '/metrics/per-object'
-    scrape_interval: 5s
     static_configs:
       - targets:
         - 'rabbitmq:15692'


### PR DESCRIPTION
## Summary
- Rename scrape targets to match actual service names: row-store → rows, triple-store → triples, api-gateway-metrics → api-gateway
- Remove per-job `scrape_interval: 5s` overrides (use global default)
- Applied to both Pulsar and RabbitMQ Prometheus configs in 2.7 and 2.8

## Test plan
- [x] Deploy and verify Prometheus scrapes all TrustGraph services successfully
- [x] Confirm no stale/unreachable targets in Prometheus targets page
