### PR TITLE
feat: add attestation engine component for RAG processor group

### DIFF
--- a/trustgraph_configurator/templates/2.8/components.jsonnet
+++ b/trustgraph_configurator/templates/2.8/components.jsonnet
@@ -105,6 +105,9 @@
    // RBAC IAM: switches control to enterprise image with RBAC processor
    "rbac-iam": import "core/rbac-iam.jsonnet",
 
+   // Attestation: adds attestation processor to RAG, switches to enterprise image
+   "attestation": import "core/attestation.jsonnet",
+
    // Does nothing.  But, can be a hack to overwrite parameters
    "null": {},
 

--- a/trustgraph_configurator/templates/2.8/core/attestation.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/attestation.jsonnet
@@ -1,0 +1,26 @@
+
+// Enterprise feature, relies on Enterprise container
+
+local images = import "values/images.jsonnet";
+
+{
+
+    parameters +:: {
+        "attestation-concurrency": 1,
+    },
+
+    "rag" +: {
+        "rag-image":: images.trustgraph_enterprise,
+        "rag-extra-processors" +:: [
+            {
+                class: "trustgraph.attestation.service.Processor",
+                params: {
+                    id: "attestation-engine",
+                    concurrency: $.parameters["attestation-concurrency"],
+                } + $["pub-sub-params"],
+            },
+        ],
+        "image-pull-secret":: "private-registry-credentials",
+    },
+
+}

--- a/trustgraph_configurator/templates/2.8/core/rag.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/rag.jsonnet
@@ -37,6 +37,14 @@ local url = import "values/url.jsonnet";
 
     "rag" +: {
 
+        "rag-image":: images.trustgraph_flow,
+        "rag-extra-processors":: [],
+
+        local imagePullSecret =
+            if std.objectHasAll(self, "image-pull-secret")
+            then self["image-pull-secret"]
+            else null,
+
         local pars = $.parameters,
 
         local agentManagerConc = pars["agent-manager-concurrency"],
@@ -151,14 +159,14 @@ local url = import "values/url.jsonnet";
                                     concurrency: mcpToolConc,
                                 } + $["pub-sub-params"],
                             },
-                        ]
+                        ] + $["rag"]["rag-extra-processors"]
                     })
 		}
             );
 
-            local container =
+            local containerNoSecret =
                 engine.container("rag")
-                    .with_image(images.trustgraph_flow)
+                    .with_image($["rag"]["rag-image"])
                     .with_command([
                         "processor-group",
                         "--log-level",
@@ -169,6 +177,12 @@ local url = import "values/url.jsonnet";
                     .with_volume_mount(cfgVol, "/etc/trustgraph/")
                     .with_limits(cpuLimit, memoryLimit)
                     .with_reservations(cpuReservation, memoryReservation);
+
+            local container =
+                if imagePullSecret != null then
+                    containerNoSecret
+                        .with_image_pull_secret(imagePullSecret)
+                else containerNoSecret;
 
             local containerSet = engine.containers(
                 "rag", [ container ]

--- a/trustgraph_configurator/templates/2.8/core/rbac-iam.jsonnet
+++ b/trustgraph_configurator/templates/2.8/core/rbac-iam.jsonnet
@@ -1,3 +1,6 @@
+
+// Enterprise feature, relies on Enterprise container
+
 local images = import "values/images.jsonnet";
 
 {

--- a/trustgraph_configurator/templates/2.8/flows/agent.jsonnet
+++ b/trustgraph_configurator/templates/2.8/flows/agent.jsonnet
@@ -21,6 +21,7 @@ llm_services + mcp_service + {
     // External interfaces for agent operations
     "interfaces" +: {
         "agent": request_response_if("agent:{workspace}:{id}"),
+        "attestation-engine": request_response_if("attestation-engine:{workspace}:{id}"),
     },
 
     // Flow-level processors for agent management
@@ -50,6 +51,22 @@ llm_services + mcp_service + {
                 "librarian-response": librarian_response,
             },
         },
+
+        // Agent manager orchestrates agent conversations and tool usage
+        "attestation-engine:{id}": {
+            topics: {
+                request: request("attestation-engine:{workspace}:{id}"),
+                response: response("attestation-engine:{workspace}:{id}"),
+                "prompt-request": request("prompt-rag:{workspace}:{id}"),
+                "prompt-response": response("prompt-rag:{workspace}:{id}"),
+                "graph-rag-request": request("graph-rag:{workspace}:{id}"),
+                "graph-rag-response": response("graph-rag:{workspace}:{id}"),
+                "sparql-request": request("sparql:{workspace}:{id}"),
+                "sparql-response": response("sparql:{workspace}:{id}"),
+                explainability: flow("triples-store:{workspace}:{id}"),
+            },
+        },
+
     },
 
     // Blueprint-level processors for agent-related services


### PR DESCRIPTION
## Summary
- Adds `attestation` component that injects `trustgraph.attestation.service.Processor` into the RAG processor group
- Switches RAG image to enterprise when attestation is enabled
- Makes `rag.jsonnet` extensible via `rag-image`, `rag-extra-processors`, and `image-pull-secret` hidden fields
- Depends on #335 (fix/redundant-self) to avoid +:: double-apply

## Test plan
- [x] Verify attestation processor appears exactly once in RAG launch config
- [x] Confirm RAG uses enterprise image when attestation component is included
- [x] Check existing configs without attestation still work unchanged
