### PR TITLE
fix: regenerate RabbitMQ dashboard from updated Pulsar board

### DIFF
--- a/trustgraph_configurator/resources/2.8/grafana/dashboards/overview-dashboard-rabbitmq.json
+++ b/trustgraph_configurator/resources/2.8/grafana/dashboards/overview-dashboard-rabbitmq.json
@@ -1900,7 +1900,7 @@
                       "spec": {
                         "disableTextWrap": false,
                         "editorMode": "builder",
-                        "expr": "  label_replace(\n    rabbitmq_queue_messages{queue!~\"tg.state.config.*|amq.gen-.*\"},\n    \"short\", \"$2:$1:$3\", \"queue\", \"^([^.]+)\\\\.([^.]+)\\\\.([^.]+)\\\\..+$\"\n  )\n",
+                        "expr": "label_replace(rabbitmq_queue_messages{queue!~\"tg.state.config.*|amq.gen-.*\"}, \"short\", \"$1\", \"queue\", \"[^.]+\\.(.+)\")",
                         "fullMetaSearch": false,
                         "includeNullMetadata": true,
                         "instant": false,


### PR DESCRIPTION
## Summary
- Regenerates the RabbitMQ overview dashboard from the updated Pulsar dashboard
- Simplifies the `label_replace` regex for queue name extraction while keeping config/amq queue filters
