### PR TITLE
fix: simplify api-gateway to single internal service

### DIFF
--- a/trustgraph_configurator/templates/2.8/core/api-gateway.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/api-gateway.jsonnet
@@ -12,7 +12,6 @@ local images = import "values/images.jsonnet";
         "api-gateway-memory-limit": "512M",
         "api-gateway-memory-reservation": "512M",
         "api-gateway-replicas": 1,
-        "api-gateway-external": true,
     },
 
     "api-gateway" +: {
@@ -27,7 +26,6 @@ local images = import "values/images.jsonnet";
         local memoryLimit = pars["api-gateway-memory-limit"],
         local memoryReservation = pars["api-gateway-memory-reservation"],
         local replicas = pars["api-gateway-replicas"],
-        local external = pars["api-gateway-external"],
 
         create:: function(engine)
 
@@ -52,24 +50,14 @@ local images = import "values/images.jsonnet";
                 "api-gateway", [ container ]
             ).with_replicas(replicas);
 
-            local svc =
-                if external then
-                    engine.service("api-gateway", containerSet)
-                else
-                    engine.internalService("api-gateway", containerSet);
-
-            local service = svc
+            local service =
+                engine.internalService("api-gateway", containerSet)
                 .with_port(port, port, "api")
-                ;
-
-            local metrics =
-                engine.internalService("api-gateway-metrics", containerSet)
                 .with_port(8000, 8000, "metrics");
 
             engine.resources([
                 containerSet,
                 service,
-                metrics,
             ])
 
     },


### PR DESCRIPTION
## Summary
- Removes the unused `api-gateway-external` parameter — api-gateway is now always an internal service
- Merges the separate `api-gateway-metrics` service into the main `api-gateway` service with metrics on port 8000
- Prometheus scrape configs already target `api-gateway:8000`, so no further changes needed

## Test plan
- [x] Verify api-gateway starts and serves API on port 8088
- [x] Confirm Prometheus can scrape metrics at `api-gateway:8000`