### PR TITLE
maint: bump trustgraph-ui to 1.1.3 for 2.8

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -33,7 +33,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:1.1.0",
+    ui: "docker.io/trustgraph/trustgraph-ui:1.1.3",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Bumps `trustgraph-ui` from 1.1.0 to 1.1.3 in the 2.8 template
- Includes further theme refactors to ensure light mode works

## Test plan
- [x] Verify UI loads correctly in both dark and light mode