### PR TITLE
maint: bump trustgraph-ui to 1.3.3 for 2.8

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -33,7 +33,7 @@ local version = import "version.jsonnet";
     memgraph_lab: "docker.io/memgraph/lab:3.10.0",
     falkordb: "docker.io/falkordb/falkordb:v4.18.7",
     "workbench-ui": "docker.io/trustgraph/workbench-ui:1.8.2",
-    ui: "docker.io/trustgraph/trustgraph-ui:1.2.3",
+    ui: "docker.io/trustgraph/trustgraph-ui:1.3.3",
     "ddg-mcp-server": "docker.io/trustgraph/ddg-mcp-server:0.1.1",
     "tgi-service-intel-xpu": "ghcr.io/huggingface/text-generation-inference:3.3.1-intel-xpu",
     "tgi-service-cpu": "ghcr.io/huggingface/text-generation-inference:3.3.7-intel-cpu",


### PR DESCRIPTION
## Summary
- Bump trustgraph-ui image tag from 1.2.3 to 1.3.3
- Picks up plugin architecture, runtime UX tailoring, theming system, and shared UI component refactor

## Test plan
- [x] Render a config and verify UI image tag is 1.3.3
- [x] Deploy and confirm UI loads with new plugin/theming features