### PR TITLE
maint: bump trustgraph-enterprise to 1.1.7 for 2.8

### DIFF
--- a/trustgraph_configurator/templates/2.8/values/images.jsonnet
+++ b/trustgraph_configurator/templates/2.8/values/images.jsonnet
@@ -26,7 +26,7 @@ local version = import "version.jsonnet";
     trustgraph_hf: "docker.io/trustgraph/trustgraph-hf:" + version,
     trustgraph_mcp: "docker.io/trustgraph/trustgraph-mcp:" + version,
     trustgraph_unstructured: "docker.io/trustgraph/trustgraph-unstructured:" + version,
-    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.6",
+    trustgraph_enterprise: "docker.io/trustgraph/trustgraph-enterprise:1.1.7",
     trustgraph_docling: "docker.io/trustgraph/trustgraph-docling:" + version,
     qdrant: "docker.io/qdrant/qdrant:v1.18.0",
     memgraph_mage: "docker.io/memgraph/memgraph-mage:3.10.1",


### PR DESCRIPTION
## Summary
- Bump trustgraph-enterprise image tag from 1.1.6 to 1.1.7
- Picks up attestation engine updates

## Test plan
- [x] Render a config with enterprise components and verify image tag is 1.1.7

