### PR TITLE
maint: bump trustgraph-enterprise to 1.1.3 and TG to 2.8.11

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.2",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.3",
     trustgraph_docling: "docker.io/trustgraph/trustgraph-docling:" + version,
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",

--- a/trustgraph_configurator/templates/index.json
+++ b/trustgraph_configurator/templates/index.json
@@ -33,7 +33,7 @@
         {
             "name": "2.8",
             "description": "Removes scale-bottlenecks to better support large multi-tenant deployments",
-            "version": "2.8.5",
+            "version": "2.8.11",
             "status": "pre-release"
         }
     ],


### PR DESCRIPTION
## Summary
- Bumps `trustgraph-enterprise` from 1.1.2 to 1.1.3 (adds attestation engine)
- Bumps TrustGraph 2.8 from 2.8.5 to 2.8.11 (fixes MCP client/server, implements gateway pass-through)

## Test plan
- [x] Verify enterprise services start correctly
- [x] Confirm MCP client and server function
- [x] Test gateway pass-through
