### PR TITLE
feat: add UX plugin system with config volume and bundle sideloading

### DIFF
--- a/trustgraph_configurator/templates/2.8/components.jsonnet
+++ b/trustgraph_configurator/templates/2.8/components.jsonnet
@@ -93,6 +93,9 @@
    // The prompt manager
    "prompt-overrides": import "core/prompt-overrides.jsonnet",
 
+   // UI plugins
+   "register-plugins": import "ui/register-plugins.jsonnet",
+
    // Extra MCP services
    "ddg-mcp-server": import "mcp/ddg-mcp-server.jsonnet",
 

--- a/trustgraph_configurator/templates/2.8/ui/plugins.json
+++ b/trustgraph_configurator/templates/2.8/ui/plugins.json
@@ -1,0 +1,218 @@
+{
+  "workflows": [
+    {
+      "id": "ingest",
+      "title": "Document Ingestion",
+      "icon": "⬆",
+      "paletteKey": "amber",
+      "description": "Load documents and process them into knowledge.",
+      "screenshot": "/doc-ingest.jpg"
+    },
+    {
+      "id": "explore",
+      "title": "Context Graph Explorer",
+      "icon": "◈",
+      "paletteKey": "emerald",
+      "description": "Explore the context graph visually.",
+      "screenshot": "/ctxt-graph.jpg"
+    },
+    {
+      "id": "graph-rag",
+      "title": "Graph RAG Query",
+      "icon": "◉",
+      "paletteKey": "blue",
+      "description": "Ask questions with knowledge graph provenance.",
+      "screenshot": "/graph-rag.jpg"
+    },
+    {
+      "id": "agent",
+      "title": "Agent Query",
+      "icon": "⚡",
+      "paletteKey": "amber",
+      "description": "Multi-step reasoning agent with provenance.",
+      "screenshot": "/agent-retrieval.jpg"
+    },
+    {
+      "id": "doc-rag",
+      "title": "Document RAG Query",
+      "icon": "◉",
+      "paletteKey": "purple",
+      "description": "Semantic document search with grounded answers.",
+      "screenshot": "/doc-rag.jpg"
+    },
+    {
+      "id": "raw-graph",
+      "title": "Graph Navigator",
+      "icon": "◎",
+      "paletteKey": "cyan",
+      "description": "Explore any graph — no schema required.",
+      "screenshot": "/ss-raw-graph.png"
+    },
+    {
+      "id": "prompts",
+      "title": "Prompt Management",
+      "icon": "✎",
+      "paletteKey": "amber",
+      "description": "Browse, edit, and test LLM prompt templates.",
+      "screenshot": "/prompts.jpg"
+    },
+    {
+      "id": "agent-config",
+      "title": "Agent Console",
+      "icon": "⚙",
+      "paletteKey": "cyan",
+      "description": "Configure agent patterns, task types, and tools.",
+      "screenshot": "/agent.jpg"
+    },
+    {
+      "id": "data",
+      "title": "Table Explorer",
+      "icon": "▤",
+      "paletteKey": "blue",
+      "description": "Search structured data across schemas.",
+      "screenshot": "/ss-data.png"
+    },
+    {
+      "id": "ontology",
+      "title": "Ontology Viewer",
+      "icon": "◇",
+      "paletteKey": "purple",
+      "description": "Browse classes, properties, and relationships."
+    },
+    {
+      "id": "ontology-manage",
+      "title": "Ontology Management",
+      "icon": "◆",
+      "paletteKey": "emerald",
+      "description": "Create, edit, validate, and export OWL ontologies.",
+      "screenshot": "/ontology.jpg"
+    },
+    {
+      "id": "schemas",
+      "title": "Schema Management",
+      "icon": "▦",
+      "paletteKey": "blue",
+      "description": "Define and manage structured data schemas.",
+      "screenshot": "/schema.jpg"
+    },
+    {
+      "id": "sparql",
+      "title": "SPARQL Query",
+      "icon": "⟐",
+      "paletteKey": "purple",
+      "description": "Execute SPARQL queries against the knowledge graph."
+    },
+    {
+      "id": "graphql",
+      "title": "GraphQL Query",
+      "icon": "⬡",
+      "paletteKey": "cyan",
+      "description": "Execute GraphQL queries against structured data."
+    }
+  ],
+  "demos": [
+    {
+      "id": "solar-missions",
+      "title": "Solar System Missions",
+      "icon": "◉",
+      "paletteKey": "amber",
+      "description": "Explore space missions across the solar system.",
+      "url": "/plugins/solar-missions.iife.js",
+      "globalName": "SolarMissionsPlugin",
+      "screenshot": "/plugins/solar-missions.png"
+    },
+    {
+      "id": "hwsec",
+      "title": "Hardware Security Explorer",
+      "icon": "◈",
+      "paletteKey": "blue",
+      "description": "Hardware decomposition tree with security annotations.",
+      "url": "/plugins/hwsec.iife.js",
+      "globalName": "HwSecPlugin"
+    },
+    {
+      "id": "playground",
+      "title": "Playground",
+      "icon": "△",
+      "paletteKey": "rose",
+      "description": "Experimental sandbox for trying things out.",
+      "url": "/plugins/playground.iife.js",
+      "globalName": "PlaygroundPlugin"
+    },
+    {
+      "id": "world-events",
+      "title": "World Events Explorer",
+      "icon": "⊕",
+      "paletteKey": "cyan",
+      "description": "Geo-temporal event explorer with map, timeline, and filters.",
+      "url": "/plugins/world-events.iife.js",
+      "globalName": "WorldEventsPlugin"
+    },
+    {
+      "id": "retail-assistant",
+      "title": "Retail Shopping Assistant",
+      "icon": "◈",
+      "paletteKey": "emerald",
+      "description": "AI shopping assistant for PC builds, gifts, and camping gear.",
+      "url": "/plugins/retail-brand.iife.js",
+      "globalName": "RetailBrandPlugin",
+      "componentName": "RetailAssistant"
+    },
+    {
+      "id": "brand-analytics",
+      "title": "Brand Analytics",
+      "icon": "◎",
+      "paletteKey": "purple",
+      "description": "Brand intelligence from interaction signals. See what users buy, reject, and why.",
+      "url": "/plugins/retail-brand.iife.js",
+      "globalName": "RetailBrandPlugin",
+      "componentName": "BrandAnalytics"
+    },
+    {
+      "id": "risk",
+      "title": "Risk Management",
+      "icon": "🛡",
+      "paletteKey": "rose",
+      "description": "Enterprise risk explorer with time-windowed event analysis, threat actors, assets, and incident response tracking.",
+      "url": "/plugins/risk.iife.js",
+      "globalName": "RiskPlugin"
+    },
+    {
+      "id": "game-theory",
+      "title": "Game Theory",
+      "icon": "♟",
+      "paletteKey": "purple",
+      "description": "Interactive game tree visualizer with payoff matrices, backward induction, Nash equilibria, and what-if sandbox.",
+      "url": "/plugins/game-theory.iife.js",
+      "globalName": "GameTheoryPlugin",
+      "screenshot": "/plugins/game-theory.png"
+    },
+    {
+      "id": "innovation",
+      "title": "Innovation Intelligence",
+      "icon": "🔍",
+      "paletteKey": "cyan",
+      "description": "Innovation ecosystem explorer for navigating organisations, capabilities, procurement routes, and people.",
+      "url": "/plugins/innovation.iife.js",
+      "globalName": "InnovationPlugin"
+    },
+    {
+      "id": "law-in-context",
+      "title": "Law in Context",
+      "icon": "⚖",
+      "paletteKey": "amber",
+      "description": "Multilingual legal explorer: institutions, civic rights, compliance obligations, emergency powers, and legislative structure.",
+      "url": "/plugins/law.iife.js",
+      "globalName": "LawPlugin"
+    },
+    {
+      "id": "threat-explorer",
+      "title": "Threat Explorer",
+      "icon": "⚠",
+      "paletteKey": "cyan",
+      "description": "Cybersecurity investigation tool: pivot through risk events, actors, assets, and categories. Drill into raw OCSF events for evidence.",
+      "url": "/plugins/threat.iife.js",
+      "globalName": "ThreatPlugin"
+    }
+  ]
+}

--- a/trustgraph_configurator/templates/2.8/ui/register-plugins.jsonnet
+++ b/trustgraph_configurator/templates/2.8/ui/register-plugins.jsonnet
@@ -1,0 +1,35 @@
+{
+
+    with:: function(key, value)
+        if key == "add-demos" then
+            self + {
+                "ui-plugins" +:: {
+                    demos +: value,
+                },
+            }
+        else if key == "add-workflows" then
+            self + {
+                "ui-plugins" +:: {
+                    workflows +: value,
+                },
+            }
+        else if key == "replace-demos" then
+            self + {
+                "ui-plugins" +:: {
+                    demos: value,
+                },
+            }
+        else if key == "replace-workflows" then
+            self + {
+                "ui-plugins" +:: {
+                    workflows: value,
+                },
+            }
+        else if key == "bundle" then
+            self + {
+                "ui-bundle" +:: value,
+            }
+        else
+            error "register-plugins: unknown key '" + key + "'",
+
+}

--- a/trustgraph_configurator/templates/2.8/ui/trustgraph-ui.jsonnet
+++ b/trustgraph_configurator/templates/2.8/ui/trustgraph-ui.jsonnet
@@ -1,17 +1,38 @@
 local images = import "values/images.jsonnet";
+local default_plugins = import "ui/plugins.json";
 
 {
+
+    "ui-plugins":: default_plugins,
+
+    "ui-bundle":: {},
 
     "trustgraph-ui" +: {
     
         create:: function(engine)
+
+            local cfgVol = engine.configVolume(
+                "ui-plugin-cfg", "ui/config",
+                {
+                    "plugins.json": std.manifestJsonEx(
+                        $["ui-plugins"], "  "
+                    ),
+                }
+            );
+
+            local bundleVol = engine.configVolume(
+                "ui-bundle-cfg", "ui/bundle",
+                $["ui-bundle"]
+            );
 
             local container =
                 engine.container("trustgraph-ui")
                     .with_image(images["ui"])
                     .with_limits("0.1", "256M")
                     .with_reservations("0.1", "256M")
-                    .with_port(8888, 8888, "ui");
+                    .with_port(8888, 8888, "ui")
+                    .with_volume_mount(cfgVol, "/usr/lib/python3.12/site-packages/trustgraph_ui/ui/config/")
+                    .with_volume_mount(bundleVol, "/usr/lib/python3.12/site-packages/trustgraph_ui/ui/bundle/");
 
             local containerSet = engine.containers(
                 "trustgraph-ui", [ container ]
@@ -23,6 +44,8 @@ local images = import "values/images.jsonnet";
                 ;
 
             engine.resources([
+                cfgVol,
+                bundleVol,
                 containerSet,
                 service,
             ])

--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -33,7 +33,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:1.1.3",
+    ui: "docker.io/trustgraph/trustgraph-ui:1.2.3",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Adds `register-plugins` component for managing UI plugins via config volumes
- Default plugin registry (workflows + demos) shipped as `plugins.json` mounted into the UI container
- Supports `add-demos`, `add-workflows`, `replace-demos`, `replace-workflows` to customise the plugin set
- Bundle sideloading via `importstr` for external JS plugin assets, mounted at `/bundle/`
- Bumps `trustgraph-ui` to 1.2.3

## Test plan
- [x] Verify default plugins load in the UI
- [x] Test `add-demos` appends a new demo plugin
- [x] Test `replace-demos` replaces the demo list
- [x] Test bundle sideloading with an external JS plugin via `importstr`
