### PR TITLE
maint: update VertexAI models and default region

### DIFF
--- a/trustgraph_configurator/templates/2.8/llm/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.8/llm/vertexai.jsonnet
@@ -11,7 +11,7 @@ local models = import "parameters/vertexai.jsonnet";
         },
 
     "vertexai-private-key":: "/vertexai/private.json",
-    "vertexai-region":: "us-central1",
+    "vertexai-region":: "global",
     "vertexai-max-output-tokens":: 4096,
     "vertexai-temperature":: 0.0,
     "vertexai-models":: models,

--- a/trustgraph_configurator/templates/2.8/parameters/vertexai.jsonnet
+++ b/trustgraph_configurator/templates/2.8/parameters/vertexai.jsonnet
@@ -4,16 +4,24 @@
 {
     "type": "string",
     "description": "LLM model to use",
-    "default": "gemini-2.5-flash",
+    "default": "gemini-3.5-flash-lite",
     "enum": [
         // Gemini 3 models (preview)
         {
-            id: "gemini-3-pro-preview",
-            description: "Gemini 3 Pro (preview)"
+            id: "gemini-3.5-flash-lite",
+            description: "Gemini 3.5 Flash Lite"
         },
         {
-            id: "gemini-3-flash-preview",
-            description: "Gemini 3 Flash (preview)"
+            id: "gemini-3.6-flash",
+            description: "Gemini 3.6 Flash"
+        },
+        {
+            id: "gemini-3.5-flash",
+            description: "Gemini 3.5 Flash"
+        },
+        {
+            id: "gemini-3.1-pro",
+            description: "Gemini 3.1 Pro (preview)"
         },
 
         // Gemini 2.5 models
@@ -30,51 +38,11 @@
             description: "Gemini 2.5 Flash Lite"
         },
 
-        // Gemini 2.0 models
-        {
-            id: "gemini-2.0-flash-001",
-            description: "Gemini 2.0 Flash"
-        },
-        {
-            id: "gemini-2.0-flash-lite-001",
-            description: "Gemini 2.0 Flash Lite"
-        },
-
         // Gemma models
         {
-            id: "gemma-3-27b",
-            description: "Gemma 3 27B"
-        },
-        {
-            id: "gemma-3n-e4b",
-            description: "Gemma 3n E4B"
-        },
-
-        // Claude models on VertexAI
-        {
-            id: "claude-opus-4-6",
-            description: "Claude Opus 4.6"
-        },
-        {
-            id: "claude-opus-4-5",
-            description: "Claude Opus 4.5"
-        },
-        {
-            id: "claude-sonnet-4-5",
-            description: "Claude Sonnet 4.5"
-        },
-        {
-            id: "claude-haiku-4-5",
-            description: "Claude Haiku 4.5"
-        },
-        {
-            id: "claude-opus-4-1",
-            description: "Claude Opus 4.1"
-        },
-        {
-            id: "claude-sonnet-4",
-            description: "Claude Sonnet 4"
-        },
+            id: "google/gemma-4-26b-a4b-it-maas",
+            description: "Gemma 4 26B A4B"
+        }
     ],
     "required": true
 }


### PR DESCRIPTION
## Summary
- Update model list to current Gemini 3.x (3.5 Flash Lite, 3.6 Flash, 3.5 Flash, 3.1 Pro) and Gemma 4 models
- Remove deprecated Gemini 2.0, Claude, and old Gemma model entries
- Change default model to gemini-3.5-flash-lite
- Change default region from us-central1 to global

## Test plan
- [x] Render a VertexAI config and verify the new model list and defaults appear correctly
- [x] Confirm the global region is set in the generated output
