### PR TITLE
maint: change default Gemini model to gemini-2.5-flash

### DIFF
--- a/trustgraph_configurator/templates/2.8/parameters/googleaistudio.jsonnet
+++ b/trustgraph_configurator/templates/2.8/parameters/googleaistudio.jsonnet
@@ -4,7 +4,7 @@
 {
     "type": "string",
     "description": "LLM model to use",
-    "default": "gemini-2.5-flash-lite",
+    "default": "gemini-2.5-flash",
     "enum": [
         // Gemini 3 models (preview)
         {

--- a/trustgraph_configurator/templates/2.8/parameters/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.8/parameters/vertexai.jsonnet
@@ -4,7 +4,7 @@
 {
     "type": "string",
     "description": "LLM model to use",
-    "default": "gemini-2.5-flash-lite",
+    "default": "gemini-2.5-flash",
     "enum": [
         // Gemini 3 models (preview)
         {


### PR DESCRIPTION
## Summary
- Change default Gemini model from `gemini-2.5-flash-lite` to `gemini-2.5-flash` for both Google AI Studio and Vertex AI
- Flash offers better instruction-following for minimal cost delta, making it a better production default

## Test plan
- [ ] Verify Google AI Studio deployment uses `gemini-2.5-flash` as default
- [ ] Verify Vertex AI deployment uses `gemini-2.5-flash` as default
