### PR TITLE
maint: bump trustgraph-enterprise to 1.1.2 for 2.8

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.1",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.2",
     trustgraph_docling: "docker.io/trustgraph/trustgraph-docling:" + version,
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",


### PR DESCRIPTION
## Summary
- Bumps `trustgraph-enterprise` from 1.1.1 to 1.1.2 in the 2.8 template
- Includes new IAM metrics

## Test plan
- [x] Verify enterprise services start correctly
- [x] Confirm new IAM metrics appear in Prometheus
