### PR TITLE
maint: remove deprecated template-index from config composer

### DIFF
--- a/trustgraph_configurator/templates/2.8/runtime-config/config-composer.jsonnet
+++ b/trustgraph_configurator/templates/2.8/runtime-config/config-composer.jsonnet
@@ -22,9 +22,6 @@
                 // Prompts configuration
                 prompt: {
                     "system": config_spec.prompts["system-template"],
-                    "template-index": std.objectFieldsAll(
-                        config_spec.prompts.templates
-                    ),
                 } + {
                     ["template." + template.key]: template.value
                     for template in std.objectKeysValuesAll(


### PR DESCRIPTION
## Summary
- Remove the deprecated `template-index` field from the prompt config in config-composer.jsonnet

## Test plan
- [x] Render a config and verify prompt section no longer includes `template-index`
- [x] Confirm templates are still composed correctly via `template.*` keys
