### PR TITLE
fix: remove redundant self+ in with_params to prevent +:: double-apply

### DIFF
--- a/trustgraph_configurator/templates/2.8/renderers/decode-config.jsonnet
+++ b/trustgraph_configurator/templates/2.8/renderers/decode-config.jsonnet
@@ -37,7 +37,7 @@ local apply = function(p, components)
         },
 
         with_params:: function(pars)
-            self + std.foldl(
+            std.foldl(
                 function(obj, par) obj.with(par.key, par.value),
                 std.objectKeysValues(pars),
                 self


### PR DESCRIPTION
## Summary
- Removes the redundant `self +` in `decode-config.jsonnet`'s `with_params` function
- The `std.foldl` already starts from `self`, so the extra `self +` caused `+::` (append) fields to be applied twice

## Test plan
- [x] Verify all existing configs still build correctly
- [x] Confirm components using `+::` fields (e.g. attestation) only appear once
